### PR TITLE
chore: add missing parenthesis in header parsing

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -257,10 +257,12 @@ function extractLinks(
 
   // Extract from x-nitro-prerender headers
   const header = res.headers.get("x-nitro-prerender") || "";
-  _links.push(...header.split(",")
+  _links.push(
+    ...header
+      .split(",")
       .map((i) => i.trim())
-      .map((i) => decodeURIComponent(i));
-
+      .map((i) => decodeURIComponent(i))
+  );
 
   for (const link of _links.filter(Boolean)) {
     const parsed = parseURL(link);


### PR DESCRIPTION
Related to #799 

My bad, a missing parenthesis slipped through :(