### PR TITLE
fix(rollup): use mlly as fallback resolver when externals disabled

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -359,6 +359,7 @@ export const plugins = [
         });
         if (!resolved) {
           const _resolved = await resolvePath(id, {
+            url: nitro.options.nodeModulesDirs,
             conditions: [
               "default",
               nitro.options.dev ? "development" : "production",
@@ -366,7 +367,6 @@ export const plugins = [
               "node",
               "import",
             ],
-            url: nitro.options.nodeModulesDirs,
           }).catch(() => null);
           if (_resolved) {
             return { id: _resolved, external: false };


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

resolves #947

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When externals are disabled (workers like cf), we completely depend on rollup/node-resolve plugin which happens to fail resolving in pnpm monorepos. This PR adds mlly support as fallback which seems to supporting pnpm well and fixing resolving issue + a small fix for node+noExternals

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
