### PR TITLE
feat: opt-in option to compress public assets using `gzip` and `br`

### DIFF
--- a/docs/content/3.config/index.md
+++ b/docs/content/3.config/index.md
@@ -79,11 +79,14 @@ Public asset directories to serve in development and bundle in production.
 
 If a `public/` directory is detected, it will be added by default, but you can add more by yourself too!
 
+## `compressPublicAssets`
+
+If enabled, Nitro will generate a precompressed (gzip and brotli) verison of all public assets and prerendered routes
+bigger than 1024 bytes into public directory. Using this option you can support zero overhead asset compression without using a CDN.
+
 ## `serverAssets`
 
 Assets can be accessed in server logic and bundled in production.
-
-
 
 ## `devServer`
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -41,6 +41,7 @@ const NitroDefaults: NitroConfig = {
     presets: nitroImports
   },
   virtual: {},
+  compressPublicAssets: false,
 
   // Dev
   dev: false,

--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -20,9 +20,7 @@ export function publicAssets (nitro: Nitro): Plugin {
         size: number,
         encoding?: string
       }> = {}
-
       const files = await globby('**', { cwd: nitro.options.output.publicDir, absolute: false, dot: true })
-      console.log(files)
       for (const id of files) {
         let type = mime.getType(id) || 'text/plain'
         if (type.startsWith('text')) { type += '; charset=utf-8' }
@@ -41,18 +39,18 @@ export function publicAssets (nitro: Nitro): Plugin {
         }
 
         if (nitro.options.compressPublicAssets) {
-          for (const method of ['gzip', 'br']) {
+          for (const method of ['gz', 'br']) {
             const suffix = '.' + method
             const compressedPath = fullPath + suffix
             const compressedBuff: Buffer = await new Promise((resolve, reject) => {
-              zlib[method === 'gzip' ? 'gzip' : 'brotliCompress'](assetData,
+              zlib[method === 'gz' ? 'gzip' : 'brotliCompress'](assetData,
                 (error, result) => error ? reject(error) : resolve(result)
               )
             })
             await fsp.writeFile(compressedPath, compressedBuff)
             assets[assetId + suffix] = {
               ...assets[assetId],
-              encoding: method,
+              encoding: method === 'gz' ? 'gzip' : 'br',
               size: compressedBuff.length,
               path: assets[assetId].path + suffix
             }

--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -39,18 +39,18 @@ export function publicAssets (nitro: Nitro): Plugin {
         }
 
         if (nitro.options.compressPublicAssets && assetData.length > 1024) {
-          for (const method of ['gz', 'br']) {
-            const suffix = '.' + method
+          for (const encoding of ['gzip', 'br']) {
+            const suffix = '.' + (encoding === 'gzip' ? 'gz' : 'br')
             const compressedPath = fullPath + suffix
             const compressedBuff: Buffer = await new Promise((resolve, reject) => {
-              zlib[method === 'gz' ? 'gzip' : 'brotliCompress'](assetData,
+              zlib[encoding === 'gzip' ? 'gzip' : 'brotliCompress'](assetData,
                 (error, result) => error ? reject(error) : resolve(result)
               )
             })
             await fsp.writeFile(compressedPath, compressedBuff)
             assets[assetId + suffix] = {
               ...assets[assetId],
-              encoding: method === 'gz' ? 'gzip' : 'br',
+              encoding,
               size: compressedBuff.length,
               path: assets[assetId].path + suffix
             }

--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -53,6 +53,7 @@ export function publicAssets (nitro: Nitro): Plugin {
             assets[assetId + suffix] = {
               ...assets[assetId],
               encoding: method,
+              size: compressedBuff.length,
               path: assets[assetId].path + suffix
             }
           }

--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -38,7 +38,7 @@ export function publicAssets (nitro: Nitro): Plugin {
           path: relative(nitro.options.output.serverDir, fullPath)
         }
 
-        if (nitro.options.compressPublicAssets) {
+        if (nitro.options.compressPublicAssets && assetData.length > 1024) {
           for (const method of ['gz', 'br']) {
             const suffix = '.' + method
             const compressedPath = fullPath + suffix

--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -20,7 +20,12 @@ export function publicAssets (nitro: Nitro): Plugin {
         size: number,
         encoding?: string
       }> = {}
-      const files = await globby('**', { cwd: nitro.options.output.publicDir, absolute: false, dot: true })
+      const files = await globby('**', {
+        cwd: nitro.options.output.publicDir,
+        absolute: false,
+        dot: true,
+        ignore: ['*.gz', '*.br']
+      })
       for (const id of files) {
         let type = mime.getType(id) || 'text/plain'
         if (type.startsWith('text')) { type += '; charset=utf-8' }
@@ -38,7 +43,7 @@ export function publicAssets (nitro: Nitro): Plugin {
           path: relative(nitro.options.output.serverDir, fullPath)
         }
 
-        if (nitro.options.compressPublicAssets && assetData.length > 1024) {
+        if (nitro.options.compressPublicAssets && assetData.length > 1024 && !assetId.endsWith('.map')) {
           for (const encoding of ['gzip', 'br']) {
             const suffix = '.' + (encoding === 'gzip' ? 'gz' : 'br')
             const compressedPath = fullPath + suffix

--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -1,40 +1,69 @@
-import { readFileSync, statSync } from 'fs'
+import { promises as fsp } from 'fs'
+import zlib from 'node:zlib'
+import { relative, resolve } from 'pathe'
 import createEtag from 'etag'
 import mime from 'mime'
-import { relative, resolve } from 'pathe'
-import { globbySync } from 'globby'
+import { globby } from 'globby'
 import type { Plugin } from 'rollup'
 import type { Nitro } from '../../types'
 import { virtual } from './virtual'
 
 export function publicAssets (nitro: Nitro): Plugin {
-  const assets: Record<string, { type: string, etag: string, mtime: string, path: string }> = {}
-
-  const files = globbySync('**/*.*', { cwd: nitro.options.output.publicDir, absolute: false, dot: true })
-
-  const publicAssetBases = nitro.options.publicAssets
-    .filter(dir => !dir.fallthrough && dir.baseURL !== '/')
-    .map(dir => dir.baseURL)
-
-  for (const id of files) {
-    // @ts-ignore
-    let type = mime.getType(id) || 'text/plain'
-    if (type.startsWith('text')) { type += '; charset=utf-8' }
-    const fullPath = resolve(nitro.options.output.publicDir, id)
-    const etag = createEtag(readFileSync(fullPath))
-    const stat = statSync(fullPath)
-
-    assets['/' + decodeURIComponent(id)] = {
-      type,
-      etag,
-      mtime: stat.mtime.toJSON(),
-      path: relative(nitro.options.output.serverDir, fullPath)
-    }
-  }
-
   return virtual({
-    '#internal/nitro/virtual/public-assets-data': `export default ${JSON.stringify(assets, null, 2)};`,
-    '#internal/nitro/virtual/public-assets-node': `
+    // #internal/nitro/virtual/public-assets-data
+    '#internal/nitro/virtual/public-assets-data': async () => {
+      const assets: Record<string, {
+        type: string,
+        etag: string,
+        mtime: string,
+        path: string,
+        size: number,
+        encoding?: string
+      }> = {}
+
+      const files = await globby('**', { cwd: nitro.options.output.publicDir, absolute: false, dot: true })
+      console.log(files)
+      for (const id of files) {
+        let type = mime.getType(id) || 'text/plain'
+        if (type.startsWith('text')) { type += '; charset=utf-8' }
+        const fullPath = resolve(nitro.options.output.publicDir, id)
+        const assetData = await fsp.readFile(fullPath)
+        const etag = createEtag(assetData)
+        const stat = await fsp.stat(fullPath)
+
+        const assetId = '/' + decodeURIComponent(id)
+        assets[assetId] = {
+          type,
+          etag,
+          mtime: stat.mtime.toJSON(),
+          size: stat.size,
+          path: relative(nitro.options.output.serverDir, fullPath)
+        }
+
+        if (nitro.options.compressPublicAssets) {
+          for (const method of ['gzip', 'br']) {
+            const suffix = '.' + method
+            const compressedPath = fullPath + suffix
+            const compressedBuff: Buffer = await new Promise((resolve, reject) => {
+              zlib[method === 'gzip' ? 'gzip' : 'brotliCompress'](assetData,
+                (error, result) => error ? reject(error) : resolve(result)
+              )
+            })
+            await fsp.writeFile(compressedPath, compressedBuff)
+            assets[assetId + suffix] = {
+              ...assets[assetId],
+              encoding: method,
+              path: assets[assetId].path + suffix
+            }
+          }
+        }
+      }
+
+      return `export default ${JSON.stringify(assets, null, 2)};`
+    },
+    // #internal/nitro/virtual/public-assets-node
+    '#internal/nitro/virtual/public-assets-node': () => {
+      return `
 import { promises as fsp } from 'fs'
 import { resolve } from 'pathe'
 import { dirname } from 'pathe'
@@ -43,8 +72,15 @@ import assets from '#internal/nitro/virtual/public-assets-data'
 export function readAsset (id) {
   const serverDir = dirname(fileURLToPath(import.meta.url))
   return fsp.readFile(resolve(serverDir, assets[id].path))
-}`,
-    '#internal/nitro/virtual/public-assets': `
+}`
+    },
+    // #internal/nitro/virtual/public-assets
+    '#internal/nitro/virtual/public-assets': () => {
+      const publicAssetBases = nitro.options.publicAssets
+        .filter(dir => !dir.fallthrough && dir.baseURL !== '/')
+        .map(dir => dir.baseURL)
+
+      return `
 import assets from '#internal/nitro/virtual/public-assets-data'
 ${nitro.options.serveStatic ? 'export * from "#internal/nitro/virtual/public-assets-node"' : 'export const readAsset = () => Promise(null)'}
 
@@ -64,5 +100,6 @@ export function getAsset (id) {
   return assets[id]
 }
 `
+    }
   }, nitro.vfs)
 }

--- a/src/runtime/static.ts
+++ b/src/runtime/static.ts
@@ -75,6 +75,10 @@ export default eventHandler(async (event) => {
     event.res.setHeader('Content-Encoding', asset.encoding)
   }
 
+  if (asset.size) {
+    event.res.setHeader('Content-Length', asset.size)
+  }
+
   // TODO: Asset dir cache control
   // if (isBuildAsset) {
   // const TWO_DAYS = 2 * 60 * 60 * 24

--- a/src/runtime/static.ts
+++ b/src/runtime/static.ts
@@ -4,6 +4,8 @@ import { getAsset, readAsset, isPublicAssetURL } from '#internal/nitro/virtual/p
 
 const METHODS = ['HEAD', 'GET']
 
+const EncodingMap = { gzip: '.gz', br: '.br' }
+
 export default eventHandler(async (event) => {
   if (event.req.method && !METHODS.includes(event.req.method)) {
     return
@@ -14,9 +16,8 @@ export default eventHandler(async (event) => {
 
   const encodingHeader = String(event.req.headers['accept-encoding'] || '')
   const encodings = encodingHeader.split(',')
-    .map(x => x.trim())
-    .filter(enc => enc === 'br' || enc === 'gzip')
-    .map(enc => '.' + enc)
+    .map(e => EncodingMap[e.trim()])
+    .filter(Boolean)
     .concat([''])
   if (encodings.length > 1) {
     event.res.setHeader('Vary', 'Accept-Encoding')

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -134,6 +134,7 @@ export interface NitroOptions {
   imports: UnimportPluginOptions | false
   plugins: string[]
   virtual: Record<string, string | (() => string | Promise<string>)>
+  compressPublicAssets: boolean
 
   // Dev
   dev: boolean

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -1,6 +1,7 @@
 import { defineNitroConfig } from '../../src'
 
 export default defineNitroConfig({
+  compressPublicAssets: true,
   imports: {
     presets: [
       {


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

#69

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR enables public (and pre-rendered) assets compression with opt-in flag `compressPublicAssets`.

When this flag is enabled, after copying all public assets and prerendering, public asset plugin creates compressed version of assets using gzip (`.gz`) and brotli (`.br`).

In runtime, the static asset handler checks the incoming request's `accept-encoding` header and if the browser supporting it, tries to search for the compressed assets in the manifest.

Because this feature does compression on build time, it works universally for all presets as long as they allow responding binary data and has zero overhead on runtime performance.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

