### PR TITLE
fix(plugin): Fixes imports of plugins under windows platform

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -264,7 +264,7 @@ export async function loadOptions (configOverrides: NitroConfig = {}): Promise<N
   options.plugins = options.plugins.map(p => resolvePath(p, options))
 
   if (isWindows) {
-    options.plugins = options.plugins.map(p => pathToFileURL(p).toString())
+    options.plugins = options.plugins.map(p => pathToFileURL(p).href)
   }
 
   return options

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,3 +1,5 @@
+import { pathToFileURL } from 'url'
+import { isWindows } from 'std-env'
 import { resolve, join } from 'pathe'
 import { loadConfig } from 'c12'
 import { klona } from 'klona/full'
@@ -260,6 +262,10 @@ export async function loadOptions (configOverrides: NitroConfig = {}): Promise<N
 
   // Resolve plugin paths
   options.plugins = options.plugins.map(p => resolvePath(p, options))
+
+  if (isWindows) {
+    options.plugins = options.plugins.map(p => pathToFileURL(p).toString())
+  }
 
   return options
 }


### PR DESCRIPTION
### 🔗 Linked issue

  * https://github.com/nuxt-themes/docus/issues/684

### ❓ Type of change

- [X ] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Docus has recently been made public, but this has highlighted some issues when building under windows.
One of them is that nitro I think has trouble parsing plugin paths under windows due to a lack of the "file:///" prefix when passed to the import

Currently it's being called by
https://github.com/Tahul/pinceau/blob/e99c19bbca4ef4626c59d35bbd5bf652df6d2753/src/nuxt.ts#L44


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

- [ X] I have linked an issue or discussion.

