### PR TITLE
fix: add missing name and version fields to `.output/package.json`

### DIFF
--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -216,6 +216,8 @@ export function externals (opts: NodeExternalsOptions): Plugin {
 
       // Write an informative package.json
       await fsp.writeFile(resolve(opts.outDir, 'package.json'), JSON.stringify({
+        name: 'nitro-output',
+        version: '0.0.0',
         private: true,
         bundledDependencies: Array.from(tracedPackages.keys())
       }, null, 2), 'utf8')


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://github.com/unjs/nitro/issues/508

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
This change adds a `name` and `version` field to the generated package.json for the `aws-lambda` preset.

<!-- Why is this change required? What problem does it solve? -->
When building and deploying code with AWS SAM, there's a validation step running on the package.json file, which requires `name` and `version` to be set.

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Resolves #508 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

Let me know if this requires a documentation update (I don't think so)

