### PR TITLE
docs: latest Cloudflare Worker changes

### DIFF
--- a/docs/content/2.deploy/providers/cloudflare.md
+++ b/docs/content/2.deploy/providers/cloudflare.md
@@ -23,11 +23,11 @@ account_id = "<the account_id you obtained>"
 workers_dev = true
 route = ""
 zone_id = ""
-compatibility_date = "2022-04-07"
+compatibility_date = "2022-09-10"
+main=".output/server/index.mjs"
 
 [site]
 bucket = ".output/public"
-entry-point = ".output"
 
 [build]
 command = ""


### PR DESCRIPTION
Hi,
I tried setting up a Nuxt 3 + Nitro SSR over cloudflare workers and realized cloudflare workers .toml configuration have changed since this documentation was prepared.
e.g. https://github.com/gouthamrangarajan/cloudflare-workers/tree/main/nuxt-nitro-101
