### PR TITLE
fix: add missing include path `../../**/*` in generate tsconfig.json

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -101,7 +101,8 @@ export async function writeTypes (nitro: Nitro) {
       },
       include: [
         './nitro.d.ts',
-        '../../**/*'
+        join(relative(join(nitro.options.buildDir, 'types'), nitro.options.rootDir), '**/*'),
+        ...nitro.options.srcDir !== nitro.options.rootDir ? [join(relative(join(nitro.options.buildDir, 'types'), nitro.options.srcDir), '**/*')] : []
       ]
     }
     await writeFile(join(nitro.options.buildDir, 'types/tsconfig.json'), JSON.stringify(tsConfig, null, 2))

--- a/src/build.ts
+++ b/src/build.ts
@@ -100,7 +100,8 @@ export async function writeTypes (nitro: Nitro) {
           : {}
       },
       include: [
-        './nitro.d.ts'
+        './nitro.d.ts',
+        '../../**/*'
       ]
     }
     await writeFile(join(nitro.options.buildDir, 'types/tsconfig.json'), JSON.stringify(tsConfig, null, 2))


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

fix #204
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
the generated tsconfig.json file in .nitro/types is missing "include path" of "../../**/*", causing typescript unable to grab all global types defined in .nitro/types/nitro.d.ts.  adding "../../**/*" to tsConfig.include array in nitro\src\build.ts should fix this issue.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

