### PR TITLE
fix(aws-lambda): omit cookies from v1 response

### DIFF
--- a/src/runtime/entries/aws-lambda.ts
+++ b/src/runtime/entries/aws-lambda.ts
@@ -57,17 +57,20 @@ export const handler = async function handler(
     body: event.body, // TODO: handle event.isBase64Encoded
   });
 
-  const outgoingCookies = r.headers["set-cookie"];
-  const cookies = Array.isArray(outgoingCookies)
-    ? outgoingCookies
-    : outgoingCookies?.split(",") || [];
-
-  return {
-    cookies,
+  const response: Result = {
     statusCode: r.status,
     headers: normalizeOutgoingHeaders(r.headers),
     body: r.body.toString(),
   };
+
+  if ("cookies" in event || 'rawPath' in event) {
+    const outgoingCookies = r.headers["set-cookie"];
+    (response as Exclude<APIGatewayProxyResultV2, string>).cookies = Array.isArray(outgoingCookies)
+      ? outgoingCookies
+      : outgoingCookies?.split(",") || [];
+  }
+
+  return response
 };
 
 function normalizeIncomingHeaders(headers?: APIGatewayProxyEventHeaders) {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/unjs/nitro/issues/504

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This omits responding with cookies on aws lambda v1 format.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
