### PR TITLE
fix(azure): pass query params to local call

### DIFF
--- a/src/runtime/entries/azure.ts
+++ b/src/runtime/entries/azure.ts
@@ -6,7 +6,8 @@ export async function handle (context, req) {
   let url: string
   if (req.headers['x-ms-original-url']) {
     // This URL has been proxied as there was no static file matching it.
-    url = parseURL(req.headers['x-ms-original-url']).pathname
+    const parsedURL = parseURL(req.headers['x-ms-original-url'])
+    url = parsedURL.pathname + parsedURL.search
   } else {
     // Because Azure SWA handles /api/* calls differently they
     // never hit the proxy and we have to reconstitute the URL.


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue
resolves https://github.com/nuxt/content/issues/1299
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Pass search parameters to Nitro local call. 
In the current state, Nitro handlers will not receive query parameters in Azure deployment.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

