### PR TITLE
feat: add prerender:route hook

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -4,7 +4,7 @@ import { parseURL } from 'ufo'
 import chalk from 'chalk'
 import { createNitro } from './nitro'
 import { build } from './build'
-import type { Nitro } from './types'
+import type { Nitro, PrerenderRoute } from './types'
 import { writeFile } from './utils'
 
 const allowedExtensions = new Set(['', '.json'])
@@ -41,26 +41,39 @@ export async function prerender (nitro: Nitro) {
   }
 
   const generateRoute = async (route: string) => {
+    const start = Date.now()
+
+    // Check if we should render routee
     if (!canPrerender(route)) { return }
     generatedRoutes.add(route)
     routes.delete(route)
+
+    // Create result object
+    const _route: PrerenderRoute = { route }
+
+    // Fetch the route
     const res = await (localFetch(route, { headers: { 'X-Nitro-Prerender': route } }) as ReturnType<typeof fetch>)
-    const contents = await res.text()
+    _route.contents = await res.text()
     if (res.status !== 200) {
-      throw new Error(`[${res.status}] ${res.statusText}`)
+      _route.error = new Error(`[${res.status}] ${res.statusText}`) as any
+      _route.error.statusCode = res.status
+      _route.error.statusMessage = res.statusText
     }
 
+    // Write to the file
     const isImplicitHTML = !route.endsWith('.html') && (res.headers.get('content-type') || '').includes('html')
     const routeWithIndex = route.endsWith('/') ? route + 'index' : route
-    const fileName = isImplicitHTML ? route + '/index.html' : routeWithIndex
-    const filePath = join(nitro.options.output.publicDir, fileName)
-    await writeFile(filePath, contents)
-    // Crawl Links
+    _route.fileName = isImplicitHTML ? route + '/index.html' : routeWithIndex
+    const filePath = join(nitro.options.output.publicDir, _route.fileName)
+    await writeFile(filePath, _route.contents)
+
+    // Crawl route links
     if (
+      !_route.error &&
       nitro.options.prerender.crawlLinks &&
       isImplicitHTML
     ) {
-      const crawledRoutes = extractLinks(contents, route, res)
+      const crawledRoutes = extractLinks(_route.contents, route, res)
       for (const crawledRoute of crawledRoutes) {
         if (canPrerender(crawledRoute)) {
           routes.add(crawledRoute)
@@ -68,7 +81,8 @@ export async function prerender (nitro: Nitro) {
       }
     }
 
-    return { route, contents, filePath }
+    _route.generateTimeMS = Date.now() - start
+    return _route
   }
 
   nitro.logger.info(nitro.options.prerender.crawlLinks
@@ -77,18 +91,13 @@ export async function prerender (nitro: Nitro) {
   )
   for (let i = 0; i < 100 && routes.size; i++) {
     for (const route of Array.from(routes)) {
-      const start = Date.now()
-      let end: number | null = null
+      const _route = await generateRoute(route).catch(error => ({ route, error } as PrerenderRoute))
 
-      try {
-        const { contents, filePath } = await generateRoute(route)
-        end = Date.now()
-        nitro.logger.log(chalk.gray(`  ├─ ${route} (${end - start}ms)`))
-        await nitro.hooks.callHook('prerender:route', { route, contents, filePath })
-      } catch (error) {
-        nitro.logger.log(chalk.gray(`  ├─ ${route} (${end - start}ms) ${error ? `(${error})` : ''}`))
-        await nitro.hooks.callHook('prerender:route', error)
-      }
+      // Skipped (not allowed or duplicate)
+      if (!_route) { continue }
+
+      await nitro.hooks.callHook('prerender:route', _route)
+      nitro.logger.log(chalk[_route.error ? 'yellow' : 'gray'](`  ├─ ${_route.route} (${_route.generateTimeMS}ms) ${_route.error ? `(${_route.error})` : ''}`))
     }
   }
 }

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -84,9 +84,10 @@ export async function prerender (nitro: Nitro) {
         const { contents, filePath } = await generateRoute(route)
         end = Date.now()
         nitro.logger.log(chalk.gray(`  ├─ ${route} (${end - start}ms)`))
-        nitro.hooks.callHook('prerender:route', { route, contents, filePath })
+        await nitro.hooks.callHook('prerender:route', { route, contents, filePath })
       } catch (error) {
         nitro.logger.log(chalk.gray(`  ├─ ${route} (${end - start}ms) ${error ? `(${error})` : ''}`))
+        await nitro.hooks.callHook('prerender:route', error)
       }
     }
   }

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -23,14 +23,21 @@ export interface Nitro {
   close: () => Promise<void>
 }
 
+export interface PrerenderRoute {
+  route: string
+  contents?: string
+  fileName?: string
+  error?: Error & { statusCode: number, statusMessage: string }
+  generateTimeMS?: number
+}
+
 type HookResult = void | Promise<void>
 export interface NitroHooks {
   'rollup:before': (nitro: Nitro) => HookResult
   'compiled': (nitro: Nitro) => HookResult
   'dev:reload': () => HookResult
   'close': () => HookResult
-  /* Hook called when a route has been generated. */
-  'prerender:route': (value: { route: string; contents: string; filePath: string } | Error) => HookResult
+  'prerender:route': (route: PrerenderRoute) => HookResult
 }
 
 export interface StorageMounts {

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -29,6 +29,8 @@ export interface NitroHooks {
   'compiled': (nitro: Nitro) => HookResult
   'dev:reload': () => HookResult
   'close': () => HookResult
+  /* Hook called when a route has been generated. */
+  'prerender:route': (options: { route: string; contents: string; filePath: string }) => HookResult
 }
 
 export interface StorageMounts {

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -30,7 +30,7 @@ export interface NitroHooks {
   'dev:reload': () => HookResult
   'close': () => HookResult
   /* Hook called when a route has been generated. */
-  'prerender:route': (options: { route: string; contents: string; filePath: string }) => HookResult
+  'prerender:route': (value: { route: string; contents: string; filePath: string } | Error) => HookResult
 }
 
 export interface StorageMounts {


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Add a new hook `prerender:route` that is called when a single page has been successfully prerendered.

This hook can be used externally to create specific logic tied to route generation, such as editing output of a route.

`generateRoute` now returns `{ contents, route, filePath }` instead of nothing, in order to:

- Access the saved file directly by its `filePath`.
- Read the `contents` that have been generated.

I can see more potential for SSG (fully static).

A quick example usage could be to dynamically download and replace static assets, stored on an API server, that you don't want to use in production (parse HTML content, download image, replace image path with the one downloaded locally).

Please, let me know if this change is not intended for nitro.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

