### PR TITLE
feat(handlers): allow method suffix in handler file path

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -45,7 +45,15 @@ export async function writeTypes (nitro: Nitro) {
 
   const middleware = [
     ...nitro.scannedHandlers,
-    ...nitro.options.handlers
+    ...nitro.options.handlers.map((handler) => {
+      if (handler.method) { return handler }
+      // if there is a method suffix, use it as the method
+      const [, method = undefined] = handler.handler.match(/\.(get|head|patch|post|put|delete|connect|options|trace)(\.\w+)*$/) || []
+      return {
+        ...handler,
+        method
+      }
+    })
   ]
 
   for (const mw of middleware) {

--- a/src/rollup/plugins/handlers.ts
+++ b/src/rollup/plugins/handlers.ts
@@ -17,7 +17,15 @@ export function handlers (nitro: Nitro) {
     '#internal/nitro/virtual/server-handlers': () => {
       const handlers = [
         ...nitro.scannedHandlers,
-        ...nitro.options.handlers
+        ...nitro.options.handlers.map((handler) => {
+          if (handler.method) { return handler }
+          // if there is a method suffix, use it as the method
+          const [, method = undefined] = handler.handler.match(/\.(get|head|patch|post|put|delete|connect|options|trace)(\.\w+)*$/) || []
+          return {
+            ...handler,
+            method
+          }
+        })
       ]
       if (nitro.options.serveStatic) {
         handlers.unshift({ middleware: true, handler: '#internal/nitro/static' })


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue
resolve https://github.com/nuxt/framework/issues/5020
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Enhance the server handlers.
Allow (if the method is not specified) to use the method suffix as the handler's route method

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

