### PR TITLE
feat(firebase): use nodejs 18 as default runtime

### DIFF
--- a/docs/content/2.deploy/providers/firebase.md
+++ b/docs/content/2.deploy/providers/firebase.md
@@ -1,6 +1,6 @@
 ---
 title: Firebase
-description: 'Discover Firebase preset for Nitro!'
+description: "Discover Firebase preset for Nitro!"
 ---
 
 **Preset:** `firebase` ([switch to this preset](/deploy/#changing-the-deployment-preset))
@@ -45,6 +45,7 @@ yarn global add firebase-tools
 npm install -g firebase-tools
 ```
 
+**Note**: You need to be on [^11.18.0](https://github.com/firebase/firebase-tools/releases/tag/v11.18.0) to deploy a nodejs18 function.
 
 #### Initialize your Firebase project
 

--- a/src/presets/firebase.ts
+++ b/src/presets/firebase.ts
@@ -65,17 +65,19 @@ async function writeRoutes(nitro: Nitro) {
     return obj;
   }, {} as Record<string, string>);
 
-  let nodeVersion = "14";
+  let nodeVersion = "18";
+  const supportedNodeVersions = ["18", "16", "14", "12", "10"];
+  //    ^ See https://cloud.google.com/functions/docs/concepts/nodejs-runtime
   try {
     const currentNodeVersion = JSON.parse(
       await readFile(join(nitro.options.rootDir, "package.json"), "utf8")
     ).engines.node;
-    if (["16", "14"].includes(currentNodeVersion)) {
+    if (supportedNodeVersions.includes(currentNodeVersion)) {
       nodeVersion = currentNodeVersion;
     }
   } catch {
     const currentNodeVersion = process.versions.node.slice(0, 2);
-    if (["16", "14"].includes(currentNodeVersion)) {
+    if (supportedNodeVersions.includes(currentNodeVersion)) {
       nodeVersion = currentNodeVersion;
     }
   }


### PR DESCRIPTION


<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

Fixes #924

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Node 18 is the current LTS version. It is the [recommended cloud function runtime](https://cloud.google.com/functions/docs/concepts/nodejs-runtime) and is a [prerequisite for Nuxt 3](https://nuxt.com/docs/getting-started/installation). This PR changes the default runtime from 14 to 18, and falls back to an older version if it is specified in the `engines` field in `package.json`. 
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
