### PR TITLE
fix(scan): do not dedup middleware handlers

### DIFF
--- a/src/scan.ts
+++ b/src/scan.ts
@@ -21,6 +21,7 @@ export async function scanHandlers(nitro: Nitro) {
     .flatMap((h) => h.handlers)
     .filter((h, index, array) => {
       return (
+        h.middleware ||
         array.findIndex(
           (h2) => h.route === h2.route && h.method === h2.method
         ) === index


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/18518

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- x ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently we are deduplicating middleware, which means only one middleware will ever be included in the built app. We should probably only deduplicate routes that have a path.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
