### PR TITLE
fix(worker): preserve esmodule symbol for dynamic imports

### DIFF
--- a/src/presets/base-worker.ts
+++ b/src/presets/base-worker.ts
@@ -9,7 +9,7 @@ export const baseWorker = defineNitroPreset({
     output: {
       format: 'iife',
       generatedCode: {
-        symbols: true,
+        symbols: true
       }
     }
   },

--- a/src/presets/base-worker.ts
+++ b/src/presets/base-worker.ts
@@ -7,7 +7,10 @@ export const baseWorker = defineNitroPreset({
   noExternals: true,
   rollupConfig: {
     output: {
-      format: 'iife'
+      format: 'iife',
+      generatedCode: {
+        symbols: true,
+      }
     }
   },
   inlineDynamicImports: true // iffe does not support code-splitting


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

iife inlined all dynamic imports but name tag is not preserved so it is not recognized by vue defineAsyncComponent correctly as an esmodule for all dynamic chunks such as pages / layouts.

Enabling the rollup option fixes the issue.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

https://github.com/nuxt/framework/issues/5996
