### PR TITLE
feat: allow edit of commonJs plugin params

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -297,3 +297,6 @@ Rollup specific option. Specifies module imports that have side-effects
 
 Rollup specific option.
 
+### `commonJS`
+
+Rollup specific option. Specifies additionnal configuration for the rollup commonJS plugin.

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -299,4 +299,4 @@ Rollup specific option.
 
 ### `commonJS`
 
-Rollup specific option. Specifies additionnal configuration for the rollup commonJS plugin.
+Rollup specific option. Specifies additional configuration for the rollup CommonJS plugin.

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -300,7 +300,7 @@ export const plugins = [
   rollupConfig.plugins.push(commonjs({
     esmExternals: id => !id.startsWith('unenv/'),
     requireReturnsDefault: 'auto',
-    ...nitro.options.commonJs
+    ...nitro.options.commonJS
   }))
 
   // https://github.com/rollup/plugins/tree/master/packages/json

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -299,7 +299,8 @@ export const plugins = [
   // https://github.com/rollup/plugins/tree/master/packages/commonjs
   rollupConfig.plugins.push(commonjs({
     esmExternals: id => !id.startsWith('unenv/'),
-    requireReturnsDefault: 'auto'
+    requireReturnsDefault: 'auto',
+    ...nitro.options.commonJs
   }))
 
   // https://github.com/rollup/plugins/tree/master/packages/json

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -10,6 +10,7 @@ import type { StorageMounts } from '../rollup/plugins/storage'
 import type { RollupConfig } from '../rollup/config'
 import type { Options as EsbuildOptions } from '../rollup/plugins/esbuild'
 import { NitroErrorHandler, NitroDevEventHandler, NitroEventHandler } from './handler'
+import type { RollupCommonJSOptions } from '@rollup/plugin-commonjs'
 
 export interface Nitro {
   options: NitroOptions,
@@ -139,6 +140,7 @@ export interface NitroOptions {
   externals: NodeExternalsOptions
   analyze: false | PluginVisualizerOptions
   replace: Record<string, string | ((id: string) => string)>
+  commonJs?: RollupCommonJSOptions
 
   // Advanced
   typescript: {

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -5,12 +5,12 @@ import type { PluginVisualizerOptions } from 'rollup-plugin-visualizer'
 import type { NestedHooks, Hookable } from 'hookable'
 import type { Consola, LogLevel } from 'consola'
 import { WatchOptions } from 'chokidar'
+import type { RollupCommonJSOptions } from '@rollup/plugin-commonjs'
 import type { NodeExternalsOptions } from '../rollup/plugins/externals'
 import type { StorageMounts } from '../rollup/plugins/storage'
 import type { RollupConfig } from '../rollup/config'
 import type { Options as EsbuildOptions } from '../rollup/plugins/esbuild'
 import { NitroErrorHandler, NitroDevEventHandler, NitroEventHandler } from './handler'
-import type { RollupCommonJSOptions } from '@rollup/plugin-commonjs'
 
 export interface Nitro {
   options: NitroOptions,

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -140,7 +140,7 @@ export interface NitroOptions {
   externals: NodeExternalsOptions
   analyze: false | PluginVisualizerOptions
   replace: Record<string, string | ((id: string) => string)>
-  commonJs?: RollupCommonJSOptions
+  commonJS?: RollupCommonJSOptions
 
   // Advanced
   typescript: {


### PR DESCRIPTION
- add commonjs field to edit the commonjs plugin

<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue
https://github.com/nuxt/framework/pull/4762
https://github.com/nuxt/framework/issues/4661

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Add the commonJs key to NitroOptions and assign by destructuring nitro.option.commonJs  when adding the @rollup/plugin-commonjs.
Would improve the linked PR by avoiding replacing the commonJS plugin at build. The commonJS dynamicRequireTargets declaration would be directly into nitro/nuxt config

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

