### PR TITLE
fix: improve error handler to include stacktrace

### DIFF
--- a/src/runtime/entries/nitro-dev.ts
+++ b/src/runtime/entries/nitro-dev.ts
@@ -34,5 +34,5 @@ server.listen(listenAddress, () => {
   })
 })
 
-process.on('unhandledRejection', err => console.error('[nitro] [dev] [unhandledRejection] ' + err))
-process.on('uncaughtException', err => console.error('[nitro] [dev] [uncaughtException] ' + err))
+process.on('unhandledRejection', err => console.error('[nitro] [dev] [unhandledRejection]', err))
+process.on('uncaughtException', err => console.error('[nitro] [dev] [uncaughtException]', err))

--- a/src/runtime/entries/nitro-prerenderer.ts
+++ b/src/runtime/entries/nitro-prerenderer.ts
@@ -3,5 +3,5 @@ import { nitroApp } from '../app'
 
 export const localFetch = nitroApp.localFetch
 
-process.on('unhandledRejection', err => console.error('[nitro] [dev] [unhandledRejection] ' + err))
-process.on('uncaughtException', err => console.error('[nitro] [dev] [uncaughtException] ' + err))
+process.on('unhandledRejection', err => console.error('[nitro] [dev] [unhandledRejection]', err))
+process.on('uncaughtException', err => console.error('[nitro] [dev] [uncaughtException]', err))

--- a/src/runtime/entries/node-server.ts
+++ b/src/runtime/entries/node-server.ts
@@ -23,7 +23,7 @@ server.listen(port, hostname, (err) => {
   console.log(`Listening on ${protocol}://${hostname}:${port}${useRuntimeConfig().app.baseURL}`)
 })
 
-process.on('unhandledRejection', err => console.error('[nitro] [dev] [unhandledRejection] ' + err))
-process.on('uncaughtException', err => console.error('[nitro] [dev] [uncaughtException] ' + err))
+process.on('unhandledRejection', err => console.error('[nitro] [dev] [unhandledRejection]', err))
+process.on('uncaughtException', err => console.error('[nitro] [dev] [uncaughtException]', err))
 
 export default {}

--- a/src/runtime/entries/node.ts
+++ b/src/runtime/entries/node.ts
@@ -3,5 +3,5 @@ import { nitroApp } from '../app'
 
 export const handler = nitroApp.h3App.nodeHandler
 
-process.on('unhandledRejection', err => console.error('[nitro] [dev] [unhandledRejection] ' + err))
-process.on('uncaughtException', err => console.error('[nitro] [dev] [uncaughtException] ' + err))
+process.on('unhandledRejection', err => console.error('[nitro] [dev] [unhandledRejection]', err))
+process.on('uncaughtException', err => console.error('[nitro] [dev] [uncaughtException]', err))


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If an unhandled error occurs somewhere, nito only prints the error message. This makes it hard to locate where the error occurs and how to fix it. With this PR, the full stacktrace is printed for an error.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

