### PR TITLE
fix(cache): validate using entry `expires`

### DIFF
--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -67,14 +67,14 @@ export function defineCachedFunction<T = any>(
       ((await useStorage().getItem(cacheKey)) as any) || {};
 
     const ttl = (opts.maxAge ?? opts.maxAge ?? 0) * 1000;
-    if (ttl) {
+    if (ttl && !entry.expires) {
       entry.expires = Date.now() + ttl;
     }
 
     const expired =
       shouldInvalidateCache ||
       entry.integrity !== integrity ||
-      (ttl && Date.now() - (entry.mtime || 0) > ttl) ||
+      (entry.expires && Date.now() > entry.expires) ||
       !validate(entry);
 
     const _resolve = async () => {


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR more accurately invalidates files based on their set expiry time, rather than using the maxAge + modified time.

The previous logic works correctly when using the function as intended.

However, I need to implement dynamic maxAge times. It's a bit of a hack but I'm using `validate(entry)` to modify the expires time that is stored. The issue is that the previous logic looks like it won't honor my custom `expires` time and will always reset it.

Having a purposeful exposed function to dynamically set the entry options before they are stored would be nice, but out of the scope of this PR.

Here is the code sample:

```ts
 const generateSvg = defineCachedFunction<{ options: OgImageOptions }>(
    async () => {
      const options = await fetchOptions(path)
      setHeader(e, 'Content-Type', 'image/svg+xml')
      const provider = await useProvider(options.provider!)
      return { options, svg: provider.createSvg(withBase(path, useHostname(e)), options) }
    },
    {
      validate(entry) {
        const options = entry.value?.options || {}
        if (options.maxAge) {
          // modify the expires to user provided maxAge
          entry.expires = Date.now() + options.maxAge * 1000
        }
        else if (options?.static) {
          // modify the mtime to 1 hour
          entry.expires = Date.now() + 60 * 60 * 1000
        }
        return true
      },
      getKey: () => `nuxt-og-image:svg:${path}`,
      maxAge: 0,
      swr: true,
    },
  )
```

It's possible I haven't considered something, but I believe that this logic makes more sense generally. There doesn't seem to be any tests around the caching, so please sanity-check my logic.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
