### PR TITLE
feat: add option to define additional presets

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -57,9 +57,7 @@ const NitroDefaults: NitroConfig = {
   },
 
   // Rollup
-  alias: {
-    '#internal/nitro': runtimeDir
-  },
+  alias: {},
   unenv: {},
   analyze: false,
   moduleSideEffects: ['unenv/runtime/polyfill/', 'node-fetch-native/polyfill'],
@@ -74,7 +72,8 @@ const NitroDefaults: NitroConfig = {
   },
   nodeModulesDirs: [],
   hooks: {},
-  commands: {}
+  commands: {},
+  presets: {}
 }
 
 export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroOptions> {
@@ -82,6 +81,14 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
   let preset = userConfig.preset || process.env.NITRO_PRESET || detectTarget() || 'node-server'
   if (userConfig.dev) {
     preset = 'nitro-dev'
+  }
+
+  if (!userConfig.alias) {
+    userConfig.alias = {
+      '#internal/nitro': runtimeDir
+    }
+  } else {
+    userConfig.alias['#internal/nitro'] = runtimeDir
   }
 
   // Load configuration and preset
@@ -92,7 +99,15 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
     cwd: userConfig.rootDir,
     resolve (id: string) {
       type PT = Map<String, NitroConfig>
+
       let matchedPreset = (PRESETS as any as PT)[id] || (PRESETS as any as PT)[camelCase(id)]
+      if (userConfig.presets && Object.keys(userConfig.presets).length > 0) {
+        const userPreset = userConfig.presets[id] || userConfig.presets[camelCase(id)]
+        if (userPreset) {
+          matchedPreset = userPreset
+        }
+      }
+
       if (matchedPreset) {
         if (typeof matchedPreset === 'function') {
           matchedPreset = matchedPreset()

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -172,4 +172,5 @@ export interface NitroOptions {
     preview: string
     deploy: string
   }
+  presets: { [key: string]: NitroPreset }
 }


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Added new property to NitroConfig, which allows user to define own presets. Changed `#internal/nitro` alias to mandatory, so when user defines own alias to import his own preset from projects root directory, `#internal/nitro` does not get overwritten.

I felt the need for this kind of option, when I was working on a project with nuxt3, and had to start websocket server on the same server instance that was running nitro, and there was no easy way to do this without writing a new preset.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

