### PR TITLE
fix(vercel): always strip leading slash

### DIFF
--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -73,12 +73,12 @@ export const vercelEdge = defineNitroPreset({
 
 function generateBuildConfig (nitro: Nitro) {
   // const overrides = generateOverrides(nitro._prerenderedRoutes?.filter(r => r.fileName !== r.route) || [])
-  return defu(nitro.options.vercel?.config, <VercelBuildConfigV3>{
+  return defu(nitro.options.vercel?.config, <VercelBuildConfigV3> {
     version: 3,
     overrides: Object.fromEntries(
       (nitro._prerenderedRoutes?.filter(r => r.fileName !== r.route) || [])
         .map(({ route, fileName }) =>
-          [withoutLeadingSlash(fileName), { path: withoutLeadingSlash(route) }]
+          [withoutLeadingSlash(fileName), { path: route.replace(/^\//, '') }]
         )
     ),
     routes: [


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Vercel needs an empty string as an output for the index; my mistake, I swapped `withoutLeadingSlash` instead of the previous regexp.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

