### PR TITLE
fix(prerender): check link's pathname only for extensions

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -276,6 +276,7 @@ function extractLinks(
 
 const EXT_REGEX = /\.[\da-z]+$/;
 
-function getExtension(path: string): string {
-  return (path.match(EXT_REGEX) || [])[0] || "";
+function getExtension(link: string): string {
+  const pathname = parseURL(link).pathname;
+  return (pathname.match(EXT_REGEX) || [])[0] || "";
 }


### PR DESCRIPTION
### 🔗 Linked issue

n/a, see description below

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If a link contains parts following the pathname, e.g. a query or hash, the file extension would not be found. Links that appear to have no file extension would then NOT be excluded from crawling. Those included links led the crawler to request, e.g. static, files on which `vue-bundle-renderer` (as used in Nuxt) would produce a memory overflow.

I did not investigate the reason for the overflow being an overflow further as the link usage is incorrect in the first place.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
