### PR TITLE
fix(vercel): allow non-glob cache rules to apply to `/`

### DIFF
--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -190,6 +190,15 @@ function generateBuildConfig(nitro: Nitro) {
             dest: generateEndpoint(key) + "?url=$url",
           };
         }),
+      // If we are using a prerender function for /, then we need to write this explicitly
+      ...(nitro.options.routeRules["/"]?.cache
+        ? [
+            {
+              src: "(?<url>/)",
+              dest: "/__nitro-index",
+            },
+          ]
+        : []),
       // If we are using a prerender function as a fallback, then we do not need to output
       // the below fallback route as well
       ...(!nitro.options.routeRules["/**"]?.cache ||
@@ -209,6 +218,9 @@ function generateBuildConfig(nitro: Nitro) {
 }
 
 function generateEndpoint(url: string) {
+  if (url === "/") {
+    return "/__nitro-index";
+  }
   return url.includes("/**")
     ? "/__nitro-" +
         withoutLeadingSlash(url.replace(/\/\*\*.*/, "").replace(/[^a-z]/g, "-"))


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/unjs/nitro/issues/902

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Because of how the Vercel Build Output API works, we can't generate a file-only routing solution for a route rule that is `/`; in this very specific case we need to add it to the config as well.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
