### PR TITLE
fix(cloudflare): use full mime db

### DIFF
--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -37,6 +37,7 @@ export const cloudflarePages = defineNitroPreset({
   },
   alias: {
     // Hotfix: Cloudflare appends /index.html if mime is not found and things like ico are not in standard lite.js!
+    // https://github.com/unjs/nitro/pull/933
     _mime: "mime/index.js",
   },
   rollupConfig: {

--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -35,6 +35,10 @@ export const cloudflarePages = defineNitroPreset({
   output: {
     serverDir: "{{ rootDir }}/functions",
   },
+  alias: {
+    // Hotfix: Cloudflare appends /index.html if mime is not found and things like ico are not in standard lite.js!
+    _mime: "mime/index.js",
+  },
   rollupConfig: {
     output: {
       entryFileNames: "path.js",


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Reported by @Atinux when `icon.ico` cannot be served on cloudflare deployments.

Investigating this, `mapRequestToAsset` utility from `@cloudflare/kv-asset-handler`, appends `/index.html` always when a mime is not detected based on request extension! We use `mime/lite` and `ico` is not there this will cause cloudflare to fail! 

![image](https://user-images.githubusercontent.com/5158436/217641196-53e32b8c-f9b0-4294-b931-f93277ab2466.png)


Best approach is accessing assets meta but as a workaround, this PR uses full mime db (25KB instead of 8KB) for cloudflare.

```
Before 
  └─ .output/server/index.mjs (1.3 MB) (367 kB gzip)
Σ Total size: 1.3 MB (367 kB gzip)

1272    .output/server/index.mjs


After:

nitro 21:04:18
  └─ .output/server/index.mjs (1.33 MB) (374 kB gzip)
Σ Total size: 1.33 MB (374 kB gzip)

1300    .output/server/index.mjs
```


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
