### PR TITLE
fix: add production export condition to commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ npx nitropack build
 4️⃣ Output is in the `.output` directory and ready to be deployed on almost any VPS with no dependencies. You can locally try it too:
 
 ```bash
-node .output/server/index.mjs
+node -C production .output/server/index.mjs
 ```
 
 That's it you got it! Read the [documentation](https://nitro.unjs.io) to learn more.

--- a/docs/content/1.guide/1.introduction/0.getting-started.md
+++ b/docs/content/1.guide/1.introduction/0.getting-started.md
@@ -38,7 +38,7 @@ npx nitropack build
 Output is in the `.output` directory and ready to be deployed on almost any VPS with no dependencies. You can locally try it too:
 
 ```bash
-node .output/server/index.mjs
+node -C production .output/server/index.mjs
 ```
 
 You can add `nitropack` using your package manager now:

--- a/docs/content/2.deploy/1.node.md
+++ b/docs/content/2.deploy/1.node.md
@@ -23,7 +23,7 @@ nitro build
 When running `nitro build` with the Node server preset, the result will be an entry point that launches a ready-to-run Node server. To try output:
 
 ```bash
-$ node .output/server/index.mjs
+$ node -C production .output/server/index.mjs
 Listening on http://localhost:3000
 ```
 

--- a/docs/content/2.deploy/providers/heroku.md
+++ b/docs/content/2.deploy/providers/heroku.md
@@ -32,6 +32,6 @@ Nitro supports deploying on [Heroku](https://heroku.com/) with minimal configura
    ```json5
    "scripts": {
      "build": "nitro build", // or `nuxt build` if using nuxt
-     "start": "node .output/server/index.mjs"
+     "start": "node -C production .output/server/index.mjs"
    }
    ```

--- a/docs/content/2.deploy/providers/render.md
+++ b/docs/content/2.deploy/providers/render.md
@@ -15,7 +15,7 @@ Nitro supports deploying on [Render](https://render.com/) with minimal configura
 
 1. Depending on your package manager, set the build command to `yarn && yarn build`, `npm install && npm run build`, or `pnpm i --shamefully-hoist && pnpm build`.
 
-1. Update the start command to `node .output/server/index.mjs`
+1. Update the start command to `node -C production .output/server/index.mjs`
 
 1. Click 'Advanced' and add an environment variable with `NITRO_PRESET` set to `render-com`.
 

--- a/src/presets/node-cli.ts
+++ b/src/presets/node-cli.ts
@@ -4,6 +4,6 @@ export const cli = defineNitroPreset({
   extends: 'node',
   entry: '#internal/nitro/entries/cli',
   commands: {
-    preview: 'Run with node ./server/index.mjs [route]'
+    preview: 'Run with node -C production ./server/index.mjs [route]'
   }
 })

--- a/src/presets/node-server.ts
+++ b/src/presets/node-server.ts
@@ -5,7 +5,7 @@ export const nodeServer = defineNitroPreset({
   entry: '#internal/nitro/entries/node-server',
   serveStatic: true,
   commands: {
-    preview: 'node ./server/index.mjs'
+    preview: 'node -C production ./server/index.mjs'
   }
 })
 


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/framework/issues/8362

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As we trace dependencies via the `production` export condition, if users do not run their node output with that condition, it may cause issues for them. We may add the condition to our documentation and preview commands to prevent these issues (and possibly overall increase performance).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

