### PR TITLE
fix: fully resolve internal paths for autoimports

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -1,5 +1,6 @@
 import { promises as fsp } from 'fs'
 import { relative, resolve, join, dirname, isAbsolute } from 'pathe'
+import { resolveAlias } from 'pathe/utils'
 import * as rollup from 'rollup'
 import fse from 'fs-extra'
 import { defu } from 'defu'
@@ -66,7 +67,15 @@ export async function writeTypes (nitro: Nitro) {
   if (nitro.unimport) {
     autoImportedTypes = [
       nitro.unimport
-        .generateTypeDeclarations({ exportHelper: false })
+        .generateTypeDeclarations({
+          exportHelper: false,
+          resolvePath: (i) => {
+            if (i.from.startsWith('#internal/nitro')) {
+              return resolveAlias(i.from, nitro.options.alias)
+            }
+            return i.from
+          }
+        })
         .trim()
     ]
   }


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, generated auto-imports are relative to `#internal/nitro` which means they have no type safety unless `typescript.internalPaths` is set. This PR resolves them so we don't need to expose access to `#internal/nitro`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

