### PR TITLE
fix: use `rootDir` for providers output instead of `workspaceDir`

### DIFF
--- a/src/presets/netlify.ts
+++ b/src/presets/netlify.ts
@@ -7,8 +7,8 @@ import type { Nitro } from '../types'
 export const netlify = defineNitroPreset({
   extends: 'aws-lambda',
   output: {
-    dir: '{{ workspaceDir }}/.netlify/functions-internal',
-    publicDir: '{{ workspaceDir }}/dist'
+    dir: '{{ rootDir }}/.netlify/functions-internal',
+    publicDir: '{{ rootDir }}/dist'
   },
   rollupConfig: {
     output: {
@@ -59,8 +59,8 @@ export const netlifyEdge = defineNitroPreset({
   extends: 'base-worker',
   entry: '#internal/nitro/entries/netlify-edge',
   output: {
-    serverDir: '{{ workspaceDir }}/.netlify/edge-functions',
-    publicDir: '{{ workspaceDir }}/dist'
+    serverDir: '{{ rootDir }}/.netlify/edge-functions',
+    publicDir: '{{ rootDir }}/dist'
   },
   rollupConfig: {
     output: {

--- a/src/presets/stormkit.ts
+++ b/src/presets/stormkit.ts
@@ -3,6 +3,6 @@ import { defineNitroPreset } from '../preset'
 export const stormkit = defineNitroPreset({
   entry: '#internal/nitro/entries/stormkit',
   output: {
-    dir: '{{ workspaceDir }}/.stormkit'
+    dir: '{{ rootDir }}/.stormkit'
   }
 })

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -9,7 +9,7 @@ export const vercel = defineNitroPreset({
   extends: 'node',
   entry: '#internal/nitro/entries/vercel',
   output: {
-    dir: '{{ workspaceDir }}/.vercel/output',
+    dir: '{{ rootDir }}/.vercel/output',
     serverDir: '{{ output.dir }}/functions/index.func',
     publicDir: '{{ output.dir }}/static'
   },

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -60,7 +60,7 @@ export const vercelEdge = defineNitroPreset({
   extends: 'base-worker',
   entry: '#internal/nitro/entries/vercel-edge',
   output: {
-    dir: '{{ workspaceDir }}/.vercel/output',
+    dir: '{{ rootDir }}/.vercel/output',
     serverDir: '{{ output.dir }}/functions/index.func',
     publicDir: '{{ output.dir }}/static'
   },


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/issues/7410

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Confirmed with Vercel team - we need to output vercel build output in _project_ root directory.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

