### PR TITLE
fix!: update unenv to 0.6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "source-map-support": "^0.5.21",
     "std-env": "^3.2.1",
     "ufo": "^0.8.5",
-    "unenv": "^0.6.0",
+    "unenv": "^0.6.1",
     "unimport": "^0.6.7",
     "unstorage": "^0.5.6"
   },

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "source-map-support": "^0.5.21",
     "std-env": "^3.2.1",
     "ufo": "^0.8.5",
-    "unenv": "^0.5.4",
+    "unenv": "^0.6.0",
     "unimport": "^0.6.7",
     "unstorage": "^0.5.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
       typescript: ^4.7.4
       ufo: ^0.8.5
       unbuild: ^0.8.9
-      unenv: ^0.6.0
+      unenv: ^0.6.1
       unimport: ^0.6.7
       unstorage: ^0.5.6
       vitepress: ^0.22.4
@@ -140,7 +140,7 @@ importers:
       source-map-support: 0.5.21
       std-env: 3.2.1
       ufo: 0.8.5
-      unenv: 0.6.0
+      unenv: 0.6.1
       unimport: 0.6.7_75tz4fz3hdw34ihj4xz6ux6bmq
       unstorage: 0.5.6
     devDependencies:
@@ -5688,8 +5688,8 @@ packages:
     engines: {node: '>=12.18'}
     dev: true
 
-  /unenv/0.6.0:
-    resolution: {integrity: sha512-oTMXujuTf/d3X+H+N2ZHKHCtmSPw2LY0QLClBk8QfGmpNOKeU0ClIEXpClbRKd8ePzaYI0UoyMKAsrluC6foNQ==}
+  /unenv/0.6.1:
+    resolution: {integrity: sha512-pE1X8fyKB1v66sVCxAUeh3+NwQPd30ZlUEH0rzuxjwj0YbY4AbF0nIOjr0ZR/5cOIRPoVteUXXOz5NrS7IVLcQ==}
     dependencies:
       defu: 6.1.0
       mime: 3.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
       typescript: ^4.7.4
       ufo: ^0.8.5
       unbuild: ^0.8.9
-      unenv: ^0.5.4
+      unenv: ^0.6.0
       unimport: ^0.6.7
       unstorage: ^0.5.6
       vitepress: ^0.22.4
@@ -140,7 +140,7 @@ importers:
       source-map-support: 0.5.21
       std-env: 3.2.1
       ufo: 0.8.5
-      unenv: 0.5.4
+      unenv: 0.6.0
       unimport: 0.6.7_75tz4fz3hdw34ihj4xz6ux6bmq
       unstorage: 0.5.6
     devDependencies:
@@ -5688,8 +5688,8 @@ packages:
     engines: {node: '>=12.18'}
     dev: true
 
-  /unenv/0.5.4:
-    resolution: {integrity: sha512-TsGsA7/kchJSrzGhnSXwm704qI5/yZ8gF1OnGtoHl778AfTYI/jRL6zQeQJn89VeMHZ+o9AvueSPpfrrSpv6Vg==}
+  /unenv/0.6.0:
+    resolution: {integrity: sha512-oTMXujuTf/d3X+H+N2ZHKHCtmSPw2LY0QLClBk8QfGmpNOKeU0ClIEXpClbRKd8ePzaYI0UoyMKAsrluC6foNQ==}
     dependencies:
       defu: 6.1.0
       mime: 3.0.0


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Main breaking change of unenv 0.6.x is that body is returned as is without calling `.toString()` (which was probably pointless for h3 responses that are already stringified. only new condition is BodyInit and Buffer types could happen for presets and we need to handle.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

