### PR TITLE
fix(types): add `create` method to `$Fetch` interface

### DIFF
--- a/src/types/fetch.ts
+++ b/src/types/fetch.ts
@@ -22,6 +22,7 @@ export type TypedInternalResponse<Route, Default = unknown> =
 export interface $Fetch<DefaultT = unknown, DefaultR extends NitroFetchRequest = NitroFetchRequest> {
   <T = DefaultT, R extends NitroFetchRequest = DefaultR> (request: R, opts?: FetchOptions): Promise<TypedInternalResponse<R, T>>
   raw<T = DefaultT, R extends NitroFetchRequest = DefaultR> (request: R, opts?: FetchOptions): Promise<FetchResponse<TypedInternalResponse<R, T>>>
+  create(defaults: FetchOptions): $Fetch
 }
 
 declare global {

--- a/src/types/fetch.ts
+++ b/src/types/fetch.ts
@@ -22,7 +22,7 @@ export type TypedInternalResponse<Route, Default = unknown> =
 export interface $Fetch<DefaultT = unknown, DefaultR extends NitroFetchRequest = NitroFetchRequest> {
   <T = DefaultT, R extends NitroFetchRequest = DefaultR> (request: R, opts?: FetchOptions): Promise<TypedInternalResponse<R, T>>
   raw<T = DefaultT, R extends NitroFetchRequest = DefaultR> (request: R, opts?: FetchOptions): Promise<FetchResponse<TypedInternalResponse<R, T>>>
-  create(defaults: FetchOptions): $Fetch
+  create<T = DefaultT, R extends NitroFetchRequest = DefaultR> (defaults: FetchOptions): $Fetch<T, R>
 }
 
 declare global {


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
Not good English, sorry
I used $fetch.create when using $fetch of NuxT3, VScode threw me an error. After checking the error, I found that create was not defined in the type, so I added a create attribute to $fetch
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

