### PR TITLE
refactor: improve `esbuild.target` option handling

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -152,7 +152,6 @@ export const getRollupConfig = (nitro: Nitro) => {
 
   // esbuild
   rollupConfig.plugins.push(esbuild({
-    target: 'es2019',
     sourceMap: nitro.options.sourceMap,
     ...nitro.options.esbuild?.options
   }))

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -152,6 +152,7 @@ export const getRollupConfig = (nitro: Nitro) => {
 
   // esbuild
   rollupConfig.plugins.push(esbuild({
+    target: 'node14.16.0',
     sourceMap: nitro.options.sourceMap,
     ...nitro.options.esbuild?.options
   }))

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -152,7 +152,7 @@ export const getRollupConfig = (nitro: Nitro) => {
 
   // esbuild
   rollupConfig.plugins.push(esbuild({
-    target: 'node14.16.0',
+    target: 'es2019',
     sourceMap: nitro.options.sourceMap,
     ...nitro.options.esbuild?.options
   }))

--- a/src/rollup/plugins/esbuild.ts
+++ b/src/rollup/plugins/esbuild.ts
@@ -80,7 +80,7 @@ export function esbuild (options: Options = {}): Plugin {
         return null
       }
 
-      target = options.target || 'node14'
+      target = options.target || 'node14.16.0'
 
       const result = await transform(code, {
         loader,

--- a/src/rollup/plugins/esbuild.ts
+++ b/src/rollup/plugins/esbuild.ts
@@ -37,8 +37,6 @@ export type Options = {
 }
 
 export function esbuild (options: Options = {}): Plugin {
-  let target: string | string[]
-
   const loaders = {
     ...defaultLoaders
   }
@@ -80,11 +78,9 @@ export function esbuild (options: Options = {}): Plugin {
         return null
       }
 
-      target = options.target || 'node14.16.0'
-
       const result = await transform(code, {
         loader,
-        target,
+        target: options.target,
         define: options.define,
         sourcemap: options.sourceMap,
         sourcefile: id
@@ -105,7 +101,7 @@ export function esbuild (options: Options = {}): Plugin {
         const result = await transform(code, {
           loader: 'js',
           minify: true,
-          target
+          target: options.target
         })
         if (result.code) {
           return {

--- a/src/rollup/plugins/esbuild.ts
+++ b/src/rollup/plugins/esbuild.ts
@@ -80,7 +80,7 @@ export function esbuild (options: Options = {}): Plugin {
         return null
       }
 
-      target = options.target || 'node12'
+      target = options.target || 'node14'
 
       const result = await transform(code, {
         loader,

--- a/src/rollup/plugins/esbuild.ts
+++ b/src/rollup/plugins/esbuild.ts
@@ -16,7 +16,7 @@ export type Options = {
   exclude?: FilterPattern
   sourceMap?: boolean
   minify?: boolean
-  target?: string | string[]
+  target: string | string[]
   jsxFactory?: string
   jsxFragment?: string
   define?: {
@@ -36,7 +36,7 @@ export type Options = {
   }
 }
 
-export function esbuild (options: Options = {}): Plugin {
+export function esbuild (options: Options): Plugin {
   const loaders = {
     ...defaultLoaders
   }

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -141,7 +141,7 @@ export interface NitroOptions {
   node: boolean
   moduleSideEffects: string[]
   esbuild?: {
-    options?: EsbuildOptions
+    options?: Partial<EsbuildOptions>
   }
   noExternals: boolean,
   externals: NodeExternalsOptions


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/issues/4771

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Context: https://github.com/nuxt/framework/issues/507

This sets esbuild target to currently minimum node version required for project, and removes the additional default set within the plugin.

https://esbuild.github.io/api/#target

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

