### PR TITLE
docs(fix): prevent ellipsis overflow on small screens

### DIFF
--- a/docs/components/global/Ellipsis.vue
+++ b/docs/components/global/Ellipsis.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="absolute left-0 top-0 w-full max-w-full">
+  <div class="absolute left-0 top-0 w-full max-w-full h-full max-h-full overflow-hidden pointer-events-none">
     <div class="ellipsis" />
   </div>
 </template>


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Ellipsis component can cause unwanted horizontal scroll by overflowing device screen width if there are not enough space. (You can see on "after" screenshot there are no scrollbar at the bottom)

<details>
<summary>Before:</summary>

![Webpage scrolled horizontally](https://user-images.githubusercontent.com/56201308/219700870-e8364dc8-9a1c-4743-aa0c-28609cdafd77.png)

</details>

<details>
<summary>After:</summary>

![Screen Shot 2023-02-17 at 18 03 58](https://user-images.githubusercontent.com/56201308/219704354-e366f419-5f93-4522-bc79-a9b3113bdf67.png)

</details>


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
