### PR TITLE
feat: support runtime proxy using route rules

### DIFF
--- a/docs/content/3.config/index.md
+++ b/docs/content/3.config/index.md
@@ -1,17 +1,16 @@
 ---
 title: Configuration
 aside: false
-description: 'Customize your Nitro app with a configuration file!'
+description: "Customize your Nitro app with a configuration file!"
 ---
 
 In order to customize nitro's behavior, we create a file named `nitro.config.ts`.
 
 ```js
 // nitro.config.ts
-import { defineNitroConfig } from 'nitropack'
+import { defineNitroConfig } from "nitropack";
 
-export default defineNitroConfig({
-})
+export default defineNitroConfig({});
 ```
 
 ## Config Reference
@@ -219,11 +218,11 @@ Path to a custom runtime error handler. Replacing nitro's built-in error page.
 **Example:**
 
 ```js [nitro.config]
-import { defineNitroConfig } from 'nitropack'
+import { defineNitroConfig } from "nitropack";
 
 export default defineNitroConfig({
-  errorHandler: '~/error'
-})
+  errorHandler: "~/error",
+});
 ```
 
 ```js [error.ts]
@@ -253,7 +252,8 @@ When `cache` option is set, handlers matching pattern will be automatically wrap
     '/blog/**': { cache: { /* cache options*/ } },
     '/assets/**': { headers: { 'cache-control': 's-maxage=0' } },
     '/api/v1/**': { cors: true, headers: { 'access-control-allowed-methods': 'GET' } },
-    '/old-page': { redirect: '/new-page' }
+    '/old-page': { redirect: '/new-page' },
+    '/proxy/**': { proxy: 'https://example.com' }
   }
 }
 ```

--- a/docs/content/3.config/index.md
+++ b/docs/content/3.config/index.md
@@ -253,7 +253,8 @@ When `cache` option is set, handlers matching pattern will be automatically wrap
     '/assets/**': { headers: { 'cache-control': 's-maxage=0' } },
     '/api/v1/**': { cors: true, headers: { 'access-control-allowed-methods': 'GET' } },
     '/old-page': { redirect: '/new-page' },
-    '/proxy/**': { proxy: 'https://example.com' }
+    '/proxy/example': { proxy: 'https://example.com' },
+    "/proxy/api/**": { proxy: '/api/proxied/**' },
   }
 }
 ```

--- a/docs/content/3.config/index.md
+++ b/docs/content/3.config/index.md
@@ -254,7 +254,7 @@ When `cache` option is set, handlers matching pattern will be automatically wrap
     '/api/v1/**': { cors: true, headers: { 'access-control-allowed-methods': 'GET' } },
     '/old-page': { redirect: '/new-page' },
     '/proxy/example': { proxy: 'https://example.com' },
-    "/proxy/api/**": { proxy: '/api/proxied/**' },
+    "/proxy/**": { proxy: '/api/**' },
   }
 }
 ```

