### PR TITLE
feat: expose router in NitroApp

### DIFF
--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -1,4 +1,4 @@
-import { App as H3App, createApp, createRouter, lazyEventHandler } from 'h3'
+import { App as H3App, createApp, createRouter, lazyEventHandler, Router } from 'h3'
 import { createFetch, Headers } from 'ohmyfetch'
 import destr from 'destr'
 import { createRouter as createMatcher } from 'radix3'
@@ -13,7 +13,8 @@ import { handlers } from '#internal/nitro/virtual/server-handlers'
 
 export interface NitroApp {
   h3App: H3App
-  hooks: Hookable,
+  router: Router
+  hooks: Hookable
   localCall: ReturnType<typeof createCall>
   localFetch: ReturnType<typeof createLocalFetch>
 }
@@ -65,6 +66,7 @@ function createNitroApp (): NitroApp {
   const app: NitroApp = {
     hooks,
     h3App,
+    router,
     localCall,
     localFetch
   }


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/issues/5527#issuecomment-1160326409

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Exposing the router allows registering additional routes to be handled by the default router (rather than calling `app.use` which will append to the bottom of the stack.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

