### PR TITLE
fix: autoImport exclude `.nuxt`

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -14,7 +14,7 @@ import { visualizer } from 'rollup-plugin-visualizer'
 import * as unenv from 'unenv'
 import type { Preset } from 'unenv'
 import { sanitizeFilePath } from 'mlly'
-import unimportPlugin from 'unimport/unplugin'
+import unimportPlugin, { defaultExcludes } from 'unimport/unplugin'
 import { hash } from 'ohash'
 import type { Nitro } from '../types'
 import { resolveAliases } from '../utils'
@@ -122,6 +122,7 @@ export const getRollupConfig = (nitro: Nitro) => {
   }
 
   if (nitro.options.autoImport) {
+    nitro.options.autoImport.exclude = defaultExcludes.concat(/[\\/]\.nuxt[\\/]/)
     rollupConfig.plugins.push(unimportPlugin.rollup(nitro.options.autoImport))
   }
 


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
It has caused nuxt3 to take a very long time to build since I upgraded from rc4 to rc6
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

