### PR TITLE
fix: sort aliases to ensure priority is given to more specific aliases

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -135,7 +135,7 @@ export function readPackageJson (
 export function resolveAliases (_aliases: Record<string, string>) {
   // Sort aliases from specific to general (ie. fs/promises before fs)
   const aliases = Object.fromEntries(Object.entries(_aliases).sort(([a], [b]) =>
-    scoreAlias(b) - scoreAlias(a)
+    (b.split('/').length - a.split('/').length) || (b.length - a.length)
   ))
   // Resolve alias values in relation to each other
   for (const key in aliases) {
@@ -149,9 +149,4 @@ export function resolveAliases (_aliases: Record<string, string>) {
     }
   }
   return aliases
-}
-
-const scoreAlias = (alias: string) => {
-  const segments = alias.split('/')
-  return segments.length + (segments[segments.length - 1].length / 1000)
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -132,7 +132,12 @@ export function readPackageJson (
   }
 }
 
-export function resolveAliases (aliases: Record<string, string>) {
+export function resolveAliases (_aliases: Record<string, string>) {
+  // Sort aliases from specific to general (ie. fs/promises before fs)
+  const aliases = Object.fromEntries(Object.entries(_aliases).sort(([a], [b]) => {
+    return b.split('/').length - a.split('/').length
+  }))
+  // Resolve alias values in relation to each other
   for (const key in aliases) {
     for (const alias in aliases) {
       if (!['~', '@', '#'].includes(alias[0])) { continue }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -134,9 +134,9 @@ export function readPackageJson (
 
 export function resolveAliases (_aliases: Record<string, string>) {
   // Sort aliases from specific to general (ie. fs/promises before fs)
-  const aliases = Object.fromEntries(Object.entries(_aliases).sort(([a], [b]) => {
-    return b.split('/').length - a.split('/').length
-  }))
+  const aliases = Object.fromEntries(Object.entries(_aliases).sort(([a], [b]) =>
+    scoreAlias(b) - scoreAlias(a)
+  ))
   // Resolve alias values in relation to each other
   for (const key in aliases) {
     for (const alias in aliases) {
@@ -149,4 +149,9 @@ export function resolveAliases (_aliases: Record<string, string>) {
     }
   }
   return aliases
+}
+
+const scoreAlias = (alias: string) => {
+  const segments = alias.split('/')
+  return segments.length + (segments[segments.length - 1].length / 1000)
 }


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

resolves https://github.com/unjs/nitro/issues/378, see also https://github.com/unjs/unenv/pull/45

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A couple of issues have come up recently about alias ordering. This PR applies a fix to order aliases by specificity (e.g. number of slashes) meaning we should always have more specific alias in front of general (`fs/promises` in front of `fs`).

The upstream PR to unenv resolves it more specifically within the unenv presets but this is still worth merging here as there are other potential aliases involved.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

