### PR TITLE
fix: add missing `paths` config in `playgound/tsconfig.json`

### DIFF
--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -1,3 +1,16 @@
 {
-  "extends": "./.nitro/types/tsconfig.json"
+  "extends": "./.nitro/types/tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "nitropack": [
+        "../src/index"
+      ],
+      "#internal/nitro": [
+        "../src/runtime/index"
+      ],
+      "#internal/nitro/*": [
+        "../src/runtime/*"
+      ]
+    },
+  }
 }


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

fix #227 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In local dev env, playground's $fetch's `InteralApi` type in `nitropack` is not merge with `InternalApi` in `.nitro/types/nitro.d.ts`, causing API response types and request type `NitroFetchRequest` unable to infer from extracted keys from `InternalApi` interface.

```ts
declare module 'nitropack' {
  type Awaited<T> = T extends PromiseLike<infer U> ? Awaited<U> : T
  interface InternalApi {
    '/post': Awaited<ReturnType<typeof import('../../routes/post').default>>
  }
}
```

#### Proposed solution
This can be fix by adding `paths` config to `tsconifg.json in playground as:
```diff
"extends": "./.nitro/types/tsconfig.json",
+  "compilerOptions": {
+   "paths": {
+     "nitropack": [
+       "../src/index"
+     ],
+     "#internal/nitro": [
+       "../src/runtime/index"
+     ],
+     "#internal/nitro/*": [
+       "../src/runtime/*"
+     ]
+   },
+ }
```
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

