### PR TITLE
fix(cache): invalidate entry before calling resolver

### DIFF
--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -52,8 +52,11 @@ export function defineCachedFunction <T=any> (fn: ((...args) => T | Promise<T>),
 
     const _resolve = async () => {
       if (!pending[key]) {
-        // Remove cached value for preventing using expired cache on concurrent requests
+        // Remove cached entry to prevent using expired cache on concurrent requests
         entry.value = undefined
+        entry.integrity = undefined
+        entry.mtime = undefined
+        entry.expires = undefined
         pending[key] = Promise.resolve(resolver())
       }
       entry.value = await pending[key]

--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -52,6 +52,8 @@ export function defineCachedFunction <T=any> (fn: ((...args) => T | Promise<T>),
 
     const _resolve = async () => {
       if (!pending[key]) {
+        // Remove cached value for preventing using expired cache on concurrent requests
+        delete entry.value
         pending[key] = Promise.resolve(resolver())
       }
       entry.value = await pending[key]

--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -53,7 +53,7 @@ export function defineCachedFunction <T=any> (fn: ((...args) => T | Promise<T>),
     const _resolve = async () => {
       if (!pending[key]) {
         // Remove cached value for preventing using expired cache on concurrent requests
-        delete entry.value
+        entry.value = undefined
         pending[key] = Promise.resolve(resolver())
       }
       entry.value = await pending[key]


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://github.com/nuxt/framework/issues/5328

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Resolves https://github.com/nuxt/framework/issues/5328

When cache is expired and multiple request come in at the same time, 1st request is pending at the handler, then 2nd request will reuse invalid response from previous expired value and 404 response may be returned.

This pr is fixing the invalid cached response by removing previous response value before handler is called.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

