### PR TITLE
feat(preset): add aws-lambda-edge preset

### DIFF
--- a/docs/deploy/providers/aws.md
+++ b/docs/deploy/providers/aws.md
@@ -14,3 +14,89 @@ import { handler } from './.output/server'
 // Use programmatically
 const { statusCode, headers, body } = handler({ rawPath: '/' })
 ```
+
+# AWS Lambda@Edge
+
+**Preset:** `aws-lambda-edge` ([switch to this preset](/deploy/#changing-the-deployment-preset))
+
+Nitro provides a built-in preset to generate output format compatible with [AWS Lambda@Edge](https://docs.aws.amazon.com/lambda/latest/dg/lambda-edge.html).
+
+The output entrypoint in `.output/server/index.mjs` is compatible with [AWS Lambda@Edge format](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html).
+
+### Deploy using AWS CDK
+
+The following code is an example of deploying a Nuxt3 project to CloudFront and Lambda@Edge with [AWS CDK](https://github.com/aws/aws-cdk). Using this stack, paths under `_nuxt/` (static assets) will get their data from the S3 origin, and all other paths will be resolved by Lambda@Edge.
+
+```ts
+import { spawnSync } from "child_process";
+import { CfnOutput, RemovalPolicy, Stack, StackProps } from "aws-cdk-lib";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as s3deployment from "aws-cdk-lib/aws-s3-deployment";
+import { Construct } from "constructs";
+
+export class NitroLambdaEdgeStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    spawnSync("yarn", ["build"], {
+      stdio: "inherit",
+      cwd: "<your-project-path>",
+    });
+
+    const edgeFunction = new cloudfront.experimental.EdgeFunction(
+      this,
+      "EdgeFunction",
+      {
+        runtime: lambda.Runtime.NODEJS_16_X,
+        handler: "index.handler",
+        code: lambda.Code.fromAsset("<your-project-path>/.output/server"),
+      }
+    );
+    const bucket = new s3.Bucket(this, "Bucket", {
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
+    const s3Origin = new origins.S3Origin(bucket);
+    const distribution = new cloudfront.Distribution(this, "Distribution", {
+      defaultBehavior: {
+        origin: s3Origin,
+        edgeLambdas: [
+          {
+            functionVersion: edgeFunction.currentVersion,
+            eventType: cloudfront.LambdaEdgeEventType.ORIGIN_REQUEST,
+          },
+        ],
+      },
+      additionalBehaviors: {
+        "_nuxt/*": {
+          origin: s3Origin,
+        },
+      },
+    });
+    new s3deployment.BucketDeployment(this, "Deployment", {
+      sources: [s3deployment.Source.asset("<your-project-path>/.output/public")],
+      destinationBucket: bucket,
+      distribution,
+    });
+    new CfnOutput(this, "URL", {
+      value: `https://${distribution.distributionDomainName}`,
+    });
+  }
+}
+```
+
+::: Specify Region
+Note that the region must be specified when using the code above.
+:::
+
+```ts
+const app = new cdk.App();
+new NitroLambdaEdgeStack(app, "NitroLambdaEdgeStack", {
+  env: {
+    region: "your AWS region", // need this line
+  },
+});
+```

--- a/src/presets/aws-lambda-edge.ts
+++ b/src/presets/aws-lambda-edge.ts
@@ -1,0 +1,6 @@
+import { defineNitroPreset } from '../preset'
+
+export const awsLambdaEdge = defineNitroPreset({
+  entry: '#internal/nitro/entries/aws-lambda-edge',
+  externals: true
+})

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -1,4 +1,5 @@
 export * from './aws-lambda'
+export * from './aws-lambda-edge'
 export * from './azure-functions'
 export * from './azure'
 export * from './base-worker'

--- a/src/runtime/entries/aws-lambda-edge.ts
+++ b/src/runtime/entries/aws-lambda-edge.ts
@@ -1,0 +1,31 @@
+import type { CloudFrontHeaders, Context, CloudFrontRequestEvent, CloudFrontResultResponse } from 'aws-lambda'
+import '#internal/nitro/virtual/polyfill'
+import { nitroApp } from '../app'
+
+export const handler = async function handler (event: CloudFrontRequestEvent, context: Context): Promise<CloudFrontResultResponse> {
+  const request = event.Records[0].cf.request
+
+  const r = await nitroApp.localCall({
+    event,
+    url: request.uri,
+    context,
+    headers: normalizeIncomingHeaders(request.headers),
+    method: request.method,
+    query: request.querystring,
+    body: request.body
+  })
+
+  return {
+    status: r.status.toString(),
+    headers: normalizeOutgoingHeaders(r.headers),
+    body: r.body.toString()
+  }
+}
+
+function normalizeIncomingHeaders (headers: CloudFrontHeaders) {
+  return Object.fromEntries(Object.entries(headers).map(([key, keyValues]) => [key, keyValues.map(kv => kv.value)]))
+}
+
+function normalizeOutgoingHeaders (headers: Record<string, string | string[] | undefined>): CloudFrontHeaders {
+  return Object.fromEntries(Object.entries(headers).map(([k, v]) => [k, Array.isArray(v) ? v.map(value => ({ value })) : [{ value: v }]]))
+}

--- a/test/presets/aws-lambda-edge.test.ts
+++ b/test/presets/aws-lambda-edge.test.ts
@@ -1,0 +1,50 @@
+import { resolve } from 'pathe'
+import { describe } from 'vitest'
+import destr from 'destr'
+import type { CloudFrontHeaders, CloudFrontRequestEvent, CloudFrontResultResponse } from 'aws-lambda'
+import { setupTest, testNitro } from '../tests'
+
+describe('nitro:preset:aws-lambda-edge', async () => {
+  const ctx = await setupTest('aws-lambda-edge')
+  testNitro(ctx, async () => {
+    const { handler } = await import(resolve(ctx.outDir, 'server/index.mjs'))
+    return async ({ url: rawRelativeUrl, headers, method, body }) => {
+      // creating new URL object to parse query easier
+      const url = new URL(`https://example.com${rawRelativeUrl}`)
+      // modify headers to CloudFrontHeaders.
+      const reqHeaders: CloudFrontHeaders = Object.fromEntries(Object.entries(headers || {}).map(([k, v]) => [k, Array.isArray(v) ? v.map(value => ({ value })) : [{ value: v }]]))
+
+      const event: CloudFrontRequestEvent = {
+        Records: [
+          {
+            cf: {
+              config: {
+                distributionDomainName: 'nitro.cloudfront.net',
+                distributionId: 'EDFDVBD6EXAMPLE',
+                eventType: 'origin-request',
+                requestId: '4TyzHTaYWb1GX1qTfsHhEqV6HUDd_BzoBZnwfnvQc_1oF26ClkoUSEQ=='
+              },
+              request: {
+                clientIp: '203.0.113.178',
+                method: method || 'GET',
+                uri: url.pathname,
+                querystring: url.searchParams.toString(),
+                headers: reqHeaders,
+                body
+              }
+            }
+          }
+        ]
+      }
+      const res: CloudFrontResultResponse = await handler(event)
+      // responsed CloudFrontHeaders are special, so modify them for testing.
+      const resHeaders = Object.fromEntries(Object.entries(res.headers).map(([key, keyValues]) => [key, keyValues.map(kv => kv.value).join(',')]))
+
+      return {
+        data: destr(res.body),
+        status: parseInt(res.status),
+        headers: resHeaders
+      }
+    }
+  })
+})


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

- #79 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
Add AWS Lambda@Edge to the preset.

<!-- Why is this change required? What problem does it solve? -->
The current `aws-lambda` preset is not compatible with the Lambda@Edge format and requires users to create their own wrapper for Lambda@Edge. This PR is needed to resolve this issue.  
It would also be very powerful if Lambda@Edge were available in Nitro. It will be quite important for projects that require SSR (e.g Nuxt3) as static assets (`.output/public`) can be retrieved from AWS S3 and the rest (`.output/server`) can be resolved by Lambda@Edge.

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Resolves #79 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

