### PR TITLE
feat: include only compressible mime types

### DIFF
--- a/docs/content/3.config/index.md
+++ b/docs/content/3.config/index.md
@@ -92,6 +92,35 @@ If a `public/` directory is detected, it will be added by default, but you can a
 If enabled, Nitro will generate a pre-compressed (gzip and/or brotli) version of supported types of public assets and prerendered routes
 larger than 1024 bytes into the public directory. The best compression level is used. Using this option you can support zero overhead asset compression without using a CDN.
 
+The compressible MIME types are:
+
+- text/html - `.html`
+- text/plain - `.txt`
+- text/css - `.css`
+- text/xml - `.xml`
+- text/x-component - `.htc`
+- text/javascript - `.js`
+- application/javascript - `.js`
+- application/x-javascript - `.js`
+- application/json - `.json`
+- application/vnd.api+json - `.json`
+- application/manifest+json - `.webmanifest`
+- application/xml - `.xml`
+- application/xhtml+xml - `.xhtml`
+- application/rss+xml - `.rss`
+- application/atom+xml - `.atom`
+- image/svg+xml - `.svg`
+- image/x-icon - `.ico`
+- image/vnd.microsoft.icon - `.ico`
+- font/ttf - `.ttf`
+- application/x-font-ttf - `.ttf`
+- application/x-font-truetype - `.ttf`
+- font/eot - `.eot`
+- application/vnd.ms-fontobject - `.eot`
+- font/otf - `.otf`
+- font/opentype - `.otf`
+- application/x-font-opentype - `.otf`
+
 ## `serverAssets`
 
 Assets can be accessed in server logic and bundled in production.

--- a/docs/content/3.config/index.md
+++ b/docs/content/3.config/index.md
@@ -94,32 +94,52 @@ larger than 1024 bytes into the public directory. The best compression level is 
 
 The compressible MIME types are:
 
-- text/html - `.html`
-- text/plain - `.txt`
-- text/css - `.css`
-- text/xml - `.xml`
-- text/x-component - `.htc`
-- text/javascript - `.js`
-- application/javascript - `.js`
-- application/x-javascript - `.js`
-- application/json - `.json`
-- application/vnd.api+json - `.json`
-- application/manifest+json - `.webmanifest`
-- application/xml - `.xml`
-- application/xhtml+xml - `.xhtml`
-- application/rss+xml - `.rss`
-- application/atom+xml - `.atom`
-- image/svg+xml - `.svg`
-- image/x-icon - `.ico`
-- image/vnd.microsoft.icon - `.ico`
-- font/ttf - `.ttf`
-- application/x-font-ttf - `.ttf`
-- application/x-font-truetype - `.ttf`
-- font/eot - `.eot`
-- application/vnd.ms-fontobject - `.eot`
-- font/otf - `.otf`
-- font/opentype - `.otf`
-- application/x-font-opentype - `.otf`
+- application/dash+xml
+- application/eot
+- application/font
+- application/font-sfnt
+- application/javascript
+- application/json
+- application/opentype
+- application/otf
+- application/pkcs7-mime
+- application/protobuf
+- application/rss+xml
+- application/truetype
+- application/ttf
+- application/vnd.apple.mpegurl
+- application/vnd.mapbox-vector-tile
+- application/vnd.ms-fontobject
+- application/xhtml+xml
+- application/xml
+- application/x-font-opentype
+- application/x-font-truetype
+- application/x-font-ttf
+- application/x-httpd-cgi
+- application/x-javascript
+- application/x-mpegurl
+- application/x-opentype
+- application/x-otf
+- application/x-perl
+- application/x-ttf
+- font/eot
+- font/opentype
+- font/otf
+- font/ttf
+- image/svg+xml
+- text/css
+- text/csv
+- text/html
+- text/javascript
+- text/js
+- text/plain
+- text/richtext
+- text/tab-separated-values
+- text/xml
+- text/x-component
+- text/x-java-source
+- text/x-script
+- vnd.apple.mpegurl
 
 ## `serverAssets`
 

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -72,5 +72,24 @@ function isTextMime(mimeType: string) {
 }
 
 function isCompressableMime(mimeType: string) {
-  return /image|text|font|json|xml|javascript/.test(mimeType);
+  const compressibleMimeTypes = [
+    'atom',
+    'css',
+    'eot',
+    'htc',
+    'html',
+    'ico',
+    'js',
+    'json',
+    'mjs',
+    'otf',
+    'rss',
+    'svg',
+    'text',
+    'ttf',
+    'webmanifest',
+    'xml',
+  ];
+
+  return compressibleMimeTypes.includes(mimeType);
 }

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -71,7 +71,8 @@ function isTextMime(mimeType: string) {
   return /text|javascript|json|xml/.test(mimeType);
 }
 
