### PR TITLE
fix: normalize nitro plugin paths to url in development

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -7,7 +7,7 @@ import { defu } from 'defu'
 import { resolveModuleExportNames, resolvePath as resolveModule } from 'mlly'
 // import escapeRE from 'escape-string-regexp'
 import { withLeadingSlash, withoutTrailingSlash, withTrailingSlash } from 'ufo'
-import { isTest, isDebug, isWindows } from 'std-env'
+import { isTest, isDebug } from 'std-env'
 import { findWorkspaceDir } from 'pkg-types'
 import { resolvePath, detectTarget } from './utils'
 import type { NitroConfig, NitroOptions, NitroRouteConfig, NitroRouteRules } from './types'
@@ -262,7 +262,7 @@ export async function loadOptions (configOverrides: NitroConfig = {}): Promise<N
   // Resolve plugin paths
   options.plugins = options.plugins.map((p) => {
     const path = resolvePath(p, options)
-    if (isWindows && options.dev && isAbsolute(path)) {
+    if (options.dev && isAbsolute(path)) {
       return pathToFileURL(path).href
     }
     return path

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,5 @@
-import { resolve, join } from 'pathe'
+import { pathToFileURL } from 'node:url'
+import { resolve, join, isAbsolute } from 'pathe'
 import { loadConfig } from 'c12'
 import { klona } from 'klona/full'
 import { camelCase } from 'scule'
@@ -6,7 +7,7 @@ import { defu } from 'defu'
 import { resolveModuleExportNames, resolvePath as resolveModule } from 'mlly'
 // import escapeRE from 'escape-string-regexp'
 import { withLeadingSlash, withoutTrailingSlash, withTrailingSlash } from 'ufo'
-import { isTest, isDebug } from 'std-env'
+import { isTest, isDebug, isWindows } from 'std-env'
 import { findWorkspaceDir } from 'pkg-types'
 import { resolvePath, detectTarget } from './utils'
 import type { NitroConfig, NitroOptions, NitroRouteConfig, NitroRouteRules } from './types'
@@ -259,8 +260,13 @@ export async function loadOptions (configOverrides: NitroConfig = {}): Promise<N
   }
 
   // Resolve plugin paths
-  options.plugins = options.plugins.map(p => resolvePath(p, options))
-
+  options.plugins = options.plugins.map((p) => {
+    const path = resolvePath(p, options)
+    if (isWindows && options.dev && isAbsolute(path)) {
+      return pathToFileURL(path).href
+    }
+    return path
+  })
   return options
 }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -267,6 +267,7 @@ export async function loadOptions (configOverrides: NitroConfig = {}): Promise<N
     }
     return path
   })
+
   return options
 }
 


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/nuxt/framework/issues/8461
https://github.com/Baroshem/nuxt-security/issues/42

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We need to normalize plugins that are absolute paths (`C:\test\something`) to file URLs on windows before we generate the imports from them in `dev/index.mjs`. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

