### PR TITLE
fix: strip query parameters from commonjs included externals

### DIFF
--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -140,7 +140,7 @@ export function externals (opts: NodeExternalsOptions): Plugin {
       for (const pkgName of opts.traceInclude || []) {
         const path = await this.resolve(pkgName)
         if (path?.id) {
-          trackedExternals.add(path.id)
+          trackedExternals.add(path.id.replace(/\?.+/, ''))
         }
       }
 


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://stackblitz.com/edit/github-c92aq5

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When adding a cjs dependency via `traceInclude` it will have a `?commonjs-entry` query appended, which can't be resolved by vercel/nft. This strips this kind of query from force-included assets.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

