### PR TITLE
fix: properly serve `/index.html` static asset

### DIFF
--- a/src/runtime/static.ts
+++ b/src/runtime/static.ts
@@ -1,5 +1,5 @@
 import { eventHandler, createError } from 'h3'
-import { withoutTrailingSlash, withLeadingSlash, parseURL } from 'ufo'
+import { joinURL, withoutTrailingSlash, withLeadingSlash, parseURL } from 'ufo'
 import { getAsset, readAsset, isPublicAssetURL } from '#internal/nitro/virtual/public-assets'
 
 const METHODS = ['HEAD', 'GET']
@@ -24,7 +24,7 @@ export default eventHandler(async (event) => {
   }
 
   for (const encoding of encodings) {
-    for (const _id of [id + encoding, id + '/index.html' + encoding]) {
+    for (const _id of [id + encoding, joinURL(id, 'index.html' + encoding)]) {
       const _asset = getAsset(_id)
       if (_asset) {
         asset = _asset


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

#7467

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`/` can't be served via assets because it becomes `//index.html`, meaning we were totally skipping static `/` routes. In fact, we probably want to use `joinURL` so that the trailing slash status is not taken into account when joining with `index.html`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

