### PR TITLE
docs: fix link to cloudflare-pages preset

### DIFF
--- a/docs/content/2.deploy/0.index.md
+++ b/docs/content/2.deploy/0.index.md
@@ -17,7 +17,7 @@ When running Nitro in development mode, Nitro will always use a special preset c
 When deploying to the production using CI/CD, Nitro tries to automatically detect the provider environment and set the right one without any additional configuration. Currently, providers below can be auto-detected with zero config.
 
 - [azure](/deploy/providers/azure)
-- [cloudflare_pages](/deploy/providers/cloudflare_pages)
+- [cloudflare_pages](/deploy/providers/cloudflare#cloudflare-pages)
 - [netlify](/deploy/providers/netlify)
 - [stormkit](/deploy/providers/stormkit)
 - [vercel](/deploy/providers/vercel)


### PR DESCRIPTION
Stumbled over a broken link to the cloudflare-pages preset - attached PR fixes that.