### PR TITLE
fix(netlify, vercel): order route rules from most specific + avoid double-rendering root

### DIFF
--- a/src/presets/netlify.ts
+++ b/src/presets/netlify.ts
@@ -85,7 +85,7 @@ async function writeRedirects(nitro: Nitro) {
   let contents = "/* /.netlify/functions/server 200";
 
   const rules = Object.entries(nitro.options.routeRules)
-    .sort((a, b) => b[0].split("/").length - a[0].split("/").length)
+    .sort((a, b) => a[0].split("/").length - b[0].split("/").length)
 
   // Rewrite static cached paths to builder functions
   for (const [key] of rules.filter(

--- a/src/presets/netlify.ts
+++ b/src/presets/netlify.ts
@@ -85,7 +85,7 @@ async function writeRedirects(nitro: Nitro) {
   let contents = "/* /.netlify/functions/server 200";
 
   const rules = Object.entries(nitro.options.routeRules)
-    .sort((a, b) => a[0].split("/").length - b[0].split("/").length)
+    .sort((a, b) => a[0].split(/\/(?!\*)/).length - b[0].split(/\/(?!\*)/).length)
 
   // Rewrite static cached paths to builder functions
   for (const [key] of rules.filter(
@@ -127,7 +127,7 @@ async function writeHeaders(nitro: Nitro) {
   let contents = "";
 
   const rules = Object.entries(nitro.options.routeRules)
-    .sort((a, b) => b[0].split("/").length - a[0].split("/").length)
+    .sort((a, b) => b[0].split(/\/(?!\*)/).length - a[0].split(/\/(?!\*)/).length)
 
   for (const [path, routeRules] of rules.filter(([_, routeRules]) => routeRules.headers)) {
     const headers = [

--- a/src/presets/netlify.ts
+++ b/src/presets/netlify.ts
@@ -84,8 +84,9 @@ async function writeRedirects(nitro: Nitro) {
   const redirectsPath = join(nitro.options.output.publicDir, "_redirects");
   let contents = "/* /.netlify/functions/server 200";
 
-  const rules = Object.entries(nitro.options.routeRules)
-    .sort((a, b) => a[0].split(/\/(?!\*)/).length - b[0].split(/\/(?!\*)/).length)
+  const rules = Object.entries(nitro.options.routeRules).sort(
+    (a, b) => a[0].split(/\/(?!\*)/).length - b[0].split(/\/(?!\*)/).length
+  );
 
   // Rewrite static cached paths to builder functions
   for (const [key] of rules.filter(
@@ -96,7 +97,9 @@ async function writeRedirects(nitro: Nitro) {
       `${key.replace("/**", "/*")}\t/.netlify/builders/server 200\n` + contents;
   }
 
-  for (const [key, routeRules] of rules.filter(([_, routeRules]) => routeRules.redirect)) {
+  for (const [key, routeRules] of rules.filter(
+    ([_, routeRules]) => routeRules.redirect
+  )) {
     // TODO: Remove map when netlify support 307/308
     let code = routeRules.redirect.statusCode;
     code = { 307: 302, 308: 301 }[code] || code;
@@ -126,10 +129,13 @@ async function writeHeaders(nitro: Nitro) {
   const headersPath = join(nitro.options.output.publicDir, "_headers");
   let contents = "";
 
-  const rules = Object.entries(nitro.options.routeRules)
-    .sort((a, b) => b[0].split(/\/(?!\*)/).length - a[0].split(/\/(?!\*)/).length)
+  const rules = Object.entries(nitro.options.routeRules).sort(
+    (a, b) => b[0].split(/\/(?!\*)/).length - a[0].split(/\/(?!\*)/).length
+  );
 
-  for (const [path, routeRules] of rules.filter(([_, routeRules]) => routeRules.headers)) {
+  for (const [path, routeRules] of rules.filter(
+    ([_, routeRules]) => routeRules.headers
+  )) {
     const headers = [
       path.replace("/**", "/*"),
       ...Object.entries({ ...routeRules.headers }).map(

--- a/src/presets/netlify.ts
+++ b/src/presets/netlify.ts
@@ -84,8 +84,11 @@ async function writeRedirects(nitro: Nitro) {
   const redirectsPath = join(nitro.options.output.publicDir, "_redirects");
   let contents = "/* /.netlify/functions/server 200";
 
+  const rules = Object.entries(nitro.options.routeRules)
+    .sort((a, b) => b[0].split("/").length - a[0].split("/").length)
+
   // Rewrite static cached paths to builder functions
-  for (const [key] of Object.entries(nitro.options.routeRules).filter(
+  for (const [key] of rules.filter(
     ([_, routeRules]) =>
       routeRules.cache && (routeRules.cache?.static || routeRules.cache?.swr)
   )) {
@@ -93,9 +96,7 @@ async function writeRedirects(nitro: Nitro) {
       `${key.replace("/**", "/*")}\t/.netlify/builders/server 200\n` + contents;
   }
 
-  for (const [key, routeRules] of Object.entries(
-    nitro.options.routeRules
-  ).filter(([_, routeRules]) => routeRules.redirect)) {
+  for (const [key, routeRules] of rules.filter(([_, routeRules]) => routeRules.redirect)) {
     // TODO: Remove map when netlify support 307/308
     let code = routeRules.redirect.statusCode;
     code = { 307: 302, 308: 301 }[code] || code;
@@ -125,9 +126,10 @@ async function writeHeaders(nitro: Nitro) {
   const headersPath = join(nitro.options.output.publicDir, "_headers");
   let contents = "";
 
-  for (const [path, routeRules] of Object.entries(
-    nitro.options.routeRules
-  ).filter(([_, routeRules]) => routeRules.headers)) {
+  const rules = Object.entries(nitro.options.routeRules)
+    .sort((a, b) => b[0].split("/").length - a[0].split("/").length)
+
+  for (const [path, routeRules] of rules.filter(([_, routeRules]) => routeRules.headers)) {
     const headers = [
       path.replace("/**", "/*"),
       ...Object.entries({ ...routeRules.headers }).map(

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -43,8 +43,9 @@ export const vercel = defineNitroPreset({
       );
 
       // Write prerender functions
-      const rules = Object.entries(nitro.options.routeRules)
-        .filter(([_, value]) => value.cache && (value.cache.swr || value.cache.static))
+      const rules = Object.entries(nitro.options.routeRules).filter(
+        ([_, value]) => value.cache && (value.cache.swr || value.cache.static)
+      );
 
       for (const [key, value] of rules) {
         if (!value.cache) {
@@ -120,8 +121,9 @@ export const vercelEdge = defineNitroPreset({
 });
 
 function generateBuildConfig(nitro: Nitro) {
-  const rules = Object.entries(nitro.options.routeRules)
-    .sort((a, b) => b[0].split(/\/(?!\*)/).length - a[0].split(/\/(?!\*)/).length)
+  const rules = Object.entries(nitro.options.routeRules).sort(
+    (a, b) => b[0].split(/\/(?!\*)/).length - a[0].split(/\/(?!\*)/).length
+  );
 
   return defu(nitro.options.vercel?.config, <VercelBuildConfigV3>{
     version: 3,
@@ -175,11 +177,17 @@ function generateBuildConfig(nitro: Nitro) {
         })),
       // If we are using a prerender function as a fallback, then we do not need to output
       // the below fallback route as well
-      ...(!nitro.options.routeRules['/**']?.cache || !(nitro.options.routeRules['/**'].cache.swr || nitro.options.routeRules['/**']?.cache.static)
-        ? [{
-            src: "/(.*)",
-            dest: "/__nitro",
-          }]
+      ...(!nitro.options.routeRules["/**"]?.cache ||
+      !(
+        nitro.options.routeRules["/**"].cache.swr ||
+        nitro.options.routeRules["/**"]?.cache.static
+      )
+        ? [
+            {
+              src: "/(.*)",
+              dest: "/__nitro",
+            },
+          ]
         : []),
     ],
   });

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -121,7 +121,7 @@ export const vercelEdge = defineNitroPreset({
 
 function generateBuildConfig(nitro: Nitro) {
   const rules = Object.entries(nitro.options.routeRules)
-    .sort((a, b) => b[0].split("/").length - a[0].split("/").length)
+    .sort((a, b) => b[0].split(/\/(?!\*)/).length - a[0].split(/\/(?!\*)/).length)
 
   return defu(nitro.options.vercel?.config, <VercelBuildConfigV3>{
     version: 3,

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -173,6 +173,8 @@ function generateBuildConfig(nitro: Nitro) {
           src: key.replace(/^(.*)\/\*\*/, "(?<url>$1/.*)"),
           dest: generateEndpoint(key) + "?url=$url",
         })),
+      // If we are using a prerender function as a fallback, then we do not need to output
+      // the below fallback route as well
       ...(!nitro.options.routeRules['/**']?.cache || !(nitro.options.routeRules['/**'].cache.swr || nitro.options.routeRules['/**']?.cache.static)
         ? [{
             src: "/(.*)",

--- a/test/presets/netlify.test.ts
+++ b/test/presets/netlify.test.ts
@@ -41,8 +41,8 @@ describe("nitro:preset:netlify", async () => {
     /* eslint-disable no-tabs */
     expect(redirects).toMatchInlineSnapshot(`
       "/rules/nested/override	/other	302
-      /rules/nested/*	/base	302
       /rules/redirect/obj	https://nitro.unjs.io/	301
+      /rules/nested/*	/base	302
       /rules/redirect	/base	302
       /rules/swr-ttl/*	/.netlify/builders/server 200
       /rules/swr/*	/.netlify/builders/server 200
@@ -58,15 +58,15 @@ describe("nitro:preset:netlify", async () => {
     );
     /* eslint-disable no-tabs */
     expect(headers).toMatchInlineSnapshot(`
-      "/rules/nested/*
-        x-test: test
-      /rules/headers
+      "/rules/headers
         cache-control: s-maxage=60
       /rules/cors
         access-control-allow-origin: *
         access-control-allowed-methods: GET
         access-control-allow-headers: *
         access-control-max-age: 0
+      /rules/nested/*
+        x-test: test
       "
     `);
     /* eslint-enable no-tabs */

--- a/test/presets/netlify.test.ts
+++ b/test/presets/netlify.test.ts
@@ -58,15 +58,15 @@ describe("nitro:preset:netlify", async () => {
     );
     /* eslint-disable no-tabs */
     expect(headers).toMatchInlineSnapshot(`
-      "/rules/headers
+      "/rules/nested/*
+        x-test: test
+      /rules/headers
         cache-control: s-maxage=60
       /rules/cors
         access-control-allow-origin: *
         access-control-allowed-methods: GET
         access-control-allow-headers: *
         access-control-max-age: 0
-      /rules/nested/*
-        x-test: test
       "
     `);
     /* eslint-enable no-tabs */

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -52,14 +52,6 @@ describe("nitro:preset:vercel", async () => {
           },
           {
             "headers": {
-              "Location": "/base",
-              "x-test": "test",
-            },
-            "src": "/rules/nested/.*",
-            "status": 307,
-          },
-          {
-            "headers": {
               "Location": "/other",
             },
             "src": "/rules/nested/override",
@@ -85,6 +77,14 @@ describe("nitro:preset:vercel", async () => {
               "Location": "/base",
             },
             "src": "/rules/redirect",
+            "status": 307,
+          },
+          {
+            "headers": {
+              "Location": "/base",
+              "x-test": "test",
+            },
+            "src": "/rules/nested/.*",
             "status": 307,
           },
           {

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -45,28 +45,6 @@ describe("nitro:preset:vercel", async () => {
         "routes": [
           {
             "headers": {
-              "cache-control": "s-maxage=60",
-            },
-            "src": "/rules/headers",
-          },
-          {
-            "headers": {
-              "access-control-allow-headers": "*",
-              "access-control-allow-origin": "*",
-              "access-control-allowed-methods": "GET",
-              "access-control-max-age": "0",
-            },
-            "src": "/rules/cors",
-          },
-          {
-            "headers": {
-              "Location": "/base",
-            },
-            "src": "/rules/redirect",
-            "status": 307,
-          },
-          {
-            "headers": {
               "Location": "https://nitro.unjs.io/",
             },
             "src": "/rules/redirect/obj",
@@ -85,6 +63,28 @@ describe("nitro:preset:vercel", async () => {
               "Location": "/other",
             },
             "src": "/rules/nested/override",
+            "status": 307,
+          },
+          {
+            "headers": {
+              "cache-control": "s-maxage=60",
+            },
+            "src": "/rules/headers",
+          },
+          {
+            "headers": {
+              "access-control-allow-headers": "*",
+              "access-control-allow-origin": "*",
+              "access-control-allowed-methods": "GET",
+              "access-control-max-age": "0",
+            },
+            "src": "/rules/cors",
+          },
+          {
+            "headers": {
+              "Location": "/base",
+            },
+            "src": "/rules/redirect",
             "status": 307,
           },
           {


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This orders route rules within vercel + netlify presets so that (particularly glob) rules do not shadow rules below them. In addition, if the default vercel route rule is `/**: { static: true }` we don't also need to output a second, SSR rule.

cc: @antfu - if you clone this and checkout commit c7f8f39972b43a8ddb0b06d558b3b9f3b19f0a45, then run `vitest run -u` the test passes and the inline snapshots are not updated. I've also noticed some other weird issues like a different snapshot within a file being updated than the one it corresponds to (e.g. the next snapshot below).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
