### PR TITLE
refactor: nitro/src

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -20,10 +20,9 @@ import { compressPublicAssets } from './compress'
 
 export async function prepare (nitro: Nitro) {
   await prepareDir(nitro.options.output.dir)
-  if (!nitro.options.noPublicDir) {
-    await prepareDir(nitro.options.output.publicDir)
-  }
-  await prepareDir(nitro.options.output.serverDir)
+  await prepareDir(!nitro.options.noPublicDir
+    ? nitro.options.output.publicDir
+    : nitro.options.output.serverDir)
 }
 
 async function prepareDir (dir: string) {
@@ -182,9 +181,9 @@ async function _build (nitro: Nitro, rollupConfig: RollupConfig) {
 
   // Show deploy and preview hints
   const rOutput = relative(process.cwd(), nitro.options.output.dir)
-  const rewriteRelativePaths = (input: string) => {
-    return input.replace(/\s\.\/([^\s]*)/g, ` ${rOutput}/$1`)
-  }
+  const rewriteRelativePaths = (input: string) =>
+    input.replace(/\s\.\/([^\s]*)/g, ` ${rOutput}/$1`)
+
   if (buildInfo.commands.preview) {
     nitro.logger.success(`You can preview this build using \`${rewriteRelativePaths(buildInfo.commands.preview)}\``)
   }

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -43,10 +43,7 @@ export async function createNitro (config: NitroConfig = {}): Promise<Nitro> {
   // Public assets
   for (const dir of options.scanDirs) {
     const publicDir = resolve(dir, 'public')
-    if (!existsSync(publicDir)) { continue }
-    if (options.publicAssets.find(asset => asset.dir === publicDir)) {
-      continue
-    }
+    if (!existsSync(publicDir) || options.publicAssets.find(asset => asset.dir === publicDir)) { continue }
     options.publicAssets.push({ dir: publicDir } as any)
   }
   for (const asset of options.publicAssets) {

--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -36,13 +36,12 @@ export function externals (opts: NodeExternalsOptions): Plugin {
   return {
     name: 'node-externals',
     async resolveId (originalId, importer, options) {
-      // Skip internals
-      if (!originalId || originalId.startsWith('\x00') || originalId.includes('?') || originalId.startsWith('#')) {
-        return null
-      }
-
-      // Skip relative paths
-      if (originalId.startsWith('.')) {
+      // Skip internals and relative paths
+      if (!originalId ||
+        originalId.startsWith('\x00') ||
+        originalId.includes('?') ||
+        originalId.startsWith('#') ||
+        originalId.startsWith('.')) {
         return null
       }
 

--- a/src/rollup/plugins/storage.ts
+++ b/src/rollup/plugins/storage.ts
@@ -4,21 +4,19 @@ import type { Nitro } from '../../types'
 import { virtual } from './virtual'
 
 export function storage (nitro: Nitro) {
-  const mounts: { path: string, driver: string, opts: object }[] = []
-
   const isDevOrPrerender = nitro.options.dev || nitro.options.preset === 'nitro-prerender'
   const storageMounts = isDevOrPrerender
     ? { ...nitro.options.storage, ...nitro.options.devStorage }
     : nitro.options.storage
 
-  for (const path in storageMounts) {
+  const mounts: { path: string, driver: string, opts: object }[] = Object.keys(storageMounts).map((path) => {
     const mount = storageMounts[path]
-    mounts.push({
+    return {
       path,
       driver: builtinDrivers[mount.driver] || mount.driver,
       opts: mount
-    })
-  }
+    }
+  })
 
   const driverImports = Array.from(new Set(mounts.map(m => m.driver)))
 

--- a/src/runtime/entries/netlify-edge.ts
+++ b/src/runtime/entries/netlify-edge.ts
@@ -4,10 +4,7 @@ import { requestHasBody, useRequestBody } from '../utils'
 
 export default async function (request: Request, _context) {
   const url = new URL(request.url)
-  let body
-  if (requestHasBody(request)) {
-    body = await useRequestBody(request)
-  }
+  const body = requestHasBody(request) && await useRequestBody(request)
 
   const r = await nitroApp.localCall({
     url: url.pathname + url.search,

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -75,12 +75,10 @@ export async function scanPlugins (nitro: Nitro) {
 function scanDirs (dirs: string[]): Promise<FileInfo[]> {
   return Promise.all(dirs.map(async (dir) => {
     const fileNames = await globby(GLOB_SCAN_PATTERN, { cwd: dir, dot: true })
-    return fileNames.map((fileName) => {
-      return {
-        dir,
-        path: fileName,
-        fullPath: resolve(dir, fileName)
-      }
-    }).sort((a, b) => b.path.localeCompare(a.path))
+    return fileNames.map(fileName => ({
+      dir,
+      path: fileName,
+      fullPath: resolve(dir, fileName)
+    })).sort((a, b) => b.path.localeCompare(a.path))
   })).then(r => r.flat())
 }


### PR DESCRIPTION
I have removed wrapper functions, but in fact in runtime this code `function isObject (input: unknown) {
  return typeof input === 'object' && !Array.isArray(input)
}` as wrapper functions is already the case in your repo :)  