### PR TITLE
fix(externals): avoid overriding packages with version conflict

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -155,7 +155,7 @@ export async function loadOptions (configOverrides: NitroConfig = {}): Promise<N
   options.nodeModulesDirs.push(resolve(options.workspaceDir, 'node_modules'))
   options.nodeModulesDirs.push(resolve(options.rootDir, 'node_modules'))
   options.nodeModulesDirs.push(resolve(pkgDir, 'node_modules'))
-  options.nodeModulesDirs = Array.from(new Set(options.nodeModulesDirs))
+  options.nodeModulesDirs = Array.from(new Set(options.nodeModulesDirs.map(dir => resolve(options.rootDir, dir))))
 
   if (!options.scanDirs.length) {
     options.scanDirs = [options.srcDir]

--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -196,11 +196,7 @@ export function externals (opts: NodeExternalsOptions): Plugin {
           }
 
           // Exclude older version files
-          if (isNewer) {
-            ignoreDirs.push(existingPkgDir)
-          } else {
-            ignoreDirs.push(pkgDir)
-          }
+          ignoreDirs.push(isNewer ? existingPkgDir : pkgDir)
         } else {
           // Add to traced packages
           tracedPackages.set(pkgName, pkgDir)

--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -174,10 +174,10 @@ export function externals (opts: NodeExternalsOptions): Plugin {
         if (existingPkgDir && existingPkgDir !== pkgDir) {
           const v1 = await getPackageJson(existingPkgDir).then(r => r.version)
           const v2 = await getPackageJson(pkgDir).then(r => r.version)
-          if (semver.gte(v1, v2)) {
-            // Existing record is newer or same. Just skip.
-            continue
-          }
+          // if (semver.gte(v1, v2)) {
+          // Existing record is newer or same. Just skip.
+          // continue
+          // }
           if (semver.major(v1) !== semver.major(v2)) {
             console.warn(`Multiple major versions of package ${pkgName} are being externalized. Picking latest version.\n` + [
               existingPkgDir + '@' + v1,

--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -173,7 +173,7 @@ export function externals (opts: NodeExternalsOptions): Plugin {
         if (!pkgName) {
           continue
         }
-        const pkgDir = resolve(baseDir, pkgName)
+        let pkgDir = resolve(baseDir, pkgName)
 
         // Check for duplicate versions
         const existingPkgDir = tracedPackages.get(pkgName)
@@ -196,11 +196,16 @@ export function externals (opts: NodeExternalsOptions): Plugin {
           }
 
           // Exclude older version files
-          ignoreDirs.push(isNewer ? existingPkgDir : pkgDir)
-        } else {
-          // Add to traced packages
-          tracedPackages.set(pkgName, pkgDir)
+          if (isNewer) {
+            ignoreDirs.push(existingPkgDir)
+          } else {
+            ignoreDirs.push(pkgDir)
+            pkgDir = existingPkgDir // Update for tracedPackages
+          }
         }
+
+        // Add to traced packages
+        tracedPackages.set(pkgName, pkgDir)
       }
 
       // Filter out files from ignored packages and dedup

--- a/test/fixture/_/.gitignore
+++ b/test/fixture/_/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/test/fixture/_/node_modules/nitro-dep-a/index.mjs
+++ b/test/fixture/_/node_modules/nitro-dep-a/index.mjs
@@ -1,0 +1,1 @@
+export { default } from 'nitro-lib'

--- a/test/fixture/_/node_modules/nitro-dep-a/node_modules/nitro-lib/index.mjs
+++ b/test/fixture/_/node_modules/nitro-dep-a/node_modules/nitro-lib/index.mjs
@@ -1,0 +1,1 @@
+export default '1.0.0';

--- a/test/fixture/_/node_modules/nitro-dep-a/node_modules/nitro-lib/package.json
+++ b/test/fixture/_/node_modules/nitro-dep-a/node_modules/nitro-lib/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "nitro-lib",
+  "version": "1.0.0",
+  "exports": "./index.mjs"
+}

--- a/test/fixture/_/node_modules/nitro-dep-a/package.json
+++ b/test/fixture/_/node_modules/nitro-dep-a/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "nitro-dep-a",
+  "version": "1.0.0",
+  "exports": "./index.mjs",
+  "dependencies": {
+    "nitro-lib": "1.0.0"
+  }
+}

--- a/test/fixture/_/node_modules/nitro-dep-b/index.mjs
+++ b/test/fixture/_/node_modules/nitro-dep-b/index.mjs
@@ -1,0 +1,1 @@
+export { default } from 'nitro-lib'

--- a/test/fixture/_/node_modules/nitro-dep-b/node_modules/nitro-lib/index.mjs
+++ b/test/fixture/_/node_modules/nitro-dep-b/node_modules/nitro-lib/index.mjs
@@ -1,0 +1,1 @@
+export default '2.0.0';

--- a/test/fixture/_/node_modules/nitro-dep-b/node_modules/nitro-lib/package.json
+++ b/test/fixture/_/node_modules/nitro-dep-b/node_modules/nitro-lib/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "nitro-lib",
+  "version": "2.0.0",
+  "exports": "./index.mjs"
+}

--- a/test/fixture/_/node_modules/nitro-dep-b/package.json
+++ b/test/fixture/_/node_modules/nitro-dep-b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "nitro-dep-b",
+  "version": "1.0.0",
+  "exports": "./index.mjs",
+  "dependencies": {
+    "nitro-lib": "2.0.0"
+  }
+}

--- a/test/fixture/_/node_modules/nitro-lib/index.mjs
+++ b/test/fixture/_/node_modules/nitro-lib/index.mjs
@@ -1,0 +1,1 @@
+export default '2.0.1';

--- a/test/fixture/_/node_modules/nitro-lib/package.json
+++ b/test/fixture/_/node_modules/nitro-lib/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "nitro-lib",
+  "version": "2.0.1",
+  "exports": "./index.mjs"
+}

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -21,6 +21,9 @@ export default defineNitroConfig({
       dir: 'public/build'
     }
   ],
