### PR TITLE
feat: support `maxAge` for public assets

### DIFF
--- a/src/dev/server.ts
+++ b/src/dev/server.ts
@@ -134,7 +134,15 @@ export function createDevServer(nitro: Nitro): NitroDevServer {
   // Serve asset dirs
   for (const asset of nitro.options.publicAssets) {
     const url = joinURL(nitro.options.runtimeConfig.app.baseURL, asset.baseURL);
-    app.use(url, fromNodeMiddleware(serveStatic(asset.dir)));
+    app.use(
+      url,
+      fromNodeMiddleware(
+        serveStatic(asset.dir, {
+          maxAge: asset.fallthrough ? undefined : asset.maxAge * 1000,
+          immutable: asset.fallthrough ? undefined : true,
+        })
+      )
+    );
     if (!asset.fallthrough) {
       app.use(url, fromNodeMiddleware(servePlaceholder()));
     }

--- a/src/dev/server.ts
+++ b/src/dev/server.ts
@@ -134,15 +134,7 @@ export function createDevServer(nitro: Nitro): NitroDevServer {
   // Serve asset dirs
   for (const asset of nitro.options.publicAssets) {
     const url = joinURL(nitro.options.runtimeConfig.app.baseURL, asset.baseURL);
-    app.use(
-      url,
-      fromNodeMiddleware(
-        serveStatic(asset.dir, {
-          maxAge: asset.fallthrough ? undefined : asset.maxAge * 1000,
-          immutable: asset.fallthrough ? undefined : true,
-        })
-      )
-    );
+    app.use(url, fromNodeMiddleware(serveStatic(asset.dir)));
     if (!asset.fallthrough) {
       app.use(url, fromNodeMiddleware(servePlaceholder()));
     }

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -63,12 +63,12 @@ export async function createNitro(config: NitroConfig = {}): Promise<Nitro> {
     const isTopLevel = asset.baseURL === "/";
     asset.fallthrough = asset.fallthrough ?? isTopLevel;
     asset.maxAge = asset.maxAge ?? 0;
-    if (asset.maxAge) {
-      options.routeRules[asset.baseURL] = defu(
-        options.routeRules[asset.baseURL],
+    if (asset.maxAge && !asset.fallthrough) {
+      options.routeRules[asset.baseURL + "/**"] = defu(
+        options.routeRules[asset.baseURL + "/**"],
         {
           headers: {
-            "cache-control": `max-age=${asset.maxAge}, public, immutable`,
+            "cache-control": `public, max-age=${asset.maxAge}, immutable`,
           },
         }
       );

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { resolve } from "pathe";
 import { createHooks, createDebugger } from "hookable";
 import { createUnimport } from "unimport";
+import defu from "defu";
 import consola from "consola";
 import type { NitroConfig, Nitro } from "./types";
 import { loadOptions } from "./options";
@@ -61,7 +62,17 @@ export async function createNitro(config: NitroConfig = {}): Promise<Nitro> {
     asset.baseURL = asset.baseURL || "/";
     const isTopLevel = asset.baseURL === "/";
     asset.fallthrough = asset.fallthrough ?? isTopLevel;
-    asset.maxAge = asset.maxAge ?? (isTopLevel ? 0 : 60);
+    asset.maxAge = asset.maxAge ?? 0;
+    if (asset.maxAge) {
+      options.routeRules[asset.baseURL] = defu(
+        options.routeRules[asset.baseURL],
+        {
+          headers: {
+            "cache-control": `max-age=${asset.maxAge}, public, immutable`,
+          },
+        }
+      );
+    }
   }
 
   // Server assets

--- a/src/options.ts
+++ b/src/options.ts
@@ -285,10 +285,9 @@ export async function loadOptions(
     app: {
       baseURL: options.baseURL,
     },
-    nitro: {
-      routeRules: options.routeRules,
-    },
+    nitro: {},
   });
+  options.runtimeConfig.nitro.routeRules = options.routeRules;
 
   for (const publicAsset of options.publicAssets) {
     publicAsset.dir = resolve(options.srcDir, publicAsset.dir);

--- a/src/runtime/static.ts
+++ b/src/runtime/static.ts
@@ -96,11 +96,5 @@ export default eventHandler((event) => {
     event.node.res.setHeader("Content-Length", asset.size);
   }
 
-  // TODO: Asset dir cache control
-  // if (isBuildAsset) {
-  // const TWO_DAYS = 2 * 60 * 60 * 24
-  // event.node.res.setHeader('Cache-Control', `max-age=${TWO_DAYS}, immutable`)
-  // }
-
   return readAsset(id);
 });

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -18,12 +18,13 @@ export default defineNitroConfig({
     {
       baseName: "files",
       dir: "files",
-    }
+    },
   ],
   publicAssets: [
     {
       baseURL: "build",
       dir: "public/build",
+      maxAge: 3600,
     },
   ],
   nodeModulesDirs: ["./_/node_modules"],


### PR DESCRIPTION
Allow using `maxAge` for `publicAssets: []` option to provide caching headers:

```js
  publicAssets: [
    {
      baseURL: "dist",
      dir: "public/dist",
      maxAge: 3600,
    },
  ],
```

Remarks:
- Using route rules in production we can also map caching to native providers
- Default (and unused) 60sec is removed for public dirs allowing opt-in control of this feature
- This feature is auto-disabled for `/` prefix and `fallthrough` paths since another handler might respond
- This feature is only effective on production to reduce chance of misconfiguration and development mode issues
- `immutable` and `public` conditions enabled
- One can directly use routeRules to apply for development or any other custom beahior 

Another fix is also included that allows to modify `nitro.options.routeRules` after init syncing with runtimeConfig object.