### PR TITLE
feat: add `shouldBypassCache` option to cache utils

### DIFF
--- a/docs/content/1.guide/1.introduction/5.cache.md
+++ b/docs/content/1.guide/1.introduction/5.cache.md
@@ -20,6 +20,7 @@ const cachedFn = cachedEventHandler(fn, options);
 - `swr`: Enable Stale-While-Revalidate behavior. Enabled by default.
 - `base`: Name of the storage mointpoint to use for caching (`/cache` by default)
 - `shouldInvalidateCache`: A function that returns a boolean to invalidate the current cache and create a new one.
+- `shouldBypassCache`: A function that returns a boolean to bypass the current cache without invalidating the existing entry.
 
 ## Examples
 

--- a/examples/cached-handler/routes/index.ts
+++ b/examples/cached-handler/routes/index.ts
@@ -1,4 +1,6 @@
 export default defineCachedEventHandler(async () => {
   await new Promise((resolve) => setTimeout(resolve, 1000));
   return `Response generated at ${new Date().toISOString()} (took 1 second)`;
+}, {
+  shouldBypassCache: (e) => e.node.req.url.includes("preview")
 });

--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -22,6 +22,7 @@ export interface CacheOptions<T = any> {
   transform?: (entry: CacheEntry<T>, ...args: any[]) => any;
   validate?: (entry: CacheEntry<T>) => boolean;
   shouldInvalidateCache?: (...args: any[]) => boolean;
+  shouldBypassCache?: (...args: any[]) => boolean;
   group?: string;
   integrity?: any;
   maxAge?: number;
@@ -117,6 +118,10 @@ export function defineCachedFunction<T = any>(
   }
 
   return async (...args) => {
+    const shouldBypassCache = opts.shouldBypassCache?.(...args);
+    if (shouldBypassCache) {
+      return fn(...args);
+    }
     const key = (opts.getKey || getKey)(...args);
     const shouldInvalidateCache = opts.shouldInvalidateCache?.(...args);
     const entry = await get(key, () => fn(...args), shouldInvalidateCache);
@@ -143,6 +148,7 @@ export interface ResponseCacheEntry<T = any> {
 export interface CachedEventHandlerOptions<T = any>
   extends Omit<CacheOptions<ResponseCacheEntry<T>>, "transform" | "validate"> {
   shouldInvalidateCache?: (event: H3Event) => boolean;
+  shouldBypassCache?: (event: H3Event) => boolean;
   getKey?: (event: H3Event) => string;
   headersOnly?: boolean;
 }


### PR DESCRIPTION

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In the spirit of #746, this adds an option to bypass the whole cache logic (so getKey isn't even called), while leaving the existing cache entry untouched. Good for a ?preview param without affecting live, but also certain subpaths you never want cached.

Idk if this needs an issue/discussion, it was easier to implement and test than to start an issue, lol

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
