### PR TITLE
fix(types): allow `autoImport` option to be false

### DIFF
--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -122,7 +122,7 @@ export interface NitroOptions {
   }
   serverAssets: ServerAssetDir[]
   publicAssets: PublicAssetDir[]
-  autoImport: UnimportPluginOptions
+  autoImport: UnimportPluginOptions | false
   plugins: string[]
   virtual: Record<string, string | (() => string | Promise<string>)>
 


### PR DESCRIPTION
There was no way to disable auto-import as we were adding object default.