### PR TITLE
feat: allow overriding nested runtime config

### DIFF
--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -16,10 +16,10 @@ const getEnv = (key: string) => {
 
 const mergeWithEnvVariables = createDefu((obj: Record<string, any>, key: string, _value, namespace) => {
   // key: { subKey } can be overridden by KEY_SUB_KEY`
-  const override = getEnv(namespace ? `${namespace}_${key}` : key)
+  const override = getEnv(namespace ? `${namespace}.${key}` : key)
   if (override !== undefined) {
     obj[key] = override
-    return true
+    // Do not return `true` to allow overrding both top level keys and sub-keys
   }
 })
 

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -13,14 +13,19 @@ const getEnv = (key: string) => {
   return destr(process.env[ENV_PREFIX + envKey] ?? process.env[ENV_PREFIX_ALT + envKey])
 }
 
-for (const key in _runtimeConfig) {
-  _runtimeConfig[key] = getEnv(key) ?? _runtimeConfig[key]
-  if (_runtimeConfig[key] && typeof _runtimeConfig[key] === 'object') {
-    for (const subkey in _runtimeConfig[key]) {
+function overrideConfig (key: string, obj: unknown) {
+  if (obj && typeof obj === 'object') {
+    for (const subkey in obj) {
       // key: { subKey } can be overridden by KEY_SUB_KEY`
-      _runtimeConfig[key][subkey] = getEnv(`${key}_${subkey}`) ?? _runtimeConfig[key][subkey]
+      obj[subkey] = getEnv(`${key}_${subkey}`) ?? obj[subkey]
+      overrideConfig(`${key}_${subkey}`, obj[subkey])
     }
   }
+}
+
+for (const key in _runtimeConfig) {
+  _runtimeConfig[key] = getEnv(key) ?? _runtimeConfig[key]
+  overrideConfig(key, _runtimeConfig[key])
 }
 
 // Named exports

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -14,7 +14,7 @@ const getEnv = (key: string) => {
   return destr(process.env[ENV_PREFIX + envKey] ?? process.env[ENV_PREFIX_ALT + envKey])
 }
 
-const mergeWithEnvVariables = createDefu((obj: Record<string, any>, key: any, _value, namespace) => {
+const mergeWithEnvVariables = createDefu((obj: Record<string, any>, key: string, _value, namespace) => {
   // key: { subKey } can be overridden by KEY_SUB_KEY`
   const override = getEnv(namespace ? `${namespace}_${key}` : key)
   if (override !== undefined) {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently it isn't possible to set nested config, which is something needed in frameworks like Nuxt.

See for example https://github.com/nuxt/framework/issues/4126#issuecomment-1094127476 - currently we are not able to override anything but top-level `publicRuntimeConfig`.
 
### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

