### PR TITLE
fix: exclude internal `/_*`, `/api/_*` routes from NitroFetchReqeust type

### DIFF
--- a/src/types/fetch.ts
+++ b/src/types/fetch.ts
@@ -3,7 +3,7 @@ import type { FetchRequest, FetchOptions, FetchResponse } from 'ohmyfetch'
 // An interface to extend in a local project
 export interface InternalApi { }
 
-export type NitroFetchRequest = Exclude<keyof InternalApi | Exclude<FetchRequest, string> | string & {}, `/_${string}`|`/api/_${string}`>
+export type NitroFetchRequest = Exclude<keyof InternalApi, `/_${string}`|`/api/_${string}`> | Exclude<FetchRequest, string> | string & {}
 
 export type ValueOf<C> = C extends Record<any, any> ? C[keyof C] : never
 

--- a/src/types/fetch.ts
+++ b/src/types/fetch.ts
@@ -3,7 +3,7 @@ import type { FetchRequest, FetchOptions, FetchResponse } from 'ohmyfetch'
 // An interface to extend in a local project
 export interface InternalApi { }
 
-export type NitroFetchRequest = keyof InternalApi | Exclude<FetchRequest, string> | string & {}
+export type NitroFetchRequest = Exclude<keyof InternalApi | Exclude<FetchRequest, string> | string & {}, `/_${string}`|`/api/_${string}`>
 
 export type ValueOf<C> = C extends Record<any, any> ? C[keyof C] : never
 


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

fix #231
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

type `NitroFetchRequest` should exclude all `/_*` and `/api/_*` routes as they are for internal use and should not show type hints/auto-complete to end users.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

