### PR TITLE
docs: fix typo in storage docs

### DIFF
--- a/docs/content/1.guide/1.introduction/4.storage.md
+++ b/docs/content/1.guide/1.introduction/4.storage.md
@@ -21,7 +21,7 @@ await useStorage().setItem('cache:foo', { hello: world })
 await useStorage().getItem('cache:foo')
 ```
 
-You can mount other storage drivers through the nuxt config using the `storage` option:
+You can mount other storage drivers through the Nitro config using the `storage` option:
 
 ```js
 // nitro.config.ts


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

On [this page of the docs](https://nitro.unjs.io/guide/introduction/storage) there is a typo confusing nitro config with nuxt config.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

