### PR TITLE
fix(rumtime): disable server-timing header via options.timing

### DIFF
--- a/docs/content/3.config/index.md
+++ b/docs/content/3.config/index.md
@@ -40,7 +40,6 @@ Server runtime configuration.
 
 **Note:**: `nitro` namespace is reserved.
 
-
 <!-- Features -->
 
 ## `experimental`
@@ -59,7 +58,7 @@ Storage configuration.
 
 - Default: `false`
 
-Enable timing information.
+Enable bundle files loading time log.
 
 ## `renderer`
 
@@ -171,8 +170,6 @@ An array of paths to nitro plugins. They will be executed by order on the first 
 
 A map from dynamic virtual import names to their contents or an (async) function that returns it.
 
-
-
 <!-- Routing -->
 
 ## `baseURL`
@@ -242,7 +239,6 @@ Route options. It is a map from route pattern (following [unjs/radix3](https://g
 
 When `cache` option is set, handlers matching pattern will be automatically wrapped with `defineCachedEventHandler`. See [Cache API](/guide/introduction/cache) for all available cache options. (`swr: true|number` is shortcut for `cache: { swr: true, maxAge: number }`.)
 
-
 **Example:**
 
 ```js
@@ -266,8 +262,6 @@ Default: `{ crawlLinks: false, routes: [] }`
 Prerendered options. Any route specified will be fetched during the build and copied to the `.output/public` directory as a static asset.
 
 If `crawlLinks` option is set to `true`, nitro starts with `/` by default (or all routes in `routes` array) and for HTML pages extracts `<a href="">` tags and prerender them as well.
-
-
 
 <!-- Directories -->
 
@@ -296,8 +290,6 @@ nitro's temporary working directory for generating build-related files.
 - Default: `{ dir: '.output', serverDir: '.output/server', publicDir: '.output/public' }`
 
 Output directories for production bundle.
-
-
 
 <!-- Advanced -->
 
@@ -334,7 +326,6 @@ Preview and deploy command hints are usually filled by deployment presets.
 **⚠️ Caution! This is an advanced configuration. things can go wrong if misconfigured.**
 
 A custom error handler function for development errors.
-
 
 <!-- Rollup -->
 

--- a/docs/content/3.config/index.md
+++ b/docs/content/3.config/index.md
@@ -58,7 +58,9 @@ Storage configuration.
 
 - Default: `false`
 
-Enable bundle files loading time log.
+Enable timing information:
+
+- Bundle files loading time log
 
 ## `renderer`
 

--- a/docs/content/3.config/index.md
+++ b/docs/content/3.config/index.md
@@ -60,7 +60,7 @@ Storage configuration.
 
 Enable timing information:
 
-- Bundle files loading time log
+- Nitro startup time log
 
 ## `renderer`
 

--- a/docs/content/3.config/index.md
+++ b/docs/content/3.config/index.md
@@ -61,6 +61,7 @@ Storage configuration.
 Enable timing information:
 
 - Nitro startup time log
+- `Server-Timing` header on HTTP responses
 
 ## `renderer`
 

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -34,6 +34,10 @@ export async function createNitro(config: NitroConfig = {}): Promise<Nitro> {
     nitro.options.plugins.push("#internal/nitro/debug");
   }
 
+  if (nitro.options.timing) {
+    nitro.options.plugins.push("#internal/nitro/timing");
+  }
+
   // Logger config
   if (nitro.options.logLevel !== undefined) {
     nitro.logger.level = nitro.options.logLevel;

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -40,7 +40,7 @@ function createNitroApp(): NitroApp {
     onError: errorHandler,
   });
 
-  if(config.timing) {
+  if (config.timing) {
     h3App.use(config.app.baseURL, timingMiddleware);
   }
 

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -14,7 +14,6 @@ import {
 } from "unenv/runtime/fetch/index";
 import { createHooks, Hookable } from "hookable";
 import { useRuntimeConfig } from "./config";
-import { timingMiddleware } from "./timing";
 import { cachedEventHandler } from "./cache";
 import { createRouteRulesHandler, getRouteRulesForPath } from "./route-rules";
 import { plugins } from "#internal/nitro/virtual/plugins";
@@ -39,10 +38,6 @@ function createNitroApp(): NitroApp {
     debug: destr(process.env.DEBUG),
     onError: errorHandler,
   });
-
-  if (config.timing) {
-    h3App.use(config.app.baseURL, timingMiddleware);
-  }
 
   const router = createRouter();
 

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -40,7 +40,9 @@ function createNitroApp(): NitroApp {
     onError: errorHandler,
   });
 
-  h3App.use(config.app.baseURL, timingMiddleware);
+  if(config.timing) {
+    h3App.use(config.app.baseURL, timingMiddleware);
+  }
 
   const router = createRouter();
 

--- a/src/runtime/timing.ts
+++ b/src/runtime/timing.ts
@@ -2,14 +2,14 @@ import { eventHandler } from "h3";
 
 import { defineNitroPlugin } from "./plugin";
 
-export const globalTiming = globalThis.__timing__ || {
+const globalTiming = globalThis.__timing__ || {
   start: () => 0,
   end: () => 0,
   metrics: [],
 };
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing
-export const timingMiddleware = eventHandler((event) => {
+const timingMiddleware = eventHandler((event) => {
   const start = globalTiming.start();
 
   const _end = event.node.res.end;
@@ -33,7 +33,7 @@ export const timingMiddleware = eventHandler((event) => {
   }.bind(event.node.res);
 });
 
-export const timingPlugin = defineNitroPlugin((nitro) => {
+export default defineNitroPlugin((nitro) => {
   // Always add timing middleware to the beginning of handler stack
   nitro.h3App.stack.unshift({
     route: "/",

--- a/src/runtime/timing.ts
+++ b/src/runtime/timing.ts
@@ -34,5 +34,9 @@ export const timingMiddleware = eventHandler((event) => {
 });
 
 export const timingPlugin = defineNitroPlugin((nitro) => {
-  nitro.h3App.use(timingMiddleware);
+  // Always add timing middleware to the beginning of handler stack
+  nitro.h3App.stack.unshift({
+    route: "/",
+    handler: timingMiddleware,
+  });
 });

--- a/src/runtime/timing.ts
+++ b/src/runtime/timing.ts
@@ -8,30 +8,31 @@ export const globalTiming = globalThis.__timing__ || {
   metrics: [],
 };
 
-export const timingPlugin = defineNitroPlugin((nitro) => {
-  nitro.h3App.use(
-    eventHandler((event) => {
-      const start = globalTiming.start();
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing
+export const timingMiddleware = eventHandler((event) => {
+  const start = globalTiming.start();
 
-      const _end = event.node.res.end;
-      event.node.res.end = function (
-        chunk: any,
-        encoding: BufferEncoding,
-        cb?: () => void
-      ) {
-        const metrics = [
-          ["Generate", globalTiming.end(start)],
-          ...globalTiming.metrics,
-        ];
-        const serverTiming = metrics
-          .map((m) => `-;dur=${m[1]};desc="${encodeURIComponent(m[0])}"`)
-          .join(", ");
-        if (!event.node.res.headersSent) {
-          event.node.res.setHeader("Server-Timing", serverTiming);
-        }
-        _end.call(event.node.res, chunk, encoding, cb);
-        return this;
-      }.bind(event.node.res);
-    })
-  );
+  const _end = event.node.res.end;
+  event.node.res.end = function (
+    chunk: any,
+    encoding: BufferEncoding,
+    cb?: () => void
+  ) {
+    const metrics = [
+      ["Generate", globalTiming.end(start)],
+      ...globalTiming.metrics,
+    ];
+    const serverTiming = metrics
+      .map((m) => `-;dur=${m[1]};desc="${encodeURIComponent(m[0])}"`)
+      .join(", ");
+    if (!event.node.res.headersSent) {
+      event.node.res.setHeader("Server-Timing", serverTiming);
+    }
+    _end.call(event.node.res, chunk, encoding, cb);
+    return this;
+  }.bind(event.node.res);
+});
+
+export const timingPlugin = defineNitroPlugin((nitro) => {
+  nitro.h3App.use(timingMiddleware);
 });

--- a/src/runtime/timing.ts
+++ b/src/runtime/timing.ts
@@ -1,32 +1,37 @@
 import { eventHandler } from "h3";
 
+import { defineNitroPlugin } from "./plugin";
+
 export const globalTiming = globalThis.__timing__ || {
   start: () => 0,
   end: () => 0,
   metrics: [],
 };
 
-// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing
-export const timingMiddleware = eventHandler((event) => {
-  const start = globalTiming.start();
+export const timingPlugin = defineNitroPlugin((nitro) => {
+  nitro.h3App.use(
+    eventHandler((event) => {
+      const start = globalTiming.start();
 
-  const _end = event.res.end;
-  event.res.end = function (
-    chunk: any,
-    encoding: BufferEncoding,
-    cb?: () => void
-  ) {
-    const metrics = [
-      ["Generate", globalTiming.end(start)],
-      ...globalTiming.metrics,
-    ];
-    const serverTiming = metrics
-      .map((m) => `-;dur=${m[1]};desc="${encodeURIComponent(m[0])}"`)
-      .join(", ");
-    if (!event.res.headersSent) {
-      event.res.setHeader("Server-Timing", serverTiming);
-    }
-    _end.call(event.res, chunk, encoding, cb);
-    return this;
-  }.bind(event.res);
+      const _end = event.res.end;
+      event.res.end = function (
+        chunk: any,
+        encoding: BufferEncoding,
+        cb?: () => void
+      ) {
+        const metrics = [
+          ["Generate", globalTiming.end(start)],
+          ...globalTiming.metrics,
+        ];
+        const serverTiming = metrics
+          .map((m) => `-;dur=${m[1]};desc="${encodeURIComponent(m[0])}"`)
+          .join(", ");
+        if (!event.res.headersSent) {
+          event.res.setHeader("Server-Timing", serverTiming);
+        }
+        _end.call(event.res, chunk, encoding, cb);
+        return this;
+      }.bind(event.res);
+    })
+  );
 });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -57,6 +57,7 @@ export async function setupTest(preset: string) {
       "/rules/nested/**": { redirect: "/base", headers: { "x-test": "test" } },
       "/rules/nested/override": { redirect: { to: "/other" } },
     },
+    timing: true,
   }));
 
   if (ctx.isDev) {
@@ -239,5 +240,15 @@ export function testNitro(
     if (additionalTests) {
       additionalTests(ctx, callHandler);
     }
+  }
+
+  if (ctx.nitro!.options.timing) {
+    it("set server timing header", async () => {
+      const { data, status, headers } = await callHandler({
+        url: "/api/hello",
+      });
+      expect(status).toBe(200);
+      expect(headers["server-timing"]).toMatch(/-;dur=\d+;desc="Generate"/);
+    });
   }
 }

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -57,7 +57,7 @@ export async function setupTest(preset: string) {
       "/rules/nested/**": { redirect: "/base", headers: { "x-test": "test" } },
       "/rules/nested/override": { redirect: { to: "/other" } },
     },
-    timing: true,
+    timing: preset !== "cloudflare" && preset !== "vercel-edge",
   }));
 
   if (ctx.isDev) {


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

Fix https://github.com/nuxt/framework/issues/9824

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x]   📖 Documentation (updates to the documentation or readme)
- [x]  🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

`timing` config is for enabling bundles loading time instead of timing header, this pr is improving the accuracy of description.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
