### PR TITLE
feat(cloudflare): expose `event.context.cf`

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "source-map-support": "^0.5.21",
     "std-env": "^3.3.2",
     "ufo": "^1.0.1",
-    "unenv": "^1.1.0",
+    "unenv": "^1.1.1",
     "unimport": "^2.2.4",
     "unstorage": "^1.1.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,7 @@ importers:
       typescript: ^4.9.5
       ufo: ^1.0.1
       unbuild: ^1.1.1
-      unenv: ^1.1.0
+      unenv: ^1.1.1
       unimport: ^2.2.4
       unstorage: ^1.1.3
       vitest: ^0.28.4
@@ -141,7 +141,7 @@ importers:
       source-map-support: 0.5.21
       std-env: 3.3.2
       ufo: 1.0.1
-      unenv: 1.1.0
+      unenv: 1.1.1
       unimport: 2.2.4_rollup@3.14.0
       unstorage: 1.1.3
     devDependencies:
@@ -5118,8 +5118,8 @@ packages:
     engines: {node: '>=12.18'}
     dev: true
 
-  /unenv/1.1.0:
-    resolution: {integrity: sha512-7jLgwQ5iDHVcDoW2rCJ1vB1jUw7zT+21LC+vWCs9SWWsycgk1d4SHvPUYRsu5wNuY7hqoArgjr4xQKmIkXyAmA==}
+  /unenv/1.1.1:
+    resolution: {integrity: sha512-AfQ+sKCdeSPX/rp0tL9LZz3cAu1Mt0i9UADuN1MtbsITKDS2PqSx8LQUBMf8lKuziitIWXXwU6JXrmzARFVSRw==}
     dependencies:
       defu: 6.1.2
       mime: 3.0.0

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -48,7 +48,7 @@ function createNitroApp(): NitroApp {
   h3App.use(
     eventHandler((event) => {
       // Support platform context provided by local fetch
-      const envContext = (event.node.req as any).__unenv__?.context;
+      const envContext = (event.node.req as any).__unenv__;
       if (envContext) {
         Object.assign(event.context, envContext);
       }

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -2,6 +2,7 @@ import {
   App as H3App,
   createApp,
   createRouter,
+  eventHandler,
   lazyEventHandler,
   Router,
   toNodeListener,
@@ -42,6 +43,17 @@ function createNitroApp(): NitroApp {
   const router = createRouter();
 
   h3App.use(createRouteRulesHandler());
+
+  // A generic event handler give nitro acess to the requests
+  h3App.use(
+    eventHandler((event) => {
+      // Support platform context provided by local fetch
+      const envContext = (event.node.req as any).__unenv__?.context;
+      if (envContext) {
+        Object.assign(event.context, envContext);
+      }
+    })
+  );
 
   for (const h of handlers) {
     let handler = h.lazy ? lazyEventHandler(h.handler) : h.handler;

--- a/src/runtime/entries/cloudflare.ts
+++ b/src/runtime/entries/cloudflare.ts
@@ -31,6 +31,9 @@ async function handleEvent(event: FetchEvent) {
 
   const r = await nitroApp.localCall({
     event,
+    context: {
+      cf: (event.request as any).cf,
+    },
     url: url.pathname + url.search,
     host: url.hostname,
     protocol: url.protocol,

--- a/src/runtime/entries/cloudflare.ts
+++ b/src/runtime/entries/cloudflare.ts
@@ -32,6 +32,7 @@ async function handleEvent(event: FetchEvent) {
   const r = await nitroApp.localCall({
     event,
     context: {
+      // https://developers.cloudflare.com/workers//runtime-apis/request#incomingrequestcfproperties
       cf: (event.request as any).cf,
     },
     url: url.pathname + url.search,


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

resolves #391

closes #677

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR exposes cloudflare [request context](https://developers.cloudflare.com/workers//runtime-apis/request#incomingrequestcfproperties) as `event.context.cf`. 

Implementation is based on new unenv support. Any other platform based on localFetch, can expose the same context by passing `{ context: {} }` to the request init.

A new generic handler is added to nitro. It will be used later for other purposes as well.

Note: For nested `$fetch`, we should explicitly pass the `cf` to be proxied:

```js
  await $fetch("/test", { context: { cf: event.context.cf } });
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
