### PR TITLE
fix: add scanDirs to auto-import include

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "destr": "^1.1.1",
     "dot-prop": "^7.2.0",
     "esbuild": "^0.14.43",
+    "escape-string-regexp": "^5.0.0",
     "etag": "^1.8.1",
     "fs-extra": "^10.1.0",
     "globby": "^13.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,7 @@ importers:
       destr: ^1.1.1
       dot-prop: ^7.2.0
       esbuild: ^0.14.43
+      escape-string-regexp: ^5.0.0
       eslint: ^8.17.0
       etag: ^1.8.1
       execa: ^6.1.0
@@ -106,6 +107,7 @@ importers:
       destr: 1.1.1
       dot-prop: 7.2.0
       esbuild: 0.14.43
+      escape-string-regexp: 5.0.0
       etag: 1.8.1
       fs-extra: 10.1.0
       globby: 13.1.1

--- a/src/options.ts
+++ b/src/options.ts
@@ -137,7 +137,9 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
   }
 
   options.autoImport.include = [
-    ...Array.isArray(options.autoImport.include) ? options.autoImport.include : [options.autoImport.include],
+    ...Array.isArray(options.autoImport.include)
+      ? options.autoImport.include
+      : [options.autoImport.include].filter(Boolean),
     ...options.scanDirs
       .filter(i => i.includes('node_modules'))
       .map(i => new RegExp(`(^|\\/)${escapeRE(i.split('node_modules/').pop())}(\\/|$)(?!node_modules\\/)`))

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,6 +3,7 @@ import { loadConfig } from 'c12'
 import { klona } from 'klona/full'
 import { camelCase } from 'scule'
 import defu from 'defu'
+import escapeRE from 'escape-string-regexp'
 import { withLeadingSlash, withoutTrailingSlash, withTrailingSlash } from 'ufo'
 import { isTest } from 'std-env'
 import { resolvePath as resovleModule } from 'mlly'
@@ -135,7 +136,12 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
     options.scanDirs = [options.srcDir]
   }
 
-  options.autoImport.include = defu(Array.isArray(options.autoImport.include) ? options.autoImport.include : [options.autoImport.include], options.scanDirs)
+  options.autoImport.include = [
+    ...Array.isArray(options.autoImport.include) ? options.autoImport.include : [options.autoImport.include],
+    ...options.scanDirs
+      .filter(i => i.includes('node_modules'))
+      .map(i => new RegExp(`(^|\\/)${escapeRE(i.split('node_modules/').pop())}(\\/|$)(?!node_modules\\/)`))
+  ]
 
   options.baseURL = withLeadingSlash(withTrailingSlash(options.baseURL))
   options.runtimeConfig = defu(options.runtimeConfig, {

--- a/src/options.ts
+++ b/src/options.ts
@@ -135,6 +135,8 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
     options.scanDirs = [options.srcDir]
   }
 
+  options.autoImport.include = defu(Array.isArray(options.autoImport.include) ? options.autoImport.include : [options.autoImport.include], options.scanDirs)
+
   options.baseURL = withLeadingSlash(withTrailingSlash(options.baseURL))
   options.runtimeConfig = defu(options.runtimeConfig, {
     app: {

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-use-before-define */
 import type { Preset as UnenvPreset } from 'unenv'
-import type { Unimport, UnimportOptions } from 'unimport'
+import type { Unimport } from 'unimport'
+import type { UnimportPluginOptions } from 'unimport/unplugin'
 import type { PluginVisualizerOptions } from 'rollup-plugin-visualizer'
 import type { NestedHooks, Hookable } from 'hookable'
 import type { Consola, LogLevel } from 'consola'
@@ -121,7 +122,7 @@ export interface NitroOptions {
   }
   serverAssets: ServerAssetDir[]
   publicAssets: PublicAssetDir[]
-  autoImport: UnimportOptions
+  autoImport: UnimportPluginOptions
   plugins: string[]
   virtual: Record<string, string | (() => string | Promise<string>)>
 


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/pull/5042#issuecomment-1152357425

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes the type of autoImport options in nitro and adds scanDirs to autoImport.include.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

