### PR TITLE
fix(vercel, azure): serve prerendered routes statically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ Temporary Items
 .env
 .netlify
 .vercel
+staticwebapp.config.json

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -21,7 +21,7 @@ export async function prerender (nitro: Nitro) {
   }
   // Build with prerender preset
   nitro.logger.info('Initializing prerenderer')
-  nitro._routeFiles = []
+  nitro._prerenderedRoutes = []
   const nitroRenderer = await createNitro({
     ...nitro.options._config,
     rootDir: nitro.options.rootDir,
@@ -90,7 +90,7 @@ export async function prerender (nitro: Nitro) {
 
     const filePath = join(nitro.options.output.publicDir, _route.fileName)
     await writeFile(filePath, Buffer.from(_route.data))
-    nitro._routeFiles.push({ route, fileName: _route.fileName })
+    nitro._prerenderedRoutes.push(_route)
 
     // Crawl route links
     if (!_route.error && isImplicitHTML) {

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -21,6 +21,7 @@ export async function prerender (nitro: Nitro) {
   }
   // Build with prerender preset
   nitro.logger.info('Initializing prerenderer')
+  nitro._routeFiles = []
   const nitroRenderer = await createNitro({
     ...nitro.options._config,
     rootDir: nitro.options.rootDir,
@@ -89,6 +90,7 @@ export async function prerender (nitro: Nitro) {
 
     const filePath = join(nitro.options.output.publicDir, _route.fileName)
     await writeFile(filePath, Buffer.from(_route.data))
+    nitro._routeFiles.push({ route, fileName: _route.fileName })
 
     // Crawl route links
     if (!_route.error && isImplicitHTML) {

--- a/src/presets/azure.ts
+++ b/src/presets/azure.ts
@@ -47,7 +47,7 @@ async function writeRoutes (nitro: Nitro) {
     }
   }
 
-  const routeFiles = nitro._routeFiles || []
+  const routeFiles = nitro._prerenderedRoutes || []
 
   const indexFileExists = routeFiles.some(route => route.fileName === '/index.html')
   if (!indexFileExists) {

--- a/src/presets/azure.ts
+++ b/src/presets/azure.ts
@@ -106,11 +106,11 @@ async function writeRoutes (nitro: Nitro) {
     ]
   }
 
-  await writeFile(resolve(nitro.options.output.serverDir, 'function.json'), JSON.stringify(functionDefinition))
-  await writeFile(resolve(nitro.options.output.serverDir, '../host.json'), JSON.stringify(host))
+  await writeFile(resolve(nitro.options.output.serverDir, 'function.json'), JSON.stringify(functionDefinition, null, 2))
+  await writeFile(resolve(nitro.options.output.serverDir, '../host.json'), JSON.stringify(host, null, 2))
   const stubPackageJson = resolve(nitro.options.output.serverDir, '../package.json')
   await writeFile(stubPackageJson, JSON.stringify({ private: true }))
-  await writeFile(resolve(nitro.options.rootDir, 'staticwebapp.config.json'), JSON.stringify(config))
+  await writeFile(resolve(nitro.options.rootDir, 'staticwebapp.config.json'), JSON.stringify(config, null, 2))
   if (!indexFileExists) {
     await writeFile(resolve(nitro.options.output.publicDir, 'index.html'), '')
   }

--- a/src/presets/azure.ts
+++ b/src/presets/azure.ts
@@ -48,7 +48,7 @@ async function writeRoutes (nitro: Nitro) {
   }
 
   const routeFiles = nitro._routeFiles || []
-  console.log({ routeFiles })
+
   const indexFileExists = routeFiles.some(route => route.fileName === '/index.html')
   if (!indexFileExists) {
     config.routes.unshift(

--- a/src/presets/azure.ts
+++ b/src/presets/azure.ts
@@ -1,5 +1,4 @@
 import fse from 'fs-extra'
-import { globby } from 'globby'
 import { join, resolve } from 'pathe'
 import { writeFile } from '../utils'
 import { defineNitroPreset } from '../preset'
@@ -20,7 +19,7 @@ export const azure = defineNitroPreset({
   }
 })
 
-async function writeRoutes (nitro) {
+async function writeRoutes (nitro: Nitro) {
   const host = {
     version: '2.0'
   }
@@ -48,8 +47,9 @@ async function writeRoutes (nitro) {
     }
   }
 
-  const indexPath = resolve(nitro.options.output.publicDir, 'index.html')
-  const indexFileExists = fse.existsSync(indexPath)
+  const routeFiles = nitro._routeFiles || []
+  console.log({ routeFiles })
+  const indexFileExists = routeFiles.some(route => route.fileName === '/index.html')
   if (!indexFileExists) {
     config.routes.unshift(
       {
@@ -63,36 +63,29 @@ async function writeRoutes (nitro) {
     )
   }
 
-  const folderFiles = await globby([
-    join(nitro.options.output.publicDir, 'index.html'),
-    join(nitro.options.output.publicDir, '**/index.html')
-  ])
-  const prefix = nitro.options.output.publicDir.length
   const suffix = '/index.html'.length
-  folderFiles.forEach(file =>
-    config.routes.unshift({
-      route: file.slice(prefix, -suffix) || '/',
-      rewrite: file.slice(prefix)
-    })
-  )
+  for (const { fileName } of routeFiles) {
+    if (!fileName.endsWith('/index.html')) { continue }
 
-  const otherFiles = await globby([join(nitro.options.output.publicDir, '**/*.html'), join(nitro.options.output.publicDir, '*.html')])
-  otherFiles.forEach((file) => {
-    if (file.endsWith('index.html')) {
-      return
-    }
-    const route = file.slice(prefix, -'.html'.length)
+    config.routes.unshift({
+      route: fileName.slice(0, -suffix) || '/',
+      rewrite: fileName
+    })
+  }
+
+  for (const { fileName } of routeFiles) {
+    if (!fileName.endsWith('.html') || fileName.endsWith('index.html')) { continue }
+
+    const route = fileName.slice(0, -'.html'.length)
     const existingRouteIndex = config.routes.findIndex(_route => _route.route === route)
     if (existingRouteIndex > -1) {
       config.routes.splice(existingRouteIndex, 1)
     }
-    config.routes.unshift(
-      {
-        route,
-        rewrite: file.slice(prefix)
-      }
-    )
-  })
+    config.routes.unshift({
+      route,
+      rewrite: fileName
+    })
+  }
 
   const functionDefinition = {
     entryPoint: 'handle',
@@ -119,6 +112,6 @@ async function writeRoutes (nitro) {
   await writeFile(stubPackageJson, JSON.stringify({ private: true }))
   await writeFile(resolve(nitro.options.rootDir, 'staticwebapp.config.json'), JSON.stringify(config))
   if (!indexFileExists) {
-    await writeFile(indexPath, '')
+    await writeFile(resolve(nitro.options.output.publicDir, 'index.html'), '')
   }
 }

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -11,7 +11,7 @@ export const vercel = defineNitroPreset({
   entry: '#internal/nitro/entries/vercel',
   output: {
     dir: '{{ rootDir }}/.vercel/output',
-    serverDir: '{{ output.dir }}/functions/__nuxt.func',
+    serverDir: '{{ output.dir }}/functions/__nitro.func',
     publicDir: '{{ output.dir }}/static'
   },
   commands: {
@@ -47,7 +47,7 @@ export const vercelEdge = defineNitroPreset({
   entry: '#internal/nitro/entries/vercel-edge',
   output: {
     dir: '{{ rootDir }}/.vercel/output',
-    serverDir: '{{ output.dir }}/functions/__nuxt.func',
+    serverDir: '{{ output.dir }}/functions/__nitro.func',
     publicDir: '{{ output.dir }}/static'
   },
   commands: {
@@ -107,7 +107,7 @@ function generateBuildConfig (nitro: Nitro) {
       },
       {
         src: '/(.*)',
-        dest: '/__nuxt'
+        dest: '/__nitro'
       }
     ],
     overrides: generateOverrides(Array.from((nitro as any)._routes as Set<string>))

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -70,17 +70,16 @@ export const vercelEdge = defineNitroPreset({
   }
 })
 
-function generateOverrides (routeFiles: Array<{ route: string, fileName: string }>) {
-  return Object.fromEntries(
-    routeFiles.map(({ route, fileName }) => [withoutLeadingSlash(fileName), { path: withoutLeadingSlash(route) }])
-  )
-}
-
 function generateBuildConfig (nitro: Nitro) {
-  const overrides = generateOverrides(nitro._routeFiles?.filter(r => r.fileName !== r.route) || [])
+  // const overrides = generateOverrides(nitro._prerenderedRoutes?.filter(r => r.fileName !== r.route) || [])
   return defu(nitro.options.vercel?.config, {
     version: 3,
-    overrides,
+    overrides: Object.fromEntries(
+      (nitro._prerenderedRoutes?.filter(r => r.fileName !== r.route) || [])
+        .map(({ route, fileName }) =>
+          [withoutLeadingSlash(fileName), { path: withoutLeadingSlash(route) }]
+        )
+    ),
     routes: [
       ...nitro.options.publicAssets
         .filter(asset => !asset.fallthrough)

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -24,6 +24,8 @@ export interface Nitro {
   logger: Consola
   storage: Storage
   close: () => Promise<void>
+  /* @internal */
+  _routeFiles?: Array<{ route: string, fileName: string }>
 }
 
 export interface PrerenderRoute {

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -24,8 +24,9 @@ export interface Nitro {
   logger: Consola
   storage: Storage
   close: () => Promise<void>
+
   /* @internal */
-  _routeFiles?: Array<{ route: string, fileName: string }>
+  _prerenderedRoutes?: PrerenderGenerateRoute[]
 }
 
 export interface PrerenderRoute {

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -7,7 +7,7 @@ import { setupTest, startServer, testNitro } from '../tests'
 describe('nitro:preset:vercel', async () => {
   const ctx = await setupTest('vercel')
   testNitro(ctx, async () => {
-    const handle = await import(resolve(ctx.outDir, 'functions/index.func/index.mjs'))
+    const handle = await import(resolve(ctx.outDir, 'functions/__nuxt.func/index.mjs'))
       .then(r => r.default || r)
     await startServer(ctx, handle)
     return async ({ url }) => {
@@ -21,7 +21,7 @@ describe.skip('nitro:preset:vercel-edge', async () => {
   const ctx = await setupTest('vercel-edge')
   testNitro(ctx, async () => {
     // TODO: Add add-event-listener
-    const entry = resolve(ctx.outDir, 'functions/index.func/index.mjs')
+    const entry = resolve(ctx.outDir, 'functions/__nuxt.func/index.mjs')
     const entryCode = await fsp.readFile(entry, 'utf8')
     const runtime = new EdgeRuntime({ initialCode: entryCode })
     return async ({ url }) => {

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -7,7 +7,7 @@ import { setupTest, startServer, testNitro } from '../tests'
 describe('nitro:preset:vercel', async () => {
   const ctx = await setupTest('vercel')
   testNitro(ctx, async () => {
-    const handle = await import(resolve(ctx.outDir, 'functions/__nuxt.func/index.mjs'))
+    const handle = await import(resolve(ctx.outDir, 'functions/__nitro.func/index.mjs'))
       .then(r => r.default || r)
     await startServer(ctx, handle)
     return async ({ url }) => {
@@ -21,7 +21,7 @@ describe.skip('nitro:preset:vercel-edge', async () => {
   const ctx = await setupTest('vercel-edge')
   testNitro(ctx, async () => {
     // TODO: Add add-event-listener
-    const entry = resolve(ctx.outDir, 'functions/__nuxt.func/index.mjs')
+    const entry = resolve(ctx.outDir, 'functions/__nitro.func/index.mjs')
     const entryCode = await fsp.readFile(entry, 'utf8')
     const runtime = new EdgeRuntime({ initialCode: entryCode })
     return async ({ url }) => {


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Current hybrid vercel deployments will always server-render prerendered HTML (though you can get the static html by adding `/index.html` to the URL). Vercel provides the `overrides` property to allow us to map clean URLs (without `.html` or `index.html` suffix) to static files: https://vercel.com/docs/build-output-api/v3#build-output-configuration/supported-properties/overrides. This PR implements that.

Might also be worth a consistent implementation of accessing which HTML files have been prerendered. (See [this line](https://github.com/unjs/nitropack/blob/ba39ffe9d5fe9516825ccbafd55c18211c78a424/src/presets/azure.ts#L66-L69) for how we were doing it in Azure - I could easily create a shared context that both presets could use - happy to pick this up.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

