### PR TITLE
fix(aws-lambda): return outgoing cookies on response objects

### DIFF
--- a/src/runtime/entries/aws-lambda.ts
+++ b/src/runtime/entries/aws-lambda.ts
@@ -25,7 +25,11 @@ export const handler = async function handler (event: Event, context: Context): 
     body: event.body // TODO: handle event.isBase64Encoded
   })
 
+  const outgoingCookies = r.headers['set-cookie']
+  const cookies = Array.isArray(outgoingCookies) ? outgoingCookies : outgoingCookies?.split(',') || []
+
   return {
+    cookies,
     statusCode: r.status,
     headers: normalizeOutgoingHeaders(r.headers),
     body: r.body.toString()
@@ -37,5 +41,7 @@ function normalizeIncomingHeaders (headers: APIGatewayProxyEventHeaders) {
 }
 
 function normalizeOutgoingHeaders (headers: Record<string, string | string[] | undefined>) {
-  return Object.fromEntries(Object.entries(headers).map(([k, v]) => [k, Array.isArray(v) ? v.join(',') : v!]))
+  return Object.fromEntries(Object.entries(headers)
+    .filter(([key]) => !['set-cookie'].includes(key))
+    .map(([k, v]) => [k, Array.isArray(v) ? v.join(',') : v!]))
 }


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

resolves #245

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR returns an array of cookies to set from aws-lambda preset rather than keeping them on the headers. More info in [AWS docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.v2).

@brtinney - would be grateful if you could confirm this resolves the issue for you.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

