### PR TITLE
feat: support `prerender` route rule

### DIFF
--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -101,6 +101,7 @@ export interface NitroRouteConfig {
   cache?: CachedEventHandlerOptions | false
   headers?: Record<string, string>
   redirect?: string | { to: string, statusCode?: HTTPStatusCode }
+  prerender?: boolean
 
   // Shortcuts
   cors?: boolean

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -27,6 +27,10 @@ export default defineNitroConfig({
   nodeModulesDirs: [
     './_/node_modules'
   ],
+  routeRules: {
+    '/api/param/prerender4': { prerender: true },
+    '/api/param/prerender2': { prerender: false }
+  },
   prerender: {
     crawlLinks: true,
     ignore: [


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds a new `prerender?: boolean` route rule. It does two things:

- Adds any static (without **/*) route rule with `prerender: true` to the list of pre-rendered routes (<=> Almost same functionality as adding to `prerender.routes[]`)
- Skips any route matching a rule with `prerender: false` (<=> Almost same functionality as adding to `prerender.ignore` prefix array)

Prerender is still mainly usable with crawler being enabled. We can later support partial crawling or make a breaking change to only enable crawling for matching rules. Either way this is the starting point.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

