### PR TITLE
fix(prerender): check each segment length is less than 255 chars and whole path 1024

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -88,9 +88,9 @@ export async function prerender(nitro: Nitro) {
     if (segments.some((s) => s.length > 255)) {
       if (!displayedLengthWarns.has(route)) {
         displayedLengthWarns.add(route);
-        const _route = route.slice(0, 60);
+        const _route = route.slice(0, 60) + "...";
         nitro.logger.warn(
-          `Skipping prerender of route "${_route}..." since it exceeds 255 characters in one of the segments and can cause filesystem issues.`
+          `Skipping prerender of the route "${_route}" since it exceeds the 255-character limit in one of the path segments and can cause filesystem issues.`
         );
       }
       return false;

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -100,7 +100,7 @@ export async function prerender(nitro: Nitro) {
       const _route = route.slice(0, 60) + "...";
       if (route.length >= FS_MAX_PATH_PUBLIC_HTML) {
         nitro.logger.warn(
-          `Prerendering long route "${_route}" (${route.length}) can cause filesystem issues since it exceeds ${FS_MAX_PATH_PUBLIC_HTML}-character limit when writing to ${nitro.options.output.publicDir} and can cause filesystem issues.`
+          `Prerendering long route "${_route}" (${route.length}) can cause filesystem issues since it exceeds ${FS_MAX_PATH_PUBLIC_HTML}-character limit when writing to \`${nitro.options.output.publicDir}\`.`
         );
       } else {
         nitro.logger.warn(

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -76,11 +76,19 @@ export async function prerender(nitro: Nitro) {
 
   // Start prerendering
   const generatedRoutes = new Set();
+  const displayedLengthWarns = new Set();
   const canPrerender = (route: string = "/") => {
     if (generatedRoutes.has(route)) {
       return false;
     }
     if (route.length > 250) {
+      if (!displayedLengthWarns.has(route)) {
+        displayedLengthWarns.add(route);
+        const _route = route.slice(0, 60);
+        nitro.logger.warn(
+          `Skipping prerender of route "${_route}..." since it exceeds 250 characters.`
+        );
+      }
       return false;
     }
     for (const ignore of nitro.options.prerender.ignore) {

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -84,20 +84,23 @@ export async function prerender(nitro: Nitro) {
     }
 
     // Ensure length is not too long for filesystem
-    // 1024 is the max path length on APFS (undocumented)
-    const FS_MAX_PATH = 1024 - (nitro.options.output.publicDir.length + 10);
     // https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits
     const FS_MAX_SEGMENT = 255;
+    // 1024 is the max path length on APFS (undocumented)
+    const FS_MAX_PATH = 1024;
+    const FS_MAX_PATH_PUBLIC_HTML =
+      FS_MAX_PATH - (nitro.options.output.publicDir.length + 10);
+
     if (
-      (route.length >= FS_MAX_PATH ||
+      (route.length >= FS_MAX_PATH_PUBLIC_HTML ||
         route.split("/").some((s) => s.length > FS_MAX_SEGMENT)) &&
       !displayedLengthWarns.has(route)
     ) {
       displayedLengthWarns.add(route);
       const _route = route.slice(0, 60) + "...";
-      if (route.length >= FS_MAX_PATH) {
+      if (route.length >= FS_MAX_PATH_PUBLIC_HTML) {
         nitro.logger.warn(
-          `Prerendering long route "${_route}" (${route.length}) can cause filesystem issues since it exceeds ${FS_MAX_PATH}-character limit and can cause filesystem issues.`
+          `Prerendering long route "${_route}" (${route.length}) can cause filesystem issues since it exceeds ${FS_MAX_PATH_PUBLIC_HTML}-character limit when writing to ${nitro.options.output.publicDir} and can cause filesystem issues.`
         );
       } else {
         nitro.logger.warn(


### PR DESCRIPTION
When prerendering routes, we create a filesystem entry with directory structure corresponding to the route and serve then in production as static files.

Due to filesystem limitations ([see this table for reference](https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits)) filename (and directory names) can have maximum of 255 characters in most popular filesystem implementations while generally there is less limit (at least documented) limitation for the full path. 

This fixes nitro check to validate each segment length splitted by `/` instead of the whole path against 255 limit. Also adds a visible warning log when skipping routes due to filesystem limits.

APFS, at least also has a limitation on full path as well which is undocumented but causes `ENAMETOOLONG` error when while path (including path to `/.../project/.output/public`) is longer than 1024. I have made it a soft warning to ensure we at least warn about cross platform possible issues.
