### PR TITLE
feat: exclude auto import for server entry

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -28,7 +28,7 @@ const NitroDefaults: NitroConfig = {
     publicDir: '{{ output.dir }}/public'
   },
 
-  // Featueres
+  // Features
   experimental: {},
   storage: {},
   devStorage: {},
@@ -136,14 +136,19 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
     options.scanDirs = [options.srcDir]
   }
 
-  options.autoImport.include = [
-    ...Array.isArray(options.autoImport.include)
-      ? options.autoImport.include
-      : [options.autoImport.include].filter(Boolean),
-    ...options.scanDirs
-      .filter(i => i.includes('node_modules'))
-      .map(i => new RegExp(`(^|\\/)${escapeRE(i.split('node_modules/').pop())}(\\/|$)(?!node_modules\\/)`))
-  ]
+  if (options.autoImport) {
+    options.autoImport.include = [
+      ...Array.isArray(options.autoImport.include)
+        ? options.autoImport.include
+        : [options.autoImport.include].filter(Boolean),
+      ...options.scanDirs
+        .filter(i => i.includes('node_modules'))
+        .map(i => new RegExp(`(^|\\/)${escapeRE(i.split('node_modules/').pop())}(\\/|$)(?!node_modules\\/)`))
+    ]
+    options.autoImport.exclude = [
+      options.entry
+    ]
+  }
 
   options.baseURL = withLeadingSlash(withTrailingSlash(options.baseURL))
   options.runtimeConfig = defu(options.runtimeConfig, {

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -122,7 +122,7 @@ export interface NitroOptions {
   }
   serverAssets: ServerAssetDir[]
   publicAssets: PublicAssetDir[]
-  autoImport: UnimportPluginOptions
+  autoImport: UnimportPluginOptions | false
   plugins: string[]
   virtual: Record<string, string | (() => string | Promise<string>)>
 


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/issues/5450

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Allow `nitro.autoImports` set to `false` to disable
- Exclude the entry file from been auto imports (causing duplications)
