### PR TITLE
chore: disable `import/no-named-as-default` eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
   ],
   "rules": {
     "import/no-named-as-default-member": "off",
+    "import/no-named-as-default": "off",
     "import/default": "off",
     "no-console": "off"
   }


### PR DESCRIPTION
For `defu`