### PR TITLE
feat: expanded devServer's versatility

### DIFF
--- a/src/dev/server.ts
+++ b/src/dev/server.ts
@@ -67,7 +67,7 @@ async function killWorker (worker?: NitroWorker) {
   }
 }
 
-export function createDevServer (nitro: Nitro): NitroDevServer {
+export function createDevServer (nitro: Nitro, app: App = createApp()): NitroDevServer {
   // Worker
   const workerEntry = resolve(nitro.options.output.dir, nitro.options.output.serverDir, 'index.mjs')
 
@@ -98,9 +98,6 @@ export function createDevServer (nitro: Nitro): NitroDevServer {
     return reloadPromise
   })
   nitro.hooks.hook('dev:reload', reload)
-
-  // App
-  const app = createApp()
 
   // Dev-only handlers
   for (const handler of nitro.options.devHandlers) {


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

This change suggests moving the `createDevServer`'s `app` initialization to a function parameter which defaults to `createApp`. The reason for this is there may be large projects that are structured like:

"Massive express-based app --> build/start Nuxt"

For those massive apps to migrate to Nuxt3, where they may already have their own `app` and `app.use` stuff, they'll probably want to provide Nitro their app instance so that they can app.use the Nitro things, like [publicAssets](https://github.com/unjs/nitro/blob/6bfbb22d569bd6ab6bbb844805d6d8e93b343460/src/dev/server.ts#L115). 

Then, massive projects can simply do: `createDevServer(nitro, app)`, and most Nuxt3 things should work assuming there are no naming conflicts. 
 
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#461 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

