### PR TITLE
fix: don't use file url when building prerenderer

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -213,8 +213,8 @@ export const plugins = [
 
   // https://github.com/rollup/plugins/tree/master/packages/alias
   let buildDir = nitro.options.buildDir
-  // Windows (native) dynamic imports should be file:// urr
-  if (isWindows && (nitro.options.externals?.trace === false)) {
+  // Windows (native) dynamic imports should be file:// urls
+  if (isWindows && (nitro.options.externals?.trace === false) && nitro.options.dev) {
     buildDir = pathToFileURL(buildDir).href
   }
   rollupConfig.plugins.push(alias({


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/4555, resolves 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When prerendering, we don't want to use the source `dist/server` file, which still references virtual modules and other aliases. Instead, we want to inline it.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

