### PR TITLE
fix: retry writing traced files if there are conflicts

### DIFF
--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -5,7 +5,7 @@ import { nodeFileTrace, NodeFileTraceOptions } from '@vercel/nft'
 import type { Plugin } from 'rollup'
 import { resolvePath, isValidNodeImport, normalizeid } from 'mlly'
 import semver from 'semver'
-import { isDirectory } from '../../utils'
+import { isDirectory, retry } from '../../utils'
 
 export interface NodeExternalsOptions {
   inline?: string[]
@@ -263,16 +263,4 @@ async function isFile (file: string) {
     if (err.code === 'ENOENT') { return false }
     throw err
   }
-}
-
-async function retry (fn: () => Promise<void>, retries: number) {
-  let retry = 0
-  let error: any
-  while (retry++ < retries) {
-    try { return await fn() } catch (err) {
-      error = err
-      await new Promise(resolve => setTimeout(resolve, 2))
-    }
-  }
-  throw error
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -146,3 +146,15 @@ export function resolveAliases (_aliases: Record<string, string>) {
   }
   return aliases
 }
+
+export async function retry (fn: () => Promise<void>, retries: number) {
+  let retry = 0
+  let error: any
+  while (retry++ < retries) {
+    try { return await fn() } catch (err) {
+      error = err
+      await new Promise(resolve => setTimeout(resolve, 2))
+    }
+  }
+  throw error
+}

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { retry } from '../../src/utils'
+
+describe('retry', () => {
+  it('retries function', async () => {
+    let counter = 0
+    // eslint-disable-next-line require-await
+    const fn = async () => {
+      if (!counter++) {
+        throw new Error('deliberate')
+      }
+    }
+
+    await retry(fn, 3)
+    expect(counter).toEqual(2)
+  })
+  it('throws function', async () => {
+    // eslint-disable-next-line require-await
+    const fn = async () => { throw new Error('deliberate') }
+    expect(await retry(fn, 2).catch(() => 'thrown')).toEqual('thrown')
+  })
+})


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

resolves #536

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It seems that when multiple traced files in the same directory are copied on windows, in some circumstances, we have a race condition which causes a 'resource busy or locked' error. It's possible this is very much an edge case, such as when testing. But this change seems safe; it adds a small 2ms timeout and will retry a file up to 3 times, which will hopefully reduce any flakiness. I've [confirmed](https://github.com/nuxt/framework/pull/7927) (with `yarn patch`) that it does resolve the issue in framework repo.

(Another option would be synchronous file copying.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

