### PR TITLE
fix: don't render json response if url contains `/api/`

### DIFF
--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -41,8 +41,7 @@ export function isJsonRequest(event: H3Event) {
     hasReqHeader(event, "accept", "application/json") ||
     hasReqHeader(event, "user-agent", "curl/") ||
     hasReqHeader(event, "user-agent", "httpie/") ||
-    event.node.req.url?.endsWith(".json") ||
-    event.node.req.url?.includes("/api/")
+    event.node.req.url?.endsWith(".json")
   );
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/19093

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Although a helpful idea, I think this is too broad a net for rendering an API response. Even routes starting with `/api` might still benefit from an HTML response if requested from a browser.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
