### PR TITLE
feat: enable response type infer for API routes with params

### DIFF
--- a/src/types/fetch.ts
+++ b/src/types/fetch.ts
@@ -1,4 +1,5 @@
 import type { FetchRequest, FetchOptions, FetchResponse } from 'ohmyfetch'
+import { CovertRouteToMatcher, NumberOfRouteSegments } from './utils'
 
 // An interface to extend in a local project
 export interface InternalApi { }
@@ -9,7 +10,11 @@ export type ValueOf<C> = C extends Record<any, any> ? C[keyof C] : never
 
 export type MatchedRoutes<Route extends string> = ValueOf<{
   // exact match, prefix match or root middleware
-  [key in keyof InternalApi]: Route extends key | `${key}/${string}` | '/' ? key : never
+  [key in keyof InternalApi]: Route extends CovertRouteToMatcher<key>
+      ? NumberOfRouteSegments<Route> extends NumberOfRouteSegments<CovertRouteToMatcher<key>>
+          ? key
+          : never
+      : Route extends key | `${key}/${string}` | '/' ? key : never
 }>
 
 export type MiddlewareOf<Route extends string> = Exclude<InternalApi[MatchedRoutes<Route>], Error | void>

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,0 +1,16 @@
+export type CovertRouteToMatcher<Route extends string, Acc extends string = ''> =
+Route extends `${infer Segment}:${infer Rest}`
+    ? Rest extends `${string}:${string}`
+        ? CovertRouteToMatcher<Rest extends `${string}/${infer NextSeg}`
+            ? NextSeg
+            : never,
+          `${Segment}${string}/`>
+        : `${Acc}${Segment}${string}`
+    : never
+
+export type NumberOfRouteSegments<Route extends string, Count extends string[] = []> =
+Route extends `/${string}/${infer Rest}`
+    ? Rest extends `${string}/${string}/${string}`
+        ? NumberOfRouteSegments<Rest extends `${string}/${infer NextSeg}` ? `/${NextSeg}`:never, [...Count, '']>
+        : Count['length']
+    : never


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

resolves #221
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Update `MatchedRoutes` helper type in `types/fetch.ts` to enable  `$fetch` to infer response type even for routes with params, (ex: users/[useId]/posts/[postId].ts)

This will provide better DX for a wider range of complex requests with variables in it for requesting server routes containing params

This will also future provide Nuxt 3's `useFetch` and `useLazyFetch` to be able to infer the response's data type. 😎 

### Usage scenario

#### assume the project contains  `routes\users\[userId].ts` and `routes\users\[userId]\posts\[postId].ts`
```ts
// routes\users\[userId].ts
export default eventHandler(() => {
    return { username: 'David', age: 18 }
})
```
```ts
// routes\users\[userId]\posts\[postId].ts
export default eventHandler(() => {
    return { content: 'post content', author: 'David', points: 99 }
})
```
#### and use in other file as 
```ts
declare const params
cosnt { userId, postId } = params

const user = await $fetch(`/users/${userId}`) // or $fetch('/users/david') 
// user's type will be 
// { 
//    username: string; 
//    age: number; 
// }

const post = await $fetch(`/users/${userId}/posts/${postId}`) // or $fetch('/users/david/posts/42')
// post's type will be 
// { 
//    content: string; 
//    author: string; 
//    points: number; 
// }

const result = await $fetch(`/users/${userId}/notInServerRoutes/${postId}`)
// result's type will be `unknown`

```
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

