### PR TITLE
fix: call `rollup:before` before generating rollup config

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -35,8 +35,8 @@ export async function copyPublicAssets (nitro: Nitro) {
 }
 
 export async function build (nitro: Nitro) {
-  const rollupConfig = getRollupConfig(nitro)
   await nitro.hooks.callHook('rollup:before', nitro)
+  const rollupConfig = getRollupConfig(nitro)
   return nitro.options.dev ? _watch(nitro, rollupConfig) : _build(nitro, rollupConfig)
 }
 


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/nuxt/content/pull/1346#issuecomment-1180431720

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Likely in `rollup:before` users might want to modify nitro options with effect of changing rollup config. For example:

https://github.com/nuxt/framework/blob/f321a56e63be508e5f478b1de5227a5add2b977f/packages/nuxt/src/core/nitro.ts#L124-L134

This makes that possible.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