-const COMPRESSIBLE_MIMES_RE = /atom|css|eot|htc|html|ico|js|json|mjs|otf|rss|svg|text|ttf|webmanifest|xml/;
+const COMPRESSIBLE_MIMES_RE =
+  /atom|css|eot|htc|html|ico|js|json|mjs|otf|rss|svg|text|ttf|webmanifest|xml/;
 
 function isCompressableMime(mimeType: string) {
   return COMPRESSIBLE_MIMES_RE.test(mimeType);

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -71,7 +71,7 @@ function isTextMime(mimeType: string) {
   return /text|javascript|json|xml/.test(mimeType);
 }
 
-const COMPRESSIBLE_MIMES_RE = /atom|css|eot|htc|html|ico|js|json|mjs|otf|rss|svg|text|ttf|webmanifest|xml/
+const COMPRESSIBLE_MIMES_RE = /atom|css|eot|htc|html|ico|js|json|mjs|otf|rss|svg|text|ttf|webmanifest|xml/;
 
 function isCompressableMime(mimeType: string) {
   return COMPRESSIBLE_MIMES_RE.test(mimeType);

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -71,9 +71,57 @@ function isTextMime(mimeType: string) {
   return /text|javascript|json|xml/.test(mimeType);
 }
 
-const COMPRESSIBLE_MIMES_RE =
-  /atom|css|eot|htc|html|ico|js|json|mjs|otf|rss|svg|text|ttf|webmanifest|xml/;
+// Reference list of compressible MIME types from AWS
+// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html#compressed-content-cloudfront-file-types
+const COMPRESSIBLE_MIMES_RE = new Set([
+  "application/dash+xml",
+  "application/eot",
+  "application/font",
+  "application/font-sfnt",
+  "application/javascript",
+  "application/json",
+  "application/opentype",
+  "application/otf",
+  "application/pkcs7-mime",
+  "application/protobuf",
+  "application/rss+xml",
+  "application/truetype",
+  "application/ttf",
+  "application/vnd.apple.mpegurl",
+  "application/vnd.mapbox-vector-tile",
+  "application/vnd.ms-fontobject",
+  "application/xhtml+xml",
+  "application/xml",
+  "application/x-font-opentype",
+  "application/x-font-truetype",
+  "application/x-font-ttf",
+  "application/x-httpd-cgi",
+  "application/x-javascript",
+  "application/x-mpegurl",
+  "application/x-opentype",
+  "application/x-otf",
+  "application/x-perl",
+  "application/x-ttf",
+  "font/eot",
+  "font/opentype",
+  "font/otf",
+  "font/ttf",
+  "image/svg+xml",
+  "text/css",
+  "text/csv",
+  "text/html",
+  "text/javascript",
+  "text/js",
+  "text/plain",
+  "text/richtext",
+  "text/tab-separated-values",
+  "text/xml",
+  "text/x-component",
+  "text/x-java-source",
+  "text/x-script",
+  "vnd.apple.mpegurl"
+]);
 
 function isCompressableMime(mimeType: string) {
-  return COMPRESSIBLE_MIMES_RE.test(mimeType);
+  return COMPRESSIBLE_MIMES_RE.has(mimeType);
 }

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -71,25 +71,8 @@ function isTextMime(mimeType: string) {
   return /text|javascript|json|xml/.test(mimeType);
 }
 
-  const compressibleMimeTypes = [
-    'atom',
-    'css',
-    'eot',
-    'htc',
-    'html',
-    'ico',
-    'js',
-    'json',
-    'mjs',
-    'otf',
-    'rss',
-    'svg',
-    'text',
-    'ttf',
-    'webmanifest',
-    'xml',
-  ];
+const compressibleMimeTypesRegex = /atom|css|eot|htc|html|ico|js|json|mjs|otf|rss|svg|text|ttf|webmanifest|xml/
 
 function isCompressableMime(mimeType: string) {
-  return compressibleMimeTypes.includes(mimeType);
+  return compressibleMimeTypesRegex.test(mimeType);
 }

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -71,7 +71,6 @@ function isTextMime(mimeType: string) {
   return /text|javascript|json|xml/.test(mimeType);
 }
 
-function isCompressableMime(mimeType: string) {
   const compressibleMimeTypes = [
     'atom',
     'css',
@@ -91,5 +90,6 @@ function isCompressableMime(mimeType: string) {
     'xml',
   ];
 
+function isCompressableMime(mimeType: string) {
   return compressibleMimeTypes.includes(mimeType);
 }

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -71,8 +71,8 @@ function isTextMime(mimeType: string) {
   return /text|javascript|json|xml/.test(mimeType);
 }
 
-const compressibleMimeTypesRegex = /atom|css|eot|htc|html|ico|js|json|mjs|otf|rss|svg|text|ttf|webmanifest|xml/
+const COMPRESSIBLE_MIMES_RE = /atom|css|eot|htc|html|ico|js|json|mjs|otf|rss|svg|text|ttf|webmanifest|xml/
 
 function isCompressableMime(mimeType: string) {
-  return compressibleMimeTypesRegex.test(mimeType);
+  return COMPRESSIBLE_MIMES_RE.test(mimeType);
 }


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue
https://github.com/nuxt/framework/discussions/9626
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The code for `compressPublicAssets` was double-compressing all image types (including .jpg, .png, .gif, .webp, etc.) when it really should only be compressible static file types that are text-based. I updated the code to use the following list of MIME types, and also added it to the docs for `compressPublicAssets`:

text/html
text/css
text/plain
text/xml
text/x-component
text/javascript
application/x-javascript
application/javascript
application/json
application/manifest+json
application/vnd.api+json
application/xml
application/xhtml+xml
application/rss+xml
application/atom+xml
application/vnd.ms-fontobject
application/x-font-ttf
application/x-font-opentype
application/x-font-truetype
image/svg+xml
image/x-icon
image/vnd.microsoft.icon
font/ttf
font/eot
font/otf
font/opentype

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
