### PR TITLE
fix(prerender): prevent double slash when joining url to `index.html`

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -1,6 +1,6 @@
 import { pathToFileURL } from 'url'
 import { resolve, join } from 'pathe'
-import { parseURL, withBase, withoutBase } from 'ufo'
+import { joinURL, parseURL, withBase, withoutBase } from 'ufo'
 import chalk from 'chalk'
 import { createNitro } from './nitro'
 import { build } from './build'
@@ -79,7 +79,7 @@ export async function prerender (nitro: Nitro) {
     // Write to the file
     const isImplicitHTML = !route.endsWith('.html') && (res.headers.get('content-type') || '').includes('html')
     const routeWithIndex = route.endsWith('/') ? route + 'index' : route
-    _route.fileName = isImplicitHTML ? route + '/index.html' : routeWithIndex
+    _route.fileName = isImplicitHTML ? joinURL(route, 'index.html') : routeWithIndex
     _route.fileName = withoutBase(_route.fileName, nitro.options.baseURL)
 
     await nitro.hooks.callHook('prerender:generate', _route, nitro)


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Otherwise we get `//index.html` as the fileName.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

