### PR TITLE
fix: allow overriding specific build output files with aliases

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -219,13 +219,13 @@ export const plugins = [
   }
   rollupConfig.plugins.push(alias({
     entries: resolveAliases({
-      '#build': buildDir,
       '#internal/nitro/virtual/error-handler': nitro.options.errorHandler,
       '~': nitro.options.srcDir,
       '@/': nitro.options.srcDir,
       '~~': nitro.options.rootDir,
       '@@/': nitro.options.rootDir,
-      ...env.alias
+      ...env.alias,
+      '#build': buildDir
     })
   }))
 

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -217,16 +217,17 @@ export const plugins = [
   if (isWindows && (nitro.options.externals?.trace === false) && nitro.options.dev) {
     buildDir = pathToFileURL(buildDir).href
   }
+  const aliases = {
+    '#internal/nitro/virtual/error-handler': nitro.options.errorHandler,
+    '~': nitro.options.srcDir,
+    '@/': nitro.options.srcDir,
+    '~~': nitro.options.rootDir,
+    '@@/': nitro.options.rootDir,
+    ...env.alias
+  }
+  aliases['#build'] = aliases['#build'] || buildDir
   rollupConfig.plugins.push(alias({
-    entries: resolveAliases({
-      '#internal/nitro/virtual/error-handler': nitro.options.errorHandler,
-      '~': nitro.options.srcDir,
-      '@/': nitro.options.srcDir,
-      '~~': nitro.options.rootDir,
-      '@@/': nitro.options.rootDir,
-      ...env.alias,
-      '#build': buildDir
-    })
+    entries: resolveAliases(aliases)
   }))
 
   // Externals Plugin


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/issues/5013

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- x ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In some cases, such as the linked issue (which we could resolve by adding an alias to a stub file in the case of `ssr: false`), it is helpful to be able to override individual `#build/some-file.js` aliases, and to do this we need `#build` to be defined last in the object.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

