### PR TITLE
feat(cloudflare): `cacheControl` support for public assets with with `maxAge`

### DIFF
--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -84,9 +84,11 @@ export function readAsset (id) {
       },
       // #internal/nitro/virtual/public-assets
       "#internal/nitro/virtual/public-assets": () => {
-        const publicAssetBases = nitro.options.publicAssets
-          .filter((dir) => !dir.fallthrough && dir.baseURL !== "/")
-          .map((dir) => dir.baseURL);
+        const publicAssetBases = Object.fromEntries(
+          nitro.options.publicAssets
+            .filter((dir) => !dir.fallthrough && dir.baseURL !== "/")
+            .map((dir) => [dir.baseURL, { maxAge: dir.maxAge }])
+        );
 
         return `
 import assets from '#internal/nitro/virtual/public-assets-data'
@@ -104,10 +106,17 @@ export function isPublicAssetURL(id = '') {
   if (assets[id]) {
     return true
   }
-  for (const base of publicAssetBases) {
+  for (const base in publicAssetBases) {
     if (id.startsWith(base)) { return true }
   }
   return false
+}
+
+export function getPublicAssetMeta(id = '') {
+  for (const base in publicAssetBases) {
+    if (id.startsWith(base)) { return publicAssetBases[base] }
+  }
+  return {}
 }
 
 export function getAsset (id) {

--- a/src/runtime/entries/cloudflare.ts
+++ b/src/runtime/entries/cloudflare.ts
@@ -7,7 +7,7 @@ import { withoutBase } from "ufo";
 import { requestHasBody } from "../utils";
 import { nitroApp } from "#internal/nitro/app";
 import { useRuntimeConfig } from "#internal/nitro";
-import { isPublicAssetURL } from "#internal/nitro/virtual/public-assets";
+import { getPublicAssetMeta } from "#internal/nitro/virtual/public-assets";
 
 addEventListener("fetch", (event: any) => {
   event.respondWith(handleEvent(event));
@@ -50,11 +50,11 @@ async function handleEvent(event: FetchEvent) {
 
 function assetsCacheControl(_request) {
   const url = new URL(_request.url);
-
-  if (isPublicAssetURL(url.pathname)) {
+  const meta = getPublicAssetMeta(url.pathname);
+  if (meta.maxAge) {
     return {
-      browserTTL: 31_536_000,
-      edgeTTL: 31_536_000,
+      browserTTL: meta.maxAge,
+      edgeTTL: meta.maxAge,
     };
   }
   return {};

--- a/src/runtime/entries/cloudflare.ts
+++ b/src/runtime/entries/cloudflare.ts
@@ -5,8 +5,9 @@ import {
 } from "@cloudflare/kv-asset-handler";
 import { withoutBase } from "ufo";
 import { requestHasBody } from "../utils";
-import { nitroApp } from "../app";
+import { nitroApp } from "#internal/nitro/app";
 import { useRuntimeConfig } from "#internal/nitro";
+import { isPublicAssetURL } from "#internal/nitro/virtual/public-assets";
 
 addEventListener("fetch", (event: any) => {
   event.respondWith(handleEvent(event));
@@ -48,13 +49,14 @@ async function handleEvent(event: FetchEvent) {
 }
 
 function assetsCacheControl(_request) {
-  // TODO: Detect public asset bases
-  // if (request.url.startsWith(buildAssetsURL())) {
-  //   return {
-  //     browserTTL: 31536000,
-  //     edgeTTL: 31536000
-  //   }
-  // }
+  const url = new URL(_request.url);
+
+  if (isPublicAssetURL(url.pathname)) {
+    return {
+      browserTTL: 31_536_000,
+      edgeTTL: 31_536_000
+    }
+  }
   return {};
 }
 

--- a/src/runtime/entries/cloudflare.ts
+++ b/src/runtime/entries/cloudflare.ts
@@ -54,8 +54,8 @@ function assetsCacheControl(_request) {
   if (isPublicAssetURL(url.pathname)) {
     return {
       browserTTL: 31_536_000,
-      edgeTTL: 31_536_000
-    }
+      edgeTTL: 31_536_000,
+    };
   }
   return {};
 }

--- a/src/runtime/virtual/public-assets.d.ts
+++ b/src/runtime/virtual/public-assets.d.ts
@@ -1,4 +1,5 @@
 export const publicAssetBases: string[];
 export const isPublicAssetURL: (id: string) => boolean;
+export const getPublicAssetMeta: (id: string) => { maxAge?: number };
 export const readAsset: (id: string) => Promise<Buffer>;
 export const getAsset: (id: string) => any;


### PR DESCRIPTION
### 🔗 Linked issue
https://github.com/unjs/nitro/discussions/919

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

For now if you serve website to Cloudflare Workers you exceed free (and even paid) limits very fast because each request serves assets directly from worker and never cache in browser. 

I think that it will be great to get `maxAge` from publicAssetURLOptions, but i didn't touch rollup virtual code to make it work. 

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
