### PR TITLE
fix: default `workspaceDir` to `rootDir`

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -129,7 +129,7 @@ export async function loadOptions (configOverrides: NitroConfig = {}): Promise<N
   options.preset = presetOverride || layers.find(l => l.config.preset)?.config.preset || defaultPreset
 
   options.rootDir = resolve(options.rootDir || '.')
-  options.workspaceDir = await findWorkspaceDir(options.rootDir)
+  options.workspaceDir = await findWorkspaceDir(options.rootDir).catch(() => options.rootDir)
   options.srcDir = resolve(options.srcDir || options.rootDir)
   for (const key of ['srcDir', 'publicDir', 'buildDir']) {
     options[key] = resolve(options.rootDir, options[key])


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

resolves https://github.com/unjs/nitro/issues/551

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If we can't resolve workspaceDir, we should fallback to rootDir rather than erroring.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

