### PR TITLE
fix: default fetch baseURL to runtime nitro base

### DIFF
--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -57,7 +57,7 @@ function createNitroApp (): NitroApp {
   const localCall = createCall(h3App.nodeHandler as any)
   const localFetch = createLocalFetch(localCall, globalThis.fetch)
 
-  const $fetch = createFetch({ fetch: localFetch, Headers })
+  const $fetch = createFetch({ fetch: localFetch, Headers, defaults: { baseURL: config.app.baseURL } })
   // @ts-ignore
   globalThis.$fetch = $fetch
 


### PR DESCRIPTION
Alternative to https://github.com/nuxt/framework/pull/4423

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

otherwise users would manually have to to add base URL to their fetch calls, which is likely undesirable.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

