### PR TITLE
fix: replace `global.` in fewer instances

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -138,7 +138,7 @@ export const getRollupConfig = (nitro: Nitro) => {
     values: {
       'process.env.NODE_ENV': nitro.options.dev ? '"development"' : '"production"',
       'typeof window': '"undefined"',
-      'global.': 'globalThis.',
+      ...Object.fromEntries([';', '(', '{', '}', ' ', '\t', '\n'].map(d => [`${d}global.`, `${d}globalThis.`])),
       'process.server': 'true',
       'process.client': 'false',
       'process.dev': String(nitro.options.dev),


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

previous PR: https://github.com/nuxt/framework/pull/3107

https://github.com/nuxt/framework/issues/4547

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The following code was being replaced:

```diff
  const addRouteMiddleware = (name, middleware, options = {}) => {
    const nuxtApp = useNuxtApp();
    if (options.global || typeof name === "function") {
-     nuxtApp._middleware.global.push(typeof name === "function" ? name : middleware);
+     nuxtApp._middleware.globalThis.push(typeof name === "function" ? name : middleware);
    } else {
      nuxtApp._middleware.named[name] = middleware;
    }
  };
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

