### PR TITLE
fix(prerender): avoid adding duplicate baseURL for local fetch

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -1,6 +1,6 @@
 import { pathToFileURL } from 'url'
 import { resolve, join } from 'pathe'
-import { joinURL, parseURL } from 'ufo'
+import { joinURL, parseURL, withoutBase } from 'ufo'
 import chalk from 'chalk'
 import { createNitro } from './nitro'
 import { build } from './build'
@@ -75,8 +75,9 @@ export async function prerender (nitro: Nitro) {
     ) {
       const crawledRoutes = extractLinks(_route.contents, route, res)
       for (const crawledRoute of crawledRoutes) {
-        if (canPrerender(crawledRoute)) {
-          routes.add(crawledRoute)
+        const href = withoutBase(crawledRoute, nitro.options.baseURL)
+        if (canPrerender(href)) {
+          routes.add(href)
         }
       }
     }

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -1,6 +1,6 @@
 import { pathToFileURL } from 'url'
 import { resolve, join } from 'pathe'
-import { joinURL, parseURL, withoutBase } from 'ufo'
+import { parseURL, withBase } from 'ufo'
 import chalk from 'chalk'
 import { createNitro } from './nitro'
 import { build } from './build'
@@ -52,7 +52,7 @@ export async function prerender (nitro: Nitro) {
     const _route: PrerenderRoute = { route }
 
     // Fetch the route
-    const res = await (localFetch(joinURL(nitro.options.baseURL, route), { headers: { 'X-Nitro-Prerender': route } }) as ReturnType<typeof fetch>)
+    const res = await (localFetch(withBase(route, nitro.options.baseURL), { headers: { 'X-Nitro-Prerender': route } }) as ReturnType<typeof fetch>)
     _route.contents = await res.text()
     if (res.status !== 200) {
       _route.error = new Error(`[${res.status}] ${res.statusText}`) as any
@@ -75,9 +75,8 @@ export async function prerender (nitro: Nitro) {
     ) {
       const crawledRoutes = extractLinks(_route.contents, route, res)
       for (const crawledRoute of crawledRoutes) {
-        const href = withoutBase(crawledRoute, nitro.options.baseURL)
-        if (canPrerender(href)) {
-          routes.add(href)
+        if (canPrerender(crawledRoute)) {
+          routes.add(crawledRoute)
         }
       }
     }


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/content/issues/1252

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When following links with a baseURL set, we were following them directly, resulting in double-prefix of baseURL.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

