### PR TITLE
feat: add `workspaceDir` and use it for presets auto generated dir

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -7,6 +7,7 @@ import { resolveModuleExportNames, resolvePath as resovleModule } from 'mlly'
 // import escapeRE from 'escape-string-regexp'
 import { withLeadingSlash, withoutTrailingSlash, withTrailingSlash } from 'ufo'
 import { isTest } from 'std-env'
+import { findWorkspaceDir } from 'pkg-types'
 import { resolvePath, detectTarget } from './utils'
 import type { NitroConfig, NitroOptions } from './types'
 import { runtimeDir, pkgDir } from './dirs'
@@ -123,6 +124,7 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
   options.preset = preset
 
   options.rootDir = resolve(options.rootDir || '.')
+  options.workspaceDir = await findWorkspaceDir(options.rootDir)
   options.srcDir = resolve(options.srcDir || options.rootDir)
   for (const key of ['srcDir', 'publicDir', 'buildDir']) {
     options[key] = resolve(options.rootDir, options[key])
@@ -146,6 +148,7 @@ export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroO
   options.output.publicDir = resolvePath(options.output.publicDir, options)
   options.output.serverDir = resolvePath(options.output.serverDir, options)
 
+  options.nodeModulesDirs.push(resolve(options.workspaceDir, 'node_modules'))
   options.nodeModulesDirs.push(resolve(options.rootDir, 'node_modules'))
   options.nodeModulesDirs.push(resolve(pkgDir, 'node_modules'))
   options.nodeModulesDirs = Array.from(new Set(options.nodeModulesDirs))

--- a/src/presets/netlify.ts
+++ b/src/presets/netlify.ts
@@ -7,8 +7,8 @@ import type { Nitro } from '../types'
 export const netlify = defineNitroPreset({
   extends: 'aws-lambda',
   output: {
-    dir: '{{ rootDir }}/.netlify/functions-internal',
-    publicDir: '{{ rootDir }}/dist'
+    dir: '{{ workspaceDir }}/.netlify/functions-internal',
+    publicDir: '{{ workspaceDir }}/dist'
   },
   rollupConfig: {
     output: {
@@ -59,8 +59,8 @@ export const netlifyEdge = defineNitroPreset({
   extends: 'base-worker',
   entry: '#internal/nitro/entries/netlify-edge',
   output: {
-    serverDir: '{{ rootDir }}/.netlify/edge-functions',
-    publicDir: '{{ rootDir }}/dist'
+    serverDir: '{{ workspaceDir }}/.netlify/edge-functions',
+    publicDir: '{{ workspaceDir }}/dist'
   },
   rollupConfig: {
     output: {

--- a/src/presets/stormkit.ts
+++ b/src/presets/stormkit.ts
@@ -3,6 +3,6 @@ import { defineNitroPreset } from '../preset'
 export const stormkit = defineNitroPreset({
   entry: '#internal/nitro/entries/stormkit',
   output: {
-    dir: '{{ rootDir }}/.stormkit'
+    dir: '{{ workspaceDir }}/.stormkit'
   }
 })

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -9,7 +9,7 @@ export const vercel = defineNitroPreset({
   extends: 'node',
   entry: '#internal/nitro/entries/vercel',
   output: {
-    dir: '{{ rootDir }}/.vercel/output',
+    dir: '{{ workspaceDir }}/.vercel/output',
     serverDir: '{{ output.dir }}/functions/index.func',
     publicDir: '{{ output.dir }}/static'
   },
@@ -60,7 +60,7 @@ export const vercelEdge = defineNitroPreset({
   extends: 'base-worker',
   entry: '#internal/nitro/entries/vercel-edge',
   output: {
-    dir: '{{ rootDir }}/.vercel/output',
+    dir: '{{ workspaceDir }}/.vercel/output',
     serverDir: '{{ output.dir }}/functions/index.func',
     publicDir: '{{ output.dir }}/static'
   },

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -111,6 +111,7 @@ export interface NitroOptions {
   }
 
   // Dirs
+  workspaceDir: string
   rootDir: string
   srcDir: string
   scanDirs: string[]


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

resolves #149

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is an initial implementation of `workspaceDir` and migrating presets that have 'magic folders' (vercel, netlify + stormkit) to use this.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

