### PR TITLE
fix: wrap dynamic import in prerender to fix windows build failure

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'url'
 import { resolve, join } from 'pathe'
 import { parseURL } from 'ufo'
 import chalk from 'chalk'
@@ -26,7 +27,8 @@ export async function prerender (nitro: Nitro) {
   await build(nitroRenderer)
 
   // Import renderer entry
-  const { localFetch } = await import(resolve(nitroRenderer.options.output.serverDir, 'index.mjs'))
+  const serverEntrypoint = resolve(nitroRenderer.options.output.serverDir, 'index.mjs')
+  const { localFetch } = await import(pathToFileURL(serverEntrypoint).href)
 
   // Start prerendering
   const generatedRoutes = new Set()

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -227,7 +227,7 @@ export const plugins = [
   // https://github.com/rollup/plugins/tree/master/packages/alias
   let buildDir = nitro.options.buildDir
   // Windows (native) dynamic imports should be file:// urr
-  if (isWindows && (nitro.options.externals.trace === false)) {
+  if (isWindows && (nitro.options.externals?.trace === false)) {
     buildDir = pathToFileURL(buildDir).href
   }
   rollupConfig.plugins.push(alias({


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue
https://github.com/nuxt/framework/issues/4330

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes a bug, when a fresh install of nuxt3 on Windows can not produce a build. It is failing with an error related to files paths. It seems like all dynamic imports should be wrapped with `pathToFileURL` to work properly on Windows.
Also fixed a minor bug with configuration. Cloudflare test failed on Windows.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.