### PR TITLE
fix(options): exclude `buildDir` for auto-imports

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -148,9 +148,9 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
   // ]
 
   if (options.autoImport) {
-    options.autoImport.exclude = options.autoImport.exclude || [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/]
+    options.autoImport.exclude = options.autoImport.exclude || []
     if (Array.isArray(options.autoImport.exclude)) {
-      options.autoImport.exclude.push(options.buildDir)
+      options.autoImport.exclude.push(options.buildDir, /[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/)
     }
   }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -147,6 +147,12 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
   //     .map(i => new RegExp(`(^|\\/)${escapeRE(i.split('node_modules/').pop())}(\\/|$)(?!node_modules\\/)`))
   // ]
 
+  if (options.autoImport) {
+    if (Array.isArray(options.autoImport.exclude)) {
+      options.autoImport.exclude.push(options.buildDir)
+    }
+  }
+
   options.baseURL = withLeadingSlash(withTrailingSlash(options.baseURL))
   options.runtimeConfig = defu(options.runtimeConfig, {
     app: {

--- a/src/options.ts
+++ b/src/options.ts
@@ -37,6 +37,7 @@ const NitroDefaults: NitroConfig = {
   serverAssets: [],
   plugins: [],
   autoImport: {
+    exclude: [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/],
     presets: nitroImports
   },
   virtual: {},
@@ -147,11 +148,8 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
   //     .map(i => new RegExp(`(^|\\/)${escapeRE(i.split('node_modules/').pop())}(\\/|$)(?!node_modules\\/)`))
   // ]
 
-  if (options.autoImport) {
-    options.autoImport.exclude = options.autoImport.exclude || []
-    if (Array.isArray(options.autoImport.exclude)) {
-      options.autoImport.exclude.push(options.buildDir, /[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/)
-    }
+  if (options.autoImport && Array.isArray(options.autoImport?.exclude)) {
+    options.autoImport.exclude.push(options.buildDir)
   }
 
   options.baseURL = withLeadingSlash(withTrailingSlash(options.baseURL))

--- a/src/options.ts
+++ b/src/options.ts
@@ -148,7 +148,7 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
   //     .map(i => new RegExp(`(^|\\/)${escapeRE(i.split('node_modules/').pop())}(\\/|$)(?!node_modules\\/)`))
   // ]
 
-  if (options.autoImport && Array.isArray(options.autoImport?.exclude)) {
+  if (options.autoImport && Array.isArray(options.autoImport.exclude)) {
     options.autoImport.exclude.push(options.buildDir)
   }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -148,6 +148,7 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
   // ]
 
   if (options.autoImport) {
+    options.autoImport.exclude = options.autoImport.exclude || [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/]
     if (Array.isArray(options.autoImport.exclude)) {
       options.autoImport.exclude.push(options.buildDir)
     }


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/pull/5981, https://github.com/nuxt/bridge/issues/421

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This disables processing the build output of the previous step from auto-imports. Credit to @cinob for spotting the issue; this just moves the fix up to Nitro if we think that makes sense.

cc: @antfu 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

