### PR TITLE
fix: include dotfiles in public assets

### DIFF
--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -10,7 +10,7 @@ import { virtual } from './virtual'
 export function publicAssets (nitro: Nitro): Plugin {
   const assets: Record<string, { type: string, etag: string, mtime: string, path: string }> = {}
 
-  const files = globbySync('**/*.*', { cwd: nitro.options.output.publicDir, absolute: false })
+  const files = globbySync('**/*.*', { cwd: nitro.options.output.publicDir, absolute: false, dot: true })
 
   const publicAssetBases = nitro.options.publicAssets
     .filter(dir => !dir.fallthrough && dir.baseURL !== '/')


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/issues/4977

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It's common to need static files served on `.` prefixed paths, e.g. `.well-known`.

Currently we were ignoring them when scanning.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

