### PR TITLE
fix(build): do not override publicAssets in build

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -40,7 +40,8 @@ export async function copyPublicAssets(nitro: Nitro) {
     if (await isDirectory(asset.dir)) {
       await fse.copy(
         asset.dir,
-        join(nitro.options.output.publicDir, asset.baseURL!)
+        join(nitro.options.output.publicDir, asset.baseURL!),
+        { overwrite: false }
       );
     }
   }


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There is a misalignment across dev and build. In dev, the middleware is registered in the normal order, which mean eailer items in `publicAssets` will have higher priority. While in build, `fes.copy` defaults to overrides the existing files, making the priority in the oppsite direction.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
