### PR TITLE
feat: normalize route options and shortcuts

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -183,6 +183,19 @@ export async function loadOptions (configOverrides: NitroConfig = {}): Promise<N
     })
   }
 
+  // Normalize route rules
+  for (const rule of Object.values(options.routes)) {
+    if (rule.cors) {
+      rule.headers = {
+        ...rule.headers,
+        'access-control-allow-origin': '*',
+        'access-control-allowed-methods': '*',
+        'access-control-allow-headers': '*',
+        'access-control-max-age': '0'
+      }
+    }
+  }
+
   options.baseURL = withLeadingSlash(withTrailingSlash(options.baseURL))
   options.runtimeConfig = defu(options.runtimeConfig, {
     app: {

--- a/src/options.ts
+++ b/src/options.ts
@@ -194,6 +194,7 @@ export async function loadOptions (configOverrides: NitroConfig = {}): Promise<N
     // Redirect
     if (routeConfig.redirect) {
       routeOptions.redirect = {
+        to: '/',
         statusCode: 307,
         ...(typeof routeConfig.redirect === 'string' ? { to: routeConfig.redirect } : routeConfig.redirect)
       }

--- a/src/options.ts
+++ b/src/options.ts
@@ -187,11 +187,11 @@ export async function loadOptions (configOverrides: NitroConfig = {}): Promise<N
   for (const rule of Object.values(options.routes)) {
     if (rule.cors) {
       rule.headers = {
-        ...rule.headers,
         'access-control-allow-origin': '*',
         'access-control-allowed-methods': '*',
         'access-control-allow-headers': '*',
-        'access-control-max-age': '0'
+        'access-control-max-age': '0',
+        ...rule.headers
       }
     }
   }

--- a/src/presets/netlify.ts
+++ b/src/presets/netlify.ts
@@ -112,17 +112,7 @@ async function writeHeaders (nitro: Nitro) {
   for (const [key, value] of Object.entries(nitro.options.routes).filter(([_, value]) => value.cors || value.headers)) {
     const headers = [
       key.replace('/**', '/*'),
-      ...Object.entries({
-        ...value.cors
-          ? {
-              'access-control-allow-origin': '*',
-              'access-control-allowed-methods': '*',
-              'access-control-allow-headers': '*',
-              'access-control-max-age': '0'
-            }
-          : {},
-        ...value.headers || {}
-      }).map(([header, value]) => `  ${header}: ${value}`)
+      ...Object.entries({ ...value.headers }).map(([header, value]) => `  ${header}: ${value}`)
     ].join('\n')
 
     contents += headers + '\n'

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -93,16 +93,6 @@ function generateBuildConfig (nitro: Nitro) {
             headers: { Location: redirect.to }
           })
         }
-        if (value.cors) {
-          route = defu(route, {
-            headers: {
-              'access-control-allow-origin': '*',
-              'access-control-allowed-methods': '*',
-              'access-control-allow-headers': '*',
-              'access-control-max-age': '0'
-            }
-          })
-        }
         if (value.headers) {
           route = defu(route, {
             headers: value.headers

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -82,24 +82,23 @@ function generateBuildConfig (nitro: Nitro) {
         )
     ),
     routes: [
-      ...Object.entries(nitro.options.routes).filter(([_, value]) => value.redirect || value.headers || value.cors).map(([key, value]) => {
-        let route = {
-          src: key.replace('/**', '/.*')
-        }
-        if (value.redirect) {
-          const redirect = typeof value.redirect === 'string' ? { to: value.redirect } : value.redirect
-          route = defu(route, {
-            status: redirect.statusCode || 307,
-            headers: { Location: redirect.to }
-          })
-        }
-        if (value.headers) {
-          route = defu(route, {
-            headers: value.headers
-          })
-        }
-        return route
-      }),
+      ...Object.entries(nitro.options.routes)
+        .filter(([_, routeOptions]) => routeOptions.redirect || routeOptions.headers)
+        .map(([path, routeOptions]) => {
+          let route = {
+            src: path.replace('/**', '/.*')
+          }
+          if (routeOptions.redirect) {
+            route = defu(route, {
+              status: routeOptions.redirect.statusCode,
+              headers: { Location: routeOptions.redirect.to }
+            })
+          }
+          if (routeOptions.headers) {
+            route = defu(route, { headers: routeOptions.headers })
+          }
+          return route
+        }),
       ...nitro.options.publicAssets
         .filter(asset => !asset.fallthrough)
         .map(asset => asset.baseURL)

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -41,9 +41,10 @@ function createNitroApp (): NitroApp {
 
     // Wrap matching handlers for caching route options
     const routeOptions = getRouteOptionsForPath(h.route.replace(/:\w+|\*\*/g, '_'))
-    if (routeOptions.swr) {
+    if (routeOptions.cache) {
       handler = cachedEventHandler(handler, {
-        group: 'nitro/routes'
+        group: 'nitro/routes',
+        ...routeOptions.cache
       })
     }
 

--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -18,6 +18,7 @@ export interface CacheOptions<T = any> {
   group?: string;
   integrity?: any;
   maxAge?: number;
+  static?: boolean; // TODO
   swr?: boolean;
   staleMaxAge?: number;
   base?: string;

--- a/src/runtime/route-options.ts
+++ b/src/runtime/route-options.ts
@@ -1,7 +1,8 @@
 import { eventHandler, H3Event, sendRedirect, setHeaders } from 'h3'
+import defu from 'defu'
 import { createRouter as createRadixRouter, toRouteMatcher } from 'radix3'
-import { NitroRouteOptions } from '../types'
 import { useRuntimeConfig } from './config'
+import type { NitroRouteOptions } from 'nitropack'
 
 const config = useRuntimeConfig()
 const _routeOptionsMatcher = toRouteMatcher(createRadixRouter({ routes: config.nitro.routes }))
@@ -16,15 +17,13 @@ export function createRouteOptionsHandler () {
     }
     // Apply redirect options
     if (routeOptions.redirect) {
-      if (typeof routeOptions.redirect === 'string') {
-        routeOptions.redirect = { to: routeOptions.redirect }
-      }
-      return sendRedirect(event, routeOptions.redirect.to, routeOptions.redirect.statusCode || 307)
+      // @ts-ignore
+      return sendRedirect(event, routeOptions.redirect.to, routeOptions.redirect.statusCode)
     }
   })
 }
 
-export function getRouteOptions (event: H3Event) {
+export function getRouteOptions (event: H3Event): NitroRouteOptions {
   event.context._nitro = event.context._nitro || {}
   if (!event.context._nitro.routeOptions) {
     const path = new URL(event.req.url, 'http://localhost').pathname
@@ -33,10 +32,6 @@ export function getRouteOptions (event: H3Event) {
   return event.context._nitro.routeOptions
 }
 
-export function getRouteOptionsForPath (path: string) {
-  const routeOptions: NitroRouteOptions = {}
-  for (const rule of _routeOptionsMatcher.matchAll(path)) {
-    Object.assign(routeOptions, rule)
-  }
-  return routeOptions
+export function getRouteOptionsForPath (path: string): NitroRouteOptions {
+  return defu({}, ..._routeOptionsMatcher.matchAll(path).reverse())
 }

--- a/src/runtime/route-options.ts
+++ b/src/runtime/route-options.ts
@@ -17,7 +17,6 @@ export function createRouteOptionsHandler () {
     }
     // Apply redirect options
     if (routeOptions.redirect) {
-      // @ts-ignore
       return sendRedirect(event, routeOptions.redirect.to, routeOptions.redirect.statusCode)
     }
   })

--- a/src/runtime/route-options.ts
+++ b/src/runtime/route-options.ts
@@ -10,17 +10,6 @@ export function createRouteOptionsHandler () {
   return eventHandler((event) => {
     // Match route options against path
     const routeOptions = getRouteOptions(event)
-
-    // Apply CORS options
-    if (routeOptions.cors) {
-      setHeaders(event, {
-        'access-control-allow-origin': '*',
-        'access-control-allowed-methods': '*',
-        'access-control-allow-headers': '*',
-        'access-control-max-age': '0'
-      })
-    }
-
     // Apply headers options
     if (routeOptions.headers) {
       setHeaders(event, routeOptions.headers)

--- a/test/presets/netlify.test.ts
+++ b/test/presets/netlify.test.ts
@@ -33,10 +33,10 @@ describe('nitro:preset:netlify', async () => {
     const redirects = await fsp.readFile(resolve(ctx.rootDir, 'dist/_redirects'), 'utf-8')
     /* eslint-disable no-tabs */
     expect(redirects).toMatchInlineSnapshot(`
-      "/rules/nested/override	/other	301
-      /rules/nested/*	/base	301
-      /rules/redirect/obj	https://nitro.unjs.io/	308
-      /rules/redirect	/base	301
+      "/rules/nested/override	/other	302
+      /rules/nested/*	/base	302
+      /rules/redirect/obj	https://nitro.unjs.io/	301
+      /rules/redirect	/base	302
       /rules/static	/.netlify/builders/server 200
       /* /.netlify/functions/server 200"
     `)

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -51,7 +51,7 @@ describe('nitro:preset:vercel', async () => {
             "headers": {
               "access-control-allow-headers": "*",
               "access-control-allow-origin": "*",
-              "access-control-allowed-methods": "*",
+              "access-control-allowed-methods": "GET",
               "access-control-max-age": "0",
             },
             "src": "/rules/cors",


### PR DESCRIPTION
Context: #538

By normalizing route options, we can support more shortcuts and also avoid duplicate logic per vendor for native support.

This PR normalizes 3 shortcuts:
- cors => converted to headers
- swr / static => converted to (new) cache options (rework of #443)
- [redirect is normalized]

Also fixes some issues with netlify and vercel generated rules