### PR TITLE
fix(aws-lambda): add `multiValueQueryStringParameters` to aws preset

### DIFF
--- a/src/runtime/entries/aws-lambda.ts
+++ b/src/runtime/entries/aws-lambda.ts
@@ -8,7 +8,8 @@ type Event = Omit<APIGatewayProxyEvent, 'pathParameters' | 'stageVariables' | 'r
 type Result = Exclude<APIGatewayProxyResult | APIGatewayProxyResultV2, string> & { statusCode: number }
 
 export const handler = async function handler (event: Event, context: Context): Promise<Result> {
-  const url = withQuery((event as APIGatewayProxyEvent).path || (event as APIGatewayProxyEventV2).rawPath, event.queryStringParameters || {})
+  const query = { ...event.queryStringParameters, ...(event as APIGatewayProxyEvent).multiValueQueryStringParameters }
+  const url = withQuery((event as APIGatewayProxyEvent).path || (event as APIGatewayProxyEventV2).rawPath, query)
   const method = (event as APIGatewayProxyEvent).httpMethod || (event as APIGatewayProxyEventV2).requestContext?.http?.method || 'get'
 
   if ('cookies' in event && event.cookies) {
@@ -21,7 +22,7 @@ export const handler = async function handler (event: Event, context: Context): 
     context,
     headers: normalizeIncomingHeaders(event.headers),
     method,
-    query: event.queryStringParameters,
+    query,
     body: event.body // TODO: handle event.isBase64Encoded
   })
 


### PR DESCRIPTION


<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue
resolve #396 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This PR aims to add the `multiValueQueryStringParameters` from APIGatewayProxyEvent. Currently the request only retrieve the queries from the `queryStringParameters`, this don't allow us to have an array of query like `/api?test=foo&test=bar&test=hello` (this return only the last query -> `{ test: 'hello' }`.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

