### PR TITLE
fix(prerender): decode urls to allow comma in the `x-nitro-prerender` header

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -257,7 +257,10 @@ function extractLinks(
 
   // Extract from x-nitro-prerender headers
   const header = res.headers.get("x-nitro-prerender") || "";
-  _links.push(...header.split(",").map((i) => i.trim()));
+  _links.push(...header.split(",")
+      .map((i) => i.trim())
+      .map((i) => decodeURIComponent(i));
+
 
   for (const link of _links.filter(Boolean)) {
     const parsed = parseURL(link);


### PR DESCRIPTION
Hey, first timer here 🎉.

### 🔗 Linked issue

https://github.com/nuxt/image/pull/701

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When using `@nuxt/image-edge` with Nuxt 3 the default image provider is [IPX](https://github.com/unjs/ipx) which allows arbitrary image manipulation through URLs.

When using multiple transformations on an image the different transformations are seperated by a comma like this in the final image URL:
```
/_ipx/q_50,s_10x10/images/nitropack.png
```

`@nuxt/image-edge` appends these URLs to the `X-Nitro-Prerender` header without encoding the URL.
The header will then be split by "," when prerendering the site which leads to the following URLs being prerendered:
- _ipx/q_50
- s_10x10/images/nitropack.png

This results in some images not being properly prerendered and/or missing in the final output build when running `yarn run generate`

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
