### PR TITLE
fix(cloudflare): normalize incoming & outgoing headers

### DIFF
--- a/src/runtime/entries/aws-lambda.ts
+++ b/src/runtime/entries/aws-lambda.ts
@@ -1,7 +1,6 @@
 import type { APIGatewayProxyEvent, APIGatewayProxyEventHeaders, APIGatewayProxyEventV2, APIGatewayProxyResult, APIGatewayProxyResultV2, Context } from 'aws-lambda'
 import '#internal/nitro/virtual/polyfill'
 import { withQuery } from 'ufo'
-import type { HeadersObject } from 'unenv/runtime/_internal/types'
 import { nitroApp } from '../app'
 
 // Compatibility types that work with AWS v1, AWS v2 & Netlify
@@ -37,6 +36,6 @@ function normalizeIncomingHeaders (headers: APIGatewayProxyEventHeaders) {
   return Object.fromEntries(Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value!]))
 }
 
-function normalizeOutgoingHeaders (headers: HeadersObject) {
+function normalizeOutgoingHeaders (headers: Record<string, string | string[] | undefined>) {
   return Object.fromEntries(Object.entries(headers).map(([k, v]) => [k, Array.isArray(v) ? v.join(',') : v!]))
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,9 @@
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
+    "lib": [
+      "WebWorker"
+    ],
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Node",


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/issues/4744

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

CF headers were coming in as a Headers object; this normalizes it to the type expected elsewhere in Nitro using [Headers.entries()](https://developer.mozilla.org/en-US/docs/Web/API/Headers/entries).

I also normalise outgoing headers into the type expected by Response (an array of string/string) and tidy up a leftover internal type from `aws-lambda`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

