### PR TITLE
fix: use file urls for auto-imports in development

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,5 @@
-import { resolve, join } from 'pathe'
+import { pathToFileURL } from 'node:url'
+import { resolve, join, isAbsolute } from 'pathe'
 import { loadConfig } from 'c12'
 import { klona } from 'klona/full'
 import { camelCase } from 'scule'
@@ -165,6 +166,15 @@ export async function loadOptions (configOverrides: NitroConfig = {}): Promise<N
 
   if (options.imports && Array.isArray(options.imports.exclude)) {
     options.imports.exclude.push(options.buildDir)
+  }
+
+  // Normalise absolute auto-import paths for windows machines
+  if (options.imports && options.dev) {
+    for (const entry of options.imports.imports) {
+      if (isAbsolute(entry.from)) {
+        entry.from = pathToFileURL(entry.from).href
+      }
+    }
   }
 
   // Add h3 auto imports preset


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/danielroe/nuxt-turnstile/issues/85

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Similar to https://github.com/unjs/nitro/pull/732, we should use file urls in dev mode for absolute auto-import paths. I'll rebase this once that merges, but thought I'd open this first so you're aware.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

