### PR TITLE
fix: use node-resolve's `modulePaths`

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -281,7 +281,7 @@ export const plugins = [
     extensions,
     preferBuiltins: !!nitro.options.node,
     rootDir: nitro.options.rootDir,
-    moduleDirectories: ['node_modules'].concat(nitro.options.nodeModulesDirs),
+    modulePaths: nitro.options.nodeModulesDirs,
     // 'module' is intentionally not supported because of externals
     mainFields: ['main'],
     exportConditions: [


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/issues/7453

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

regression from https://github.com/unjs/nitro/pull/489
see https://github.com/rollup/plugins/blob/master/packages/node-resolve/CHANGELOG.md#v1410

There's been a config schema change in `@rollup/node-resolve`. This PR passes resolved directories to the correct location. `moduleDirectories` defaults to `['node_modules']` so can be omitted.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

