### PR TITLE
fix: support patch method auto-scanning

### DIFF
--- a/src/runtime/virtual/server-handlers.d.ts
+++ b/src/runtime/virtual/server-handlers.d.ts
@@ -1,10 +1,10 @@
-import type { CompatibilityEventHandler } from 'h3'
+import type { CompatibilityEventHandler, RouterMethod } from 'h3'
 
 interface HandlerDefinition {
   route: string
   lazy?: boolean
   handler: CompatibilityEventHandler | (() => Promise<CompatibilityEventHandler>)
-  method?: 'connect'| 'delete'| 'get'| 'head'| 'options'| 'post'| 'put'| 'trace'
+  method?: RouterMethod
 }
 
 export const handlers: HandlerDefinition[]

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -7,7 +7,7 @@ import type { Nitro, NitroEventHandler } from './types'
 export const GLOB_SCAN_PATTERN = '**/*.{ts,mjs,js,cjs}'
 type FileInfo = { dir: string, path: string, fullPath: string }
 
-const httpMethodRegex = /\.(connect|delete|get|head|options|post|put|trace)/
+const httpMethodRegex = /\.(connect|delete|get|head|options|patch|post|put|trace)/
 
 export async function scanHandlers (nitro: Nitro) {
   const handlers = await Promise.all([


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/issues/4609

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds `patch` to scanning regex, and also uses upstream h3 types for methods (rather than keep in two places).

Related: https://github.com/unjs/h3/pull/88

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

