### PR TITLE
fix: use the prerendering preset even if NITRO_PRESET is present

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -89,6 +89,9 @@ const NitroDefaults: NitroConfig = {
 export async function loadOptions (userConfig: NitroConfig = {}): Promise<NitroOptions> {
   // Detect preset
   let preset = process.env.NITRO_PRESET || userConfig.preset || detectTarget() || 'node-server'
+  if (userConfig.preset === "nitro-prerender") {
+    preset = "nitro-prerender"
+  }
   if (userConfig.dev) {
     preset = 'nitro-dev'
   }


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If one explicitly changes the preset using the `NITRO_PRESET` variable, then prerendering does no longer work since the nitro prerender server then uses the preset specified in that variable instead of the correct `nitro-prerender` preset.
This is a result of the changes in https://github.com/unjs/nitro/commit/92d711fe936fda0ff877c23d8a0d73ed4ea4adc4

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

