### PR TITLE
fix(prerender): update preview command to serve matching routes

### DIFF
--- a/src/presets/nitro-prerender.ts
+++ b/src/presets/nitro-prerender.ts
@@ -7,7 +7,7 @@ export const nitroPrerender = defineNitroPreset({
     serverDir: "{{ buildDir }}/prerender",
   },
   commands: {
-    preview: "npx serve -s ./public",
+    preview: "npx serve ./public",
   },
   externals: { trace: false },
 });


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/14454

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There is a bug in `serve -s` that renders _all_ responses, not just 404s, with base `index.html`: https://github.com/vercel/serve/issues/722. This PR removes the flag. 404s will now be rendered with `/404.html`, which Nuxt now outputs, so this should not have any downside downstream on Nuxt - or, I think, in any other project depending on this.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
