### PR TITLE
fix: allow users to override nitro error

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -68,7 +68,6 @@ const NitroDefaults: NitroConfig = {
   commands: {}
 }
 
-export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroOptions> {
   userConfig = klona(userConfig)
 
   const { config } = await loadConfig({
@@ -95,7 +94,6 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
       ]
     }
   })
-
   const options = klona(config) as NitroOptions
   options._config = userConfig
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -53,9 +53,7 @@ const NitroDefaults: NitroConfig = {
   },
 
   // Rollup
-  alias: {
-    '#nitro': runtimeDir
-  },
+  alias: {},
   unenv: {},
   analyze: false,
   moduleSideEffects: ['unenv/runtime/polyfill/'],
@@ -95,6 +93,9 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
       ]
     }
   })
+  // ensure it's added last to the alias object
+  config.alias['#nitro'] = runtimeDir
+
   const options = klona(config) as NitroOptions
   options._config = userConfig
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -68,6 +68,7 @@ const NitroDefaults: NitroConfig = {
   commands: {}
 }
 
+export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroOptions> {
   userConfig = klona(userConfig)
 
   const { config } = await loadConfig({
@@ -94,6 +95,7 @@ const NitroDefaults: NitroConfig = {
       ]
     }
   })
+
   const options = klona(config) as NitroOptions
   options._config = userConfig
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -95,7 +95,6 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
       ]
     }
   })
-
   const options = klona(config) as NitroOptions
   options._config = userConfig
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -53,7 +53,9 @@ const NitroDefaults: NitroConfig = {
   },
 
   // Rollup
-  alias: {},
+  alias: {
+    '#nitro': runtimeDir
+  },
   unenv: {},
   analyze: false,
   moduleSideEffects: ['unenv/runtime/polyfill/'],
@@ -93,8 +95,6 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
       ]
     }
   })
-  // ensure it's added last to the alias object
-  config.alias['#nitro'] = runtimeDir
 
   const options = klona(config) as NitroOptions
   options._config = userConfig

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'pathe'
+import { join, resolve } from 'pathe'
 import { loadConfig } from 'c12'
 import { klona } from 'klona/full'
 import { camelCase } from 'scule'
@@ -54,7 +54,8 @@ const NitroDefaults: NitroConfig = {
 
   // Rollup
   alias: {
-    '#nitro': runtimeDir
+    '#nitro': runtimeDir,
+    '#nitro-error': join(runtimeDir, 'error')
   },
   unenv: {},
   analyze: false,

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -230,7 +230,6 @@ export const plugins = [
   }
   rollupConfig.plugins.push(alias({
     entries: resolveAliases({
-      '#nitro-error': join(runtimeDir, 'error'),
       '#build': buildDir,
       '~': nitro.options.srcDir,
       '@/': nitro.options.srcDir,

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -225,6 +225,7 @@ export const plugins = [
   // https://github.com/rollup/plugins/tree/master/packages/alias
   rollupConfig.plugins.push(alias({
     entries: resolveAliases({
+      '#nitro-error': join(runtimeDir, 'error'),
       // Windows dynamic imports should be file:// url
       '#build': nitro.options.dev && isWindows
         ? pathToFileURL(nitro.options.buildDir).href

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -225,7 +225,6 @@ export const plugins = [
   // https://github.com/rollup/plugins/tree/master/packages/alias
   rollupConfig.plugins.push(alias({
     entries: resolveAliases({
-      '#nitro': runtimeDir,
       // Windows dynamic imports should be file:// url
       '#build': nitro.options.dev && isWindows
         ? pathToFileURL(nitro.options.buildDir).href

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -8,7 +8,7 @@ import { useRuntimeConfig } from './config'
 import { timingMiddleware } from './timing'
 import { cachedEventHandler } from './cache'
 import { plugins } from '#nitro/virtual/plugins'
-import handleError from '#nitro/error'
+import handleError from '#nitro-error'
 import { handlers } from '#nitro/virtual/server-handlers'
 
 export interface NitroApp {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,9 @@
       "#nitro/*": [
         "./src/runtime/*"
       ],
+      "#nitro-error": [
+        "./src/runtime/error"
+      ],
     },
   }
 }


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously it was impossible to override sub-paths (for example, `#nitro/error`) as `#nitro` was added first to the alias object.

~Do not yet merge as there is an error that this reveals in Nuxt that needs to be resolved first:~ resolved in https://github.com/nuxt/framework/pull/4215

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

