### PR TITLE
fix: add resolved side-effect for node-fetch-native

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -65,7 +65,11 @@ const NitroDefaults: NitroConfig = {
   },
   unenv: {},
   analyze: false,
-  moduleSideEffects: ['unenv/runtime/polyfill/', 'node-fetch-native/polyfill'],
+  moduleSideEffects: [
+    'unenv/runtime/polyfill/',
+    'node-fetch-native/polyfill',
+    'node-fetch-native/dist/polyfill'
+  ],
   replace: {},
   node: true,
   sourceMap: true,


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

resolves #434

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

moduleSideEffects was getting called both with full path to polyfill (including dist) and without. Without both paths in side effect list, we don't end up including side effects in the prerenderer build

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

