### PR TITLE
fix: normalize `#build` windows path for dev and prerender presets

### DIFF
--- a/src/presets/nitro-dev.ts
+++ b/src/presets/nitro-dev.ts
@@ -1,3 +1,5 @@
+import { pathToFileURL } from 'url'
+import { isWindows } from 'std-env'
 import { defineNitroPreset } from '../preset'
 
 export const nitroDev = defineNitroPreset({
@@ -8,5 +10,13 @@ export const nitroDev = defineNitroPreset({
   },
   externals: { trace: false },
   inlineDynamicImports: true, // externals plugin limitation
-  sourceMap: true
+  sourceMap: true,
+  hooks: {
+    'nitro:rollup:before' (nitro) {
+      if (isWindows) {
+        // Windows dynamic imports should be file:// url
+        nitro.options.alias['#build'] = pathToFileURL(nitro.options.buildDir).href
+      }
+    }
+  }
 })

--- a/src/presets/nitro-prerender.ts
+++ b/src/presets/nitro-prerender.ts
@@ -12,7 +12,7 @@ export const nitroPrerender = defineNitroPreset({
   hooks: {
     'nitro:rollup:before' (nitro) {
       if (isWindows) {
-      // Windows dynamic imports should be file:// url
+       // Windows dynamic imports should be file:// url
         nitro.options.alias['#build'] = pathToFileURL(nitro.options.buildDir).href
       }
     }

--- a/src/presets/nitro-prerender.ts
+++ b/src/presets/nitro-prerender.ts
@@ -1,3 +1,5 @@
+import { pathToFileURL } from 'url'
+import { isWindows } from 'std-env'
 import { defineNitroPreset } from '../preset'
 
 export const nitroPrerender = defineNitroPreset({
@@ -6,5 +8,13 @@ export const nitroPrerender = defineNitroPreset({
   output: {
     serverDir: '{{ buildDir }}/prerender'
   },
-  externals: { trace: false }
+  externals: { trace: false },
+  hooks: {
+    'nitro:rollup:before' (nitro) {
+      if (isWindows) {
+      // Windows dynamic imports should be file:// url
+        nitro.options.alias['#build'] = pathToFileURL(nitro.options.buildDir).href
+      }
+    }
+  }
 })

--- a/src/presets/nitro-prerender.ts
+++ b/src/presets/nitro-prerender.ts
@@ -12,7 +12,7 @@ export const nitroPrerender = defineNitroPreset({
   hooks: {
     'nitro:rollup:before' (nitro) {
       if (isWindows) {
-       // Windows dynamic imports should be file:// url
+        // Windows dynamic imports should be file:// url
         nitro.options.alias['#build'] = pathToFileURL(nitro.options.buildDir).href
       }
     }

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -1,4 +1,3 @@
-import { pathToFileURL } from 'url'
 import { dirname, join, relative, resolve } from 'pathe'
 import type { InputOptions, OutputOptions } from 'rollup'
 import defu from 'defu'
@@ -12,7 +11,6 @@ import replace from '@rollup/plugin-replace'
 import virtual from '@rollup/plugin-virtual'
 import wasmPlugin from '@rollup/plugin-wasm'
 import inject from '@rollup/plugin-inject'
-import { isWindows } from 'std-env'
 import { visualizer } from 'rollup-plugin-visualizer'
 import * as unenv from 'unenv'
 import type { Preset } from 'unenv'
@@ -226,10 +224,7 @@ export const plugins = [
   rollupConfig.plugins.push(alias({
     entries: resolveAliases({
       '#nitro': runtimeDir,
-      // Windows dynamic imports should be file:// url
-      '#build': nitro.options.dev && isWindows
-        ? pathToFileURL(nitro.options.buildDir).href
-        : nitro.options.buildDir,
+      '#build': nitro.options.buildDir,
       '~': nitro.options.srcDir,
       '@/': nitro.options.srcDir,
       '~~': nitro.options.rootDir,


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/4232

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The fix applied to dev preset also needs to be applied to prerender preset. It seemed easiest way was to extract from options and add to preset itself. There may be a better way to do this.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

