### PR TITLE
fix: respect `sourceMap` option

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -62,6 +62,7 @@ const NitroDefaults: NitroConfig = {
   analyze: false,
   moduleSideEffects: ['unenv/runtime/polyfill/'],
   replace: {},
+  sourceMap: true,
 
   // Advanced
   typescript: {

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -151,7 +151,7 @@ export const getRollupConfig = (nitro: Nitro) => {
   // esbuild
   rollupConfig.plugins.push(esbuild({
     target: 'es2019',
-    sourceMap: nitro.options.sourceMap !== false,
+    sourceMap: nitro.options.sourceMap,
     ...nitro.options.esbuild?.options
   }))
 

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -151,7 +151,7 @@ export const getRollupConfig = (nitro: Nitro) => {
   // esbuild
   rollupConfig.plugins.push(esbuild({
     target: 'es2019',
-    sourceMap: true,
+    sourceMap: nitro.options.sourceMap !== false,
     ...nitro.options.esbuild?.options
   }))
 

--- a/src/rollup/plugins/esbuild.ts
+++ b/src/rollup/plugins/esbuild.ts
@@ -86,7 +86,7 @@ export function esbuild (options: Options = {}): Plugin {
         loader,
         target,
         define: options.define,
-        sourcemap: options.sourceMap !== false,
+        sourcemap: options.sourceMap,
         sourcefile: id
       })
 


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We should likely respect `nitro.options.sourceMap` as default value for `esbuild` as well.

Related: https://github.com/nuxt/framework/pull/4509

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

