### PR TITLE
fix: resolve server assets dir relative to `srcDir`

### DIFF
--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -78,7 +78,7 @@ export async function createNitro(config: NitroConfig = {}): Promise<Nitro> {
   // Server assets
   nitro.options.serverAssets.push({
     baseName: "server",
-    dir: "assets",
+    dir: resolve(nitro.options.srcDir, "assets"),
   });
 
   // Plugins


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/18587

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We are now resolving server assets dirs before this point (#825), when `options` are resolved. We probably still need to resolve server dirs when adding them after this point.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
