### PR TITLE
fix(config): enable dotenv in development

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -91,6 +91,7 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
     name: 'nitro',
     defaults: NitroDefaults,
     cwd: userConfig.rootDir,
+    dotenv: userConfig.dev,
     resolve (id: string) {
       type PT = Map<String, NitroConfig>
       let matchedPreset = (PRESETS as any as PT)[id] || (PRESETS as any as PT)[camelCase(id)]


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #246

### 🔗 Linked discussion

Closes #238 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This enables `dotenv` setup feature from `c12` in development (`nitro dev` only), making `.env` files working out of the box.