--- a/src/options.ts
+++ b/src/options.ts
@@ -247,6 +247,7 @@ export async function loadOptions(
     const routeRules: NitroRouteRules = {
       ...routeConfig,
       redirect: undefined,
+      proxy: undefined,
     };
     // Redirect
     if (routeConfig.redirect) {
@@ -257,6 +258,13 @@ export async function loadOptions(
           ? { to: routeConfig.redirect }
           : routeConfig.redirect),
       };
+    }
+    // Proxy
+    if (routeConfig.proxy) {
+      routeRules.proxy =
+        typeof routeConfig.proxy === "string"
+          ? { to: routeConfig.proxy }
+          : routeConfig.proxy;
     }
     // CORS
     if (routeConfig.cors) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -265,6 +265,10 @@ export async function loadOptions(
         typeof routeConfig.proxy === "string"
           ? { to: routeConfig.proxy }
           : routeConfig.proxy;
+      if (path.endsWith("/**")) {
+        // Internal flag
+        (routeRules.proxy as any)._proxyStripBase = path.slice(0, -3);
+      }
     }
     // CORS
     if (routeConfig.cors) {

--- a/src/runtime/route-rules.ts
+++ b/src/runtime/route-rules.ts
@@ -36,7 +36,12 @@ export function createRouteRulesHandler() {
     if (routeRules.proxy) {
       let target = routeRules.proxy.to;
       if (target.endsWith("/**")) {
-        target = joinURL(target.slice(0, -3), event.path);
+        let targetPath = event.path;
+        const strpBase = (routeRules.proxy as any)._proxyStripBase;
+        if (strpBase) {
+          targetPath = withoutBase(targetPath, strpBase);
+        }
+        target = joinURL(target.slice(0, -3), targetPath);
       }
       return proxyRequest(event, target, {
         fetch: $fetch.raw as any,

--- a/src/runtime/route-rules.ts
+++ b/src/runtime/route-rules.ts
@@ -35,7 +35,7 @@ export function createRouteRulesHandler() {
     // Apply proxy options
     if (routeRules.proxy) {
       return proxyRequest(event, routeRules.proxy.to, {
-        // fetch: $fetch.raw as any, TODO: Support local fetch as well
+        fetch: $fetch.raw as any,
         ...routeRules.proxy,
       });
     }

--- a/src/runtime/route-rules.ts
+++ b/src/runtime/route-rules.ts
@@ -7,7 +7,7 @@ import {
 } from "h3";
 import defu from "defu";
 import { createRouter as createRadixRouter, toRouteMatcher } from "radix3";
-import { withoutBase } from "ufo";
+import { joinURL, withoutBase } from "ufo";
 import { useRuntimeConfig } from "./config";
 import type { NitroRouteRules } from "nitropack";
 
@@ -34,7 +34,11 @@ export function createRouteRulesHandler() {
     }
     // Apply proxy options
     if (routeRules.proxy) {
-      return proxyRequest(event, routeRules.proxy.to, {
+      let target = routeRules.proxy.to;
+      if (target.endsWith("/**")) {
+        target = joinURL(target.slice(0, -3), event.path);
+      }
+      return proxyRequest(event, target, {
         fetch: $fetch.raw as any,
         ...routeRules.proxy,
       });

--- a/src/runtime/route-rules.ts
+++ b/src/runtime/route-rules.ts
@@ -1,4 +1,10 @@
-import { eventHandler, H3Event, sendRedirect, setHeaders } from "h3";
+import {
+  eventHandler,
+  H3Event,
+  sendRedirect,
+  setHeaders,
+  proxyRequest,
+} from "h3";
 import defu from "defu";
 import { createRouter as createRadixRouter, toRouteMatcher } from "radix3";
 import { withoutBase } from "ufo";
@@ -25,6 +31,13 @@ export function createRouteRulesHandler() {
         routeRules.redirect.to,
         routeRules.redirect.statusCode
       );
+    }
+    // Apply proxy options
+    if (routeRules.proxy) {
+      return proxyRequest(event, routeRules.proxy.to, {
+        // fetch: $fetch.raw as any, TODO: Support local fetch as well
+        ...routeRules.proxy,
+      });
     }
   });
 }

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -10,6 +10,7 @@ import type { RollupCommonJSOptions } from "@rollup/plugin-commonjs";
 import type { RollupWasmOptions } from "@rollup/plugin-wasm";
 import type { Storage, BuiltinDriverName } from "unstorage";
 import type { ServerOptions as HTTPProxyOptions } from "http-proxy";
+import type { ProxyOptions } from "h3";
 import type { NodeExternalsOptions } from "../rollup/plugins/externals";
 import type { RollupConfig } from "../rollup/config";
 import type { Options as EsbuildOptions } from "../rollup/plugins/esbuild";
@@ -124,6 +125,7 @@ export interface NitroRouteConfig {
   headers?: Record<string, string>;
   redirect?: string | { to: string; statusCode?: HTTPStatusCode };
   prerender?: boolean;
+  proxy?: string | ({ to: string } & ProxyOptions);
 
   // Shortcuts
   cors?: boolean;
@@ -134,6 +136,7 @@ export interface NitroRouteConfig {
 export interface NitroRouteRules
   extends Omit<NitroRouteConfig, "redirect" | "cors" | "swr" | "static"> {
   redirect?: { to: string; statusCode: HTTPStatusCode };
+  proxy?: { to: string } & ProxyOptions;
 }
 
 export interface NitroOptions extends PresetOptions {


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

#113

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Support runtime proxy using route rules and `h3.proxyRequest` (universally works with fetch)

```js
{
  routeRules: {
    '/proxy/example': { proxy: 'https://example.com' },
    "/proxy/api/**": { proxy: '/api/proxied/**' },
  }
}
```

Local support is pending https://github.com/unjs/h3/pull/321

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
