### PR TITLE
fix(cloudflare): pass raw body instead of parsing it

### DIFF
--- a/src/runtime/entries/cloudflare-pages.ts
+++ b/src/runtime/entries/cloudflare-pages.ts
@@ -1,5 +1,5 @@
 import '#internal/nitro/virtual/polyfill'
-import { requestHasBody, useRequestBody } from '../utils'
+import { requestHasBody } from '../utils'
 import { nitroApp } from '../app'
 
 /** @see https://developers.cloudflare.com/pages/platform/functions/#writing-your-first-function */
@@ -32,7 +32,7 @@ export async function onRequest (ctx: CFRequestContext) {
   const url = new URL(ctx.request.url)
   let body
   if (requestHasBody(ctx.request)) {
-    body = await useRequestBody(ctx.request)
+    body = Buffer.from(await ctx.request.arrayBuffer())
   }
 
   const r = await nitroApp.localCall({

--- a/src/runtime/entries/cloudflare.ts
+++ b/src/runtime/entries/cloudflare.ts
@@ -1,7 +1,7 @@
 import '#internal/nitro/virtual/polyfill'
 import { getAssetFromKV, mapRequestToAsset } from '@cloudflare/kv-asset-handler'
 import { withoutBase } from 'ufo'
-import { requestHasBody, useRequestBody } from '../utils'
+import { requestHasBody } from '../utils'
 import { nitroApp } from '../app'
 import { useRuntimeConfig } from '#internal/nitro'
 
@@ -19,7 +19,7 @@ async function handleEvent (event: FetchEvent) {
   const url = new URL(event.request.url)
   let body
   if (requestHasBody(event.request)) {
-    body = await useRequestBody(event.request)
+    body = Buffer.from(await event.request.arrayBuffer())
   }
 
   const r = await nitroApp.localCall({


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In cases where it is necessary to read the body of the raw request, the cloudflare deploy was always parsing the body even using `useRawBody`.
Implementations like the stripe's webhook that needs to read the raw body would break.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

