### PR TITLE
feat: add `NitroFetchRequest` type and enhance $fetch's request type

### DIFF
--- a/src/types/fetch.ts
+++ b/src/types/fetch.ts
@@ -3,10 +3,7 @@ import type { FetchRequest, FetchOptions, FetchResponse } from 'ohmyfetch'
 // An interface to extend in a local project
 export interface InternalApi { }
 
-export type NitroFetchRequest =
-Exclude<keyof InternalApi, '/__nuxt_error'>
-| (`${string}${'/'|'.'}${string}` & {})
-| Exclude<FetchRequest, string>
+export type NitroFetchRequest = keyof InternalApi | (`${string}${'/'|'.'}${string}` & {}) | Exclude<FetchRequest, string>
 
 export type ValueOf<C> = C extends Record<any, any> ? C[keyof C] : never
 

--- a/src/types/fetch.ts
+++ b/src/types/fetch.ts
@@ -3,7 +3,7 @@ import type { FetchRequest, FetchOptions, FetchResponse } from 'ohmyfetch'
 // An interface to extend in a local project
 export interface InternalApi { }
 
-export type NitroFetchRequest = keyof InternalApi | (`${string}${'/'|'.'}${string}` & {}) | Exclude<FetchRequest, string>
+export type NitroFetchRequest = keyof InternalApi | (`${string}${'/'}${string}` & {}) | Exclude<FetchRequest, string>
 
 export type ValueOf<C> = C extends Record<any, any> ? C[keyof C] : never
 

--- a/src/types/fetch.ts
+++ b/src/types/fetch.ts
@@ -3,6 +3,11 @@ import type { FetchRequest, FetchOptions, FetchResponse } from 'ohmyfetch'
 // An interface to extend in a local project
 export interface InternalApi { }
 
+export type NitroFetchRequest =
+Exclude<keyof InternalApi, '/__nuxt_error'>
+| (`${string}${'/'|'.'}${string}` & {})
+| Exclude<FetchRequest, string>
+
 export type ValueOf<C> = C extends Record<any, any> ? C[keyof C] : never
 
 export type MatchedRoutes<Route extends string> = ValueOf<{
@@ -23,9 +28,9 @@ export type TypedInternalResponse<Route, Default> =
         : MiddlewareOf<Route>
       : Default
 
-export interface $Fetch<DefaultT = unknown, DefaultR extends FetchRequest = FetchRequest> {
-  <T = DefaultT, R extends FetchRequest = DefaultR> (request: R, opts?: FetchOptions): Promise<TypedInternalResponse<R, T>>
-  raw<T = DefaultT, R extends FetchRequest = DefaultR> (request: R, opts?: FetchOptions): Promise<FetchResponse<TypedInternalResponse<R, T>>>
+export interface $Fetch<DefaultT = unknown, DefaultR extends NitroFetchRequest = NitroFetchRequest> {
+  <T = DefaultT, R extends NitroFetchRequest = DefaultR> (request: R, opts?: FetchOptions): Promise<TypedInternalResponse<R, T>>
+  raw<T = DefaultT, R extends NitroFetchRequest = DefaultR> (request: R, opts?: FetchOptions): Promise<FetchResponse<TypedInternalResponse<R, T>>>
 }
 
 declare global {


### PR DESCRIPTION
Enhance the $fetch request's type by inferring the server route's string literal (InternalApi interface). supporting auto-complete and showing type hints.

<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

resolves #208
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Add a new type `NitroFetchRequest` to Enhance `$fetch`'s request type by inferring the generated server route's string literal (InternalApi interface).

This will provide better DX and prevent typos while $fetch by supporting auto-complete and showing type hints when entering the request. And should still be able to pass other valid request URLs like https://example.com/api or Request object like new Request('/api/test')

This will also provide Nuxt 3's `useFetch` and `useLazyFetch` to also have type hints on request parameters with little type changes. see issue nuxt/framework#4823 and PR nuxt/framework#4825

### Usage scenario
```ts
// assume the project contains routes/api/test.ts
const result = await $fetch( /** IDE should show hint: '/api/test' */ )

const request: NitroFetchRequest = /** IDE should show hint: '/api/test' */
```

```ts
$fetch('/api/test') // ok
$fetch('https://example.com/api') // ok
$fetch(new Request('api/test')) // ok

// assume no routes/other.ts
$fetch('other') // type error: Argument of type '"other"' is not assignable to parameter of type 'FetchRequestUrl | Ref<FetchRequestUrl> | (() => FetchRequestUrl)'.
```
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

