### PR TITLE
feat: improve  public asset compression

### DIFF
--- a/docs/content/3.config/index.md
+++ b/docs/content/3.config/index.md
@@ -81,8 +81,10 @@ If a `public/` directory is detected, it will be added by default, but you can a
 
 ## `compressPublicAssets`
 
-If enabled, Nitro will generate a precompressed (gzip and brotli) verison of all public assets and prerendered routes
-bigger than 1024 bytes into public directory. Using this option you can support zero overhead asset compression without using a CDN.
+- Default: `{ gzip: false, brotli: false }`
+
+If enabled, Nitro will generate a pre-compressed (gzip and/or brotli) version of supported types of public assets and prerendered routes
+larger than 1024 bytes into the public directory. The best compression level is used. Using this option you can support zero overhead asset compression without using a CDN.
 
 ## `serverAssets`
 

--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -28,7 +28,8 @@ export function publicAssets (nitro: Nitro): Plugin {
       })
       for (const id of files) {
         let type = mime.getType(id) || 'text/plain'
-        if (type.startsWith('text')) { type += '; charset=utf-8' }
+        const isTextType = type.startsWith('text')
+        if (isTextType) { type += '; charset=utf-8' }
         const fullPath = resolve(nitro.options.output.publicDir, id)
         const assetData = await fsp.readFile(fullPath)
         const etag = createEtag(assetData)
@@ -43,15 +44,27 @@ export function publicAssets (nitro: Nitro): Plugin {
           path: relative(nitro.options.output.serverDir, fullPath)
         }
 
-        if (nitro.options.compressPublicAssets && assetData.length > 1024 && !assetId.endsWith('.map')) {
-          for (const encoding of ['gzip', 'br']) {
+        if (!!nitro.options.compressPublicAssets && assetData.length > 1024 && !assetId.endsWith('.map') && isTypeCompressible(type)) {
+          let encodings = []
+          if (typeof nitro.options.compressPublicAssets === 'boolean') {
+            encodings = ['gzip', 'br']
+          } else {
+            const { gzip, brotli } = nitro.options.compressPublicAssets
+            if (gzip) { encodings.push('gzip') }
+            if (brotli) { encodings.push('br') }
+          }
+          for (const encoding of encodings) {
             const suffix = '.' + (encoding === 'gzip' ? 'gz' : 'br')
             const compressedPath = fullPath + suffix
-            const compressedBuff: Buffer = await new Promise((resolve, reject) => {
-              zlib[encoding === 'gzip' ? 'gzip' : 'brotliCompress'](assetData,
-                (error, result) => error ? reject(error) : resolve(result)
-              )
-            })
+            const compressedBuff = (encoding === 'gzip')
+              ? zlib.gzipSync(assetData, { level: zlib.constants.Z_BEST_COMPRESSION })
+              : zlib.brotliCompressSync(assetData, {
+                [zlib.constants.BROTLI_PARAM_MODE]: isTextType
+                  ? zlib.constants.BROTLI_MODE_TEXT
+                  : zlib.constants.BROTLI_MODE_GENERIC,
+                [zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY,
+                [zlib.constants.BROTLI_PARAM_SIZE_HINT]: assetData.length
+              })
             await fsp.writeFile(compressedPath, compressedBuff)
             assets[assetId + suffix] = {
               ...assets[assetId],
@@ -106,4 +119,33 @@ export function getAsset (id) {
 `
     }
   }, nitro.vfs)
+}
+
+const isTypeCompressible = (type: string): boolean => {
+  return [
+    'application/javascript',
+    'application/json',
+    'application/manifest+json',
+    'application/rss+xml',
+    'application/vnd.ms-fontobject',
+    'application/x-font-opentype',
+    'application/x-font-truetype',
+    'application/x-font-ttf',
+    'application/x-javascript',
+    'application/xml',
+    'application/xhtml+xml',
+    'font/eot',
+    'font/opentype',
+    'font/otf',
+    'font/truetype',
+    'image/svg+xml',
+    'image/vnd.microsoft.icon',
+    'image/x-icon',
+    'image/x-win-bitmap',
+    'text/css',
+    'text/javascript',
+    'text/plain',
+    'text/xml',
+    'text/x-component'
+  ].includes(type)
 }

--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -57,9 +57,12 @@ export function publicAssets (nitro: Nitro): Plugin {
               [zlib.constants.BROTLI_PARAM_SIZE_HINT]: assetData.length
             }
             const compressedBuff: Buffer = await new Promise((resolve, reject) => {
-              (encoding === 'gzip')
-                ? zlib.gzip(assetData, gzipOptions, (error, result) => error ? reject(error) : resolve(result))
-                : zlib.brotliCompress(assetData, brotliOptions, (error, result) => error ? reject(error) : resolve(result))
+              const cb = (error, result: Buffer) => error ? reject(error) : resolve(result)
+              if (encoding === 'gzip') {
+                zlib.gzip(assetData, gzipOptions, cb)
+              } else {
+                zlib.brotliCompress(assetData, brotliOptions, cb)
+              }
             })
             await fsp.writeFile(compressedPath, compressedBuff)
             assets[assetId + suffix] = {

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -88,8 +88,8 @@ export interface DevServerOptions {
 }
 
 export interface CompressOptions {
-  gzip: boolean
-  brotli: boolean
+  gzip?: boolean
+  brotli?: boolean
 }
 
 export interface NitroOptions {

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -87,6 +87,11 @@ export interface DevServerOptions {
   watch: string[]
 }
 
+export interface CompressOptions {
+  gzip: boolean
+  brotli: boolean
+}
+
 export interface NitroOptions {
   // Internal
   _config: NitroConfig
@@ -135,7 +140,7 @@ export interface NitroOptions {
   imports: UnimportPluginOptions | false
   plugins: string[]
   virtual: Record<string, string | (() => string | Promise<string>)>
-  compressPublicAssets: boolean
+  compressPublicAssets: boolean | CompressOptions
 
   // Dev
   dev: boolean


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR allows specifying the compression algorithm in the `compressPublicAssets` option.

All public assets are no longer compressed, but only selected types are. Since some file types are already internally compressed and double compression is just a waste of time and energy.

The compression level has also been set to maximum quality, which makes compressed files smaller in size and therefore faster to download.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

