### PR TITLE
docs: fix typo

### DIFF
--- a/docs/deploy/providers/digitalocean.md
+++ b/docs/deploy/providers/digitalocean.md
@@ -1,6 +1,6 @@
 # DigitalOcean
 
-**Preset:** `digitalocean` ([switch to this preset](/deploy/#changing-the-deployment-preset))
+**Preset:** `digital-ocean` ([switch to this preset](/deploy/#changing-the-deployment-preset))
 
 Nitro supports deploying on the [Digital Ocean App Platform](https://docs.digitalocean.com/products/app-platform/) with minimal configuration.
 


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes a typo in the deployment preset name to avoid confusion. Correct preset name for DigitalOcean appears to be `digital-ocean` as seen in the preset filename (compare https://github.com/unjs/nitro/tree/main/src/presets)

### 📝 Checklist

- [x] ~~I have linked an issue or discussion.~~ (not applicable)
- [x] ~~I have updated the documentation accordingly.~~ (not applicable)