+  nodeModulesDirs: [
+    './_/node_modules'
+  ],
   prerender: {
     crawlLinks: true,
     ignore: [

--- a/test/fixture/routes/modules.ts
+++ b/test/fixture/routes/modules.ts
@@ -1,5 +1,8 @@
+// @ts-ignore
 import depA from 'nitro-dep-a'
+// @ts-ignore
 import depB from 'nitro-dep-b'
+// @ts-ignore
 import depLib from 'nitro-lib'
 
 export default defineEventHandler(() => {

--- a/test/fixture/routes/modules.ts
+++ b/test/fixture/routes/modules.ts
@@ -1,0 +1,11 @@
+import depA from 'nitro-dep-a'
+import depB from 'nitro-dep-b'
+import depLib from 'nitro-lib'
+
+export default defineEventHandler(() => {
+  return {
+    depA,
+    depB,
+    depLib
+  }
+})

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -15,6 +15,7 @@ describe('API routes', () => {
       | string | number | TestResponse
       | { testFile: string, hasEnv: boolean }
       | { internalApiKey: string }
+      | { [key: string]: any }
       >>() // middleware
     expectTypeOf($fetch('/api/unknown')).toMatchTypeOf<Promise<unknown>>()
     expectTypeOf($fetch<TestResponse>('/test')).toMatchTypeOf<Promise<TestResponse>>()

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -134,5 +134,10 @@ export function testNitro (ctx: Context, getHandler: () => TestHandler | Promise
       const { status } = await callHandler({ url: '/build/non-file' })
       expect(status).toBe(404)
     })
+
+    it('resolve module version conflicts', async () => {
+      const { data } = await callHandler({ url: '/modules' })
+      expect(data).toMatchObject({ depA: '2.0.1', depB: '2.0.1', depLib: '2.0.1' })
+    })
   }
 }


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

resolves #503
resolves #456
resolves #161

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


Changes for externals handling (node targets):

- Resolve symlinks of traced files to properly dedup for pnpm
- Also show warning for major version changes with leading zero (0.1.0 => 0.2.0 and 0.0.1 => 0.0.2)
- Improve warning formatting and show it once
- Fix: **ignore entire directory of older version packages**
- Revert back windows fix for (#424) as we are now for sure writing files once.
- resolve `nodeModulesDirs` relative to rootDir
- Add tests


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

