### PR TITLE
feat: add h3 auto imports preset

### DIFF
--- a/src/imports.ts
+++ b/src/imports.ts
@@ -15,29 +15,5 @@ export const nitroImports: Preset[] = [
       'nitroPlugin',
       'defineRenderHandler'
     ]
-  },
-  {
-    from: 'h3',
-    imports: [
-      'defineEventHandler',
-      'defineLazyEventHandler',
-      'eventHandler',
-      'lazyEventHandler',
-      'dynamicEventHandler',
-      'appendHeader',
-      'assertMethod',
-      'createError',
-      'handleCacheHeaders',
-      'isMethod',
-      'sendRedirect',
-      'useCookies',
-      'useCookie',
-      'deleteCookie',
-      'setCookie',
-      'useBody',
-      'useMethod',
-      'useQuery',
-      'useRawBody'
-    ]
   }
 ]

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,10 +3,10 @@ import { loadConfig } from 'c12'
 import { klona } from 'klona/full'
 import { camelCase } from 'scule'
 import { defu } from 'defu'
+import { resolveModuleExportNames, resolvePath as resovleModule } from 'mlly'
 // import escapeRE from 'escape-string-regexp'
 import { withLeadingSlash, withoutTrailingSlash, withTrailingSlash } from 'ufo'
 import { isTest } from 'std-env'
-import { resolvePath as resovleModule } from 'mlly'
 import { resolvePath, detectTarget } from './utils'
 import type { NitroConfig, NitroOptions } from './types'
 import { runtimeDir, pkgDir } from './dirs'
@@ -150,6 +150,15 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
 
   if (options.autoImport && Array.isArray(options.autoImport.exclude)) {
     options.autoImport.exclude.push(options.buildDir)
+  }
+
+  // Add h3 auto imports preset
+  if (options.autoImport) {
+    const h3Exports = await resolveModuleExportNames('h3', { url: import.meta.url })
+    options.autoImport.presets.push({
+      from: 'h3',
+      imports: h3Exports.filter(n => !n.match(/^[A-Z]/) && n !== 'use')
+    })
   }
 
   options.baseURL = withLeadingSlash(withTrailingSlash(options.baseURL))


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Use new `mlly.resolveModuleExportNames` to resolve all available exports from installed h3 package and register them as auto imports.

/cc @antfu Can we add this as a built-in unimport functionality as a preset type for auto resolving a package with filter?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

