### PR TITLE
fix(node-server): default production host to `localhost`

### DIFF
--- a/docs/content/2.deploy/1.node.md
+++ b/docs/content/2.deploy/1.node.md
@@ -34,7 +34,7 @@ You can now deploy fully standalone `.output` directory to the hosting of your c
 You can customize server behavior using following environment variables:
 
 - `NITRO_PORT` or `PORT` (defaults to `3000`)
-- `NITRO_HOST` or `HOST` (defaults to `'0.0.0.0'`)
+- `NITRO_HOST` or `HOST` (defaults to `'localhost'`)
 - `NITRO_SSL_CERT` and `NITRO_SSL_KEY` - if both are present, this will launch the server in HTTPS mode. In the vast majority of cases, this should not be used other than for testing, and the Nitro server should be run behind a reverse proxy like nginx or Cloudflare which terminates SSL.
 
 ## Cluster mode

--- a/src/runtime/entries/node-server.ts
+++ b/src/runtime/entries/node-server.ts
@@ -11,7 +11,7 @@ const key = process.env.NITRO_SSL_KEY
 const server = cert && key ? new HttpsServer({ key, cert }, nitroApp.h3App.nodeHandler) : new HttpServer(nitroApp.h3App.nodeHandler)
 
 const port = (destr(process.env.NITRO_PORT || process.env.PORT) || 3000) as number
-const hostname = process.env.NITRO_HOST || process.env.HOST || '0.0.0.0'
+const hostname = process.env.NITRO_HOST || process.env.HOST || 'localhost'
 
 // @ts-ignore
 server.listen(port, hostname, (err) => {


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Since the host address is hard coded to `0.0.0.0` (IPv4), it is not possible to connect using `[::1]` (IPv6). Setting `localhost` will allow connection via both IPv4 and IPv6.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

