### PR TITLE
feat: `devProxy` support

### DIFF
--- a/docs/content/3.config/index.md
+++ b/docs/content/3.config/index.md
@@ -146,6 +146,23 @@ There are situations in that we directly want to provide a handler instance with
 
 We can use `devHandlers` but note that they are **only available in development mode** and **not in production build**.
 
+## `devProxy`
+
+Proxy configuration for development server.
+
+You can use this option to override development server routes and proxy-pass requests.
+
+```js
+{
+  devProxy: {
+    '/proxy/test': 'http://localhost:3001',
+    '/proxy/example': { target: 'https://example.com', changeOrigin: true }
+  }
+}
+```
+
+See [https://github.com/http-party/node-http-proxy#options](https://github.com/http-party/node-http-proxy#options) for all available target options.
+
 ## `errorHandler`
 
 Path to a custom runtime error handler. Replacing nitro's built-in error page.

--- a/src/dev/server.ts
+++ b/src/dev/server.ts
@@ -2,7 +2,7 @@ import { Worker } from 'worker_threads'
 import { existsSync, promises as fsp } from 'fs'
 import { debounce } from 'perfect-debounce'
 import { App, createApp, eventHandler, fromNodeMiddleware, H3Error, H3Event, toNodeListener } from 'h3'
-import httpProxy, { ServerOptions } from 'http-proxy'
+import httpProxy, { ServerOptions as HTTPProxyOptions } from 'http-proxy'
 import { listen, Listener, ListenOptions } from 'listhen'
 import { servePlaceholder } from 'serve-placeholder'
 import serveStatic from 'serve-static'
@@ -189,9 +189,9 @@ export function createDevServer (nitro: Nitro): NitroDevServer {
   }
 }
 
-function createProxy (defaults: ServerOptions = {}) {
+function createProxy (defaults: HTTPProxyOptions = {}) {
   const proxy = httpProxy.createProxy()
-  const handle = (event: H3Event, opts: ServerOptions = {}) => {
+  const handle = (event: H3Event, opts: HTTPProxyOptions = {}) => {
     return new Promise<void>((resolve, reject) => {
       proxy.web(event.req, event.res, { ...defaults, ...opts }, (error: any) => {
         if (error.code !== 'ECONNRESET') {

--- a/src/options.ts
+++ b/src/options.ts
@@ -48,6 +48,7 @@ const NitroDefaults: NitroConfig = {
   dev: false,
   devServer: { watch: [] },
   watchOptions: { ignoreInitial: true },
+  devProxy: {},
 
   // Routing
   baseURL: process.env.NITRO_APP_BASE_URL || '/',

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -9,6 +9,7 @@ import type { WatchOptions } from 'chokidar'
 import type { RollupCommonJSOptions } from '@rollup/plugin-commonjs'
 import type { RollupWasmOptions } from '@rollup/plugin-wasm'
 import type { Storage, BuiltinDriverName } from 'unstorage'
+import type { ServerOptions as HTTPProxyOptions } from 'http-proxy'
 import type { NodeExternalsOptions } from '../rollup/plugins/externals'
 import type { RollupConfig } from '../rollup/config'
 import type { Options as EsbuildOptions } from '../rollup/plugins/esbuild'
@@ -163,6 +164,7 @@ export interface NitroOptions extends PresetOptions {
   dev: boolean
   devServer: DevServerOptions
   watchOptions: WatchOptions
+  devProxy: Record<string, string | HTTPProxyOptions>
 
   // Routing
   baseURL: string,

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -15,6 +15,9 @@ export default defineNitroConfig({
       }
     ]
   },
+  devProxy: {
+    '/proxy/example': { target: 'https://example.com', changeOrigin: true }
+  },
   publicAssets: [
     {
       baseURL: 'build',


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

#113

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Support full-featured development-only proxy using [node-http-proxy](https://github.com/http-party/node-http-proxy)

Proxy configuration for development server.

You can use this option to override development server routes and proxy-pass requests.

```js
{
  devProxy: {
    '/proxy/test': 'http://localhost:3001',
    '/proxy/example': { target: 'https://example.com', changeOrigin: true }
  }
}
```

See [https://github.com/http-party/node-http-proxy#options](https://github.com/http-party/node-http-proxy#options) for all available target options.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

