### PR TITLE
feat(netlify): emit `server.js` to leverage native esm

### DIFF
--- a/src/presets/netlify.ts
+++ b/src/presets/netlify.ts
@@ -33,13 +33,16 @@ export const netlify = defineNitroPreset({
       const serverCJSPath = join(nitro.options.output.serverDir, 'server.js')
       const serverJSCode = `
 let _handler
-exports.handler = async function handler (event, context) {
-  if (!_handler) {
-    _handler = await import('./server.mjs').then(r => r.handler)
+exports.handler = function handler (event, context) {
+  if (_handler) {
+    return _handler(event, context)
   }
-  return _handler(event, context)
+  return import('./server.mjs').then(m => {
+    _handler = m.handler
+    return _handler(event, context)
+  })
 }
-      `.trim()
+`.trim()
       await fsp.writeFile(serverCJSPath, serverJSCode)
     }
   }

--- a/src/presets/netlify.ts
+++ b/src/presets/netlify.ts
@@ -29,6 +29,18 @@ export const netlify = defineNitroPreset({
         contents = currentRedirects + '\n' + contents
       }
       await fsp.writeFile(redirectsPath, contents)
+
+      const serverCJSPath = join(nitro.options.output.serverDir, 'server.js')
+      const serverJSCode = `
+let _handler
+exports.handler = async function handler (event, context) {
+  if (!_handler) {
+    _handler = await import('./server.mjs').then(r => r.handler)
+  }
+  return _handler(event, context)
+}
+      `.trim()
+      await fsp.writeFile(serverCJSPath, serverJSCode)
     }
   }
 })


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Emit `server.js` CJS wrapper for netlify output to avoid needing a rebuilt from netlify and leverage native ESM.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

