### PR TITLE
fix(azure): raw body no longer returns parsed json

### DIFF
--- a/src/runtime/entries/azure-functions.ts
+++ b/src/runtime/entries/azure-functions.ts
@@ -8,6 +8,7 @@ export async function handle (context, req) {
     url,
     headers: req.headers,
     method: req.method,
+    // https://github.com/Azure/azure-functions-host/issues/293
     body: req.rawBody
   })
 

--- a/src/runtime/entries/azure-functions.ts
+++ b/src/runtime/entries/azure-functions.ts
@@ -8,7 +8,7 @@ export async function handle (context, req) {
     url,
     headers: req.headers,
     method: req.method,
-    body: req.body
+    body: req.rawBody
   })
 
   context.res = {

--- a/src/runtime/entries/azure.ts
+++ b/src/runtime/entries/azure.ts
@@ -18,6 +18,7 @@ export async function handle (context, req) {
     url,
     headers: req.headers,
     method: req.method,
+    // https://github.com/Azure/azure-functions-host/issues/293
     body: req.rawBody
   })
 

--- a/src/runtime/entries/azure.ts
+++ b/src/runtime/entries/azure.ts
@@ -18,7 +18,7 @@ export async function handle (context, req) {
     url,
     headers: req.headers,
     method: req.method,
-    body: req.body
+    body: req.rawBody
   })
 
   context.res = {


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
None

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Azure functions with `httpTrigger` automatically JSON-parse the body. This is not explicitly mentioned in the docs (at least I couldn't find it), but in one of [the examples](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger?tabs=in-process%2Cfunctionsv2&pivots=programming-language-javascript#example) they use `req.body.name` showing that `req.body` is indeed an object. This then leads to problems when used with h3's `useRawBody` method, which actually returns the object instead of the stringy body when deployed to azure.

This is fixed by using `req.rawBody` in the azure handler. It's hard to find documentation on this property, but `rawBody` is used in an official test file:
https://github.com/Azure/azure-functions-host/blob/71ecbb2c303214f96d7e17310681fd717180bdbb/test/WebJobs.Script.Tests.Integration/TestScripts/Node/HttpTrigger/index.js#L13

Example `console.log(req)` in the handler:
```
....
[api] [2022-10-16T13:33:53.998Z]   body: {
[api] [2022-10-16T13:33:53.998Z]     query: 'query MeE2ENotLoggedIn {\n  me {\n    id\n  }\n}',
[api] [2022-10-16T13:33:53.998Z]     operationName: 'MeE2ENotLoggedIn'
[api] [2022-10-16T13:33:53.998Z]   },
[api] [2022-10-16T13:33:53.998Z]   rawBody: '{"query":"query MeE2ENotLoggedIn {\\n  me {\\n    id\\n  }\\n}","operationName":"MeE2ENotLoggedIn"}'
....
```

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

