### PR TITLE
fix(typescript): export missing defineNitroPlugin function

### DIFF
--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -5,7 +5,7 @@ export type {
   ResponseCacheEntry,
   CachedEventHandlerOptions,
 } from "./cache";
-export type { NitroAppPlugin } from "./plugin";
+export type { NitroAppPlugin, defineNitroPlugin } from "./plugin";
 export type { RenderResponse, RenderHandler } from "./renderer";
 
 declare module "h3" {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Otherwise users wanting to use defineNitroPlugin would have to do something like:

`import { defineNitroPlugin } from 'nitropack/dist/runtime/plugin'`

This is directly related to this https://github.com/unjs/nitro/pull/301

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [] I have linked an issue or discussion.
- [] I have updated the documentation accordingly.
