### PR TITLE
docs: fix url in auto-imports guide

### DIFF
--- a/docs/content/1.guide/1.introduction/2.auto-imports.md
+++ b/docs/content/1.guide/1.introduction/2.auto-imports.md
@@ -9,7 +9,7 @@ This is because Nitro is integrated with [unjs/unimport](https://github.com/unjs
 
 Check [the source code](https://github.com/unjs/nitro/blob/main/src/imports.ts) for list of available auto imports.
 
-With [Typescript](/guide/typescript) enabled, you can easily see them as global utilities in your IDE.
+With [Typescript](/guide/introduction/typescript) enabled, you can easily see them as global utilities in your IDE.
 
 ## Manual Imports
 


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Current Typescript url to `/guide/introduction/typescript`  in [Auto Imports](https://nitro.unjs.io/guide/introduction/auto-imports) guide.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

