### PR TITLE
feat: set default Cache-Control header with max-age of 1 year

### DIFF
--- a/src/runtime/static.ts
+++ b/src/runtime/static.ts
@@ -92,11 +92,10 @@ export default eventHandler((event) => {
     event.res.setHeader("Content-Length", asset.size);
   }
 
-  // TODO: Asset dir cache control
-  // if (isBuildAsset) {
-  // const TWO_DAYS = 2 * 60 * 60 * 24
-  // event.res.setHeader('Cache-Control', `max-age=${TWO_DAYS}, immutable`)
-  // }
+  if (isPublicAssetURL(id) && !event.res.getHeader("Cache-Control")) {
+    const ONE_YEAR = 365 * 24 * 60 * 60;
+    event.res.setHeader('Cache-Control', `max-age=${ONE_YEAR}, immutable`)
+  }
 
   return readAsset(id);
 });


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/unjs/nitro/issues/762, https://github.com/nuxt/nuxt.js/issues/15465

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

For all public static assets, we can define a best practice value for the Cache-Control header, to fall in line with the Google Lighthouse scoring of [serving assets with an efficient cache policy](https://developer.chrome.com/en/docs/lighthouse/performance/uses-long-cache-ttl/).

`Cache-Control: max-age=31536000, immutable`

This checks if the asset is public, and not already defined, and sets the header accordingly.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
