### PR TITLE
docs: update cloudflare deploy instructions

### DIFF
--- a/docs/deploy/providers/cloudflare.md
+++ b/docs/deploy/providers/cloudflare.md
@@ -19,8 +19,10 @@ bucket = ".output/public"
 entry-point = ".output"
 
 [build]
-command = "true"
-upload.format = "service-worker"
+command = "yarn build"
+
+[build.upload]
+format = "service-worker"
 ```
 
 ## Testing locally


### PR DESCRIPTION
The example TOML config is incorrect, updated based on the latest docs: https://developers.cloudflare.com/workers/cli-wrangler/configuration/#build
