### PR TITLE
fix(firebase): Use a Set for supported node versions

### DIFF
--- a/src/presets/firebase.ts
+++ b/src/presets/firebase.ts
@@ -66,18 +66,18 @@ async function writeRoutes(nitro: Nitro) {
   }, {} as Record<string, string>);
 
   let nodeVersion = "18";
-  const supportedNodeVersions = ["18", "16", "14", "12", "10"];
+  const supportedNodeVersions = new Set(["18", "16", "14", "12", "10"]);
   //    ^ See https://cloud.google.com/functions/docs/concepts/nodejs-runtime
   try {
     const currentNodeVersion = JSON.parse(
       await readFile(join(nitro.options.rootDir, "package.json"), "utf8")
     ).engines.node;
-    if (supportedNodeVersions.includes(currentNodeVersion)) {
+    if (supportedNodeVersions.has(currentNodeVersion)) {
       nodeVersion = currentNodeVersion;
     }
   } catch {
     const currentNodeVersion = process.versions.node.slice(0, 2);
-    if (supportedNodeVersions.includes(currentNodeVersion)) {
+    if (supportedNodeVersions.has(currentNodeVersion)) {
       nodeVersion = currentNodeVersion;
     }
   }


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
```bash
Error:   69:9  error  `supportedNodeVersions` should be a `Set`, and use `supportedNodeVersions.has()` to check existence or non-existence  unicorn/prefer-set-has
```

Pr #925 introduced a lint error. This PR fixes it. 
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
