### PR TITLE
feat: allow specifying wasm plugin options

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -3,6 +3,7 @@ import { dirname, join, normalize, relative, resolve } from 'pathe'
 import type { InputOptions, OutputOptions } from 'rollup'
 import { defu } from 'defu'
 import { terser } from 'rollup-plugin-terser'
+import type { RollupWasmOptions } from '@rollup/plugin-wasm'
 import commonjs from '@rollup/plugin-commonjs'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import alias from '@rollup/plugin-alias'
@@ -130,7 +131,7 @@ export const getRollupConfig = (nitro: Nitro) => {
 
   // WASM import support
   if (nitro.options.experimental.wasm) {
-    const options = { ...nitro.options.experimental.wasm as any }
+    const options = { ...nitro.options.experimental.wasm as RollupWasmOptions }
     rollupConfig.plugins.push(wasmPlugin(options))
   }
 

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -130,7 +130,7 @@ export const getRollupConfig = (nitro: Nitro) => {
 
   // WASM import support
   if (nitro.options.experimental.wasm) {
-    const options = typeof nitro.options.experimental.wasm === 'object' ? nitro.options.experimental.wasm : {}
+    const options = { ...nitro.options.experimental.wasm }
     rollupConfig.plugins.push(wasmPlugin(options))
   }
 

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -130,7 +130,8 @@ export const getRollupConfig = (nitro: Nitro) => {
 
   // WASM import support
   if (nitro.options.experimental.wasm) {
-    rollupConfig.plugins.push(wasmPlugin())
+    const options = typeof nitro.options.experimental.wasm === 'object' ? nitro.options.experimental.wasm : {}
+    rollupConfig.plugins.push(wasmPlugin(options))
   }
 
   // Build-time environment variables

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -130,7 +130,7 @@ export const getRollupConfig = (nitro: Nitro) => {
 
   // WASM import support
   if (nitro.options.experimental.wasm) {
-    const options = { ...nitro.options.experimental.wasm }
+    const options = { ...nitro.options.experimental.wasm as any }
     rollupConfig.plugins.push(wasmPlugin(options))
   }
 

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -7,6 +7,7 @@ import type { NestedHooks, Hookable } from 'hookable'
 import type { Consola, LogLevel } from 'consola'
 import type { WatchOptions } from 'chokidar'
 import type { RollupCommonJSOptions } from '@rollup/plugin-commonjs'
+import type { RollupWasmOptions } from '@rollup/plugin-wasm'
 import type { Storage, BuiltinDriverName } from 'unstorage'
 import type { NodeExternalsOptions } from '../rollup/plugins/externals'
 import type { RollupConfig } from '../rollup/config'
@@ -123,7 +124,7 @@ export interface NitroOptions {
   renderer: string
   serveStatic: boolean
   experimental?: {
-    wasm?: boolean
+    wasm?: boolean | RollupWasmOptions
   }
   serverAssets: ServerAssetDir[]
   publicAssets: PublicAssetDir[]


### PR DESCRIPTION
I'm using nitro in Nuxt 3 and I found that the default options only work when the WASM file is smaller than the default inlining-threshold. Otherwise the Nuxt3 NodeJS server environment (and other server targets I'd imagine) chokes on the wasm plugin using `require()`calls (how dare them use `require` in NodeJS! :D). And even if that would be fixed upstream in the `@rollup/plugin-wasm` package, it's still nice to be able to change the default options here.