### PR TITLE
fix(cloudflare-pages): exclude assets from function call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ Temporary Items
 .vercel
 staticwebapp.config.json
 .eslintcache
+
+test/fixture/functions

--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -81,7 +81,7 @@ export const cloudflarePages = defineNitroPreset({
 
       // Explicit prefixes
       routes.exclude.push(
-        ...explicitPublicAssets.map((dir) => joinURL(dir.baseURL, "*"))
+        ...explicitPublicAssets.map((dir) => joinURL(dir.baseURL, "*")).sort()
       );
 
       // Unprefixed assets
@@ -98,7 +98,11 @@ export const cloudflarePages = defineNitroPreset({
           ".output/**",
         ],
       });
-      routes.exclude.push(...publicAssetFiles.map((i) => withLeadingSlash(i)));
+      routes.exclude.push(
+        ...publicAssetFiles
+          .map((i) => withLeadingSlash(i))
+          .sort((a, b) => a.length - b.length)
+      );
 
       // Only allow 100 routes
       routes.exclude.splice(100);

--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -78,32 +78,23 @@ export const cloudflarePages = defineNitroPreset({
           routes.exclude.push(joinURL(path.baseURL, "*"));
         }
       }
-      // Push unprefixed static assets to exclude, up to the 100 limit
-      const roots = nitro.options.publicAssets
-        .filter((p) => p.baseURL !== "/")
-        .map((p) => p.dir);
-      for (const path of nitro.options.publicAssets) {
-        if (!path.baseURL || path.baseURL === "/") {
-          const files = await globby("**", {
-            cwd: path.dir,
-            absolute: false,
-            dot: true,
-          });
-          for (const file of files) {
-            const fullPath = join(path.dir, file);
-            // Skip assets already scanned in a more deeply nested asset directory
-            if (roots.some((r) => fullPath.startsWith(r))) {
-              continue;
-            }
-            if (routes.exclude.length < 99) {
-              routes.exclude.push(withLeadingSlash(file));
-            }
-          }
+
+      const publicAssetFiles = await globby("**", {
+        cwd: nitro.options.output.publicDir,
+        absolute: false,
+        dot: true,
+        ignore: [".output/**"], // TODO!
+      });
+
+      for (const file of publicAssetFiles) {
+        if (routes.exclude.length < 99) {
+          routes.exclude.push(withLeadingSlash(file));
         }
       }
+
       await fse.writeFile(
         resolve(nitro.options.output.publicDir, "_routes.json"),
-        JSON.stringify(routes)
+        JSON.stringify(routes, undefined, 2)
       );
     },
   },

--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -1,5 +1,6 @@
 import { resolve } from "pathe";
 import fse from "fs-extra";
+import { joinURL } from "ufo";
 import { writeFile } from "../utils";
 import { defineNitroPreset } from "../preset";
 import type { Nitro } from "../types";
@@ -55,6 +56,20 @@ export const cloudflarePages = defineNitroPreset({
       await fse.move(
         resolve(nitro.options.output.serverDir, "path.js.map"),
         resolve(nitro.options.output.serverDir, "[[path]].js.map")
+      );
+      const routes = {
+        version: 1,
+        include: ["/*"],
+        exclude: [],
+      };
+      for (const path of nitro.options.publicAssets) {
+        if (path.baseURL && path.baseURL !== "/") {
+          routes.exclude.push(joinURL(path.baseURL, "*"));
+        }
+      }
+      await fse.writeFile(
+        resolve(nitro.options.output.publicDir, "_routes.json"),
+        JSON.stringify(routes)
       );
     },
   },

--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -81,7 +81,9 @@ export const cloudflarePages = defineNitroPreset({
 
       // Explicit prefixes
       routes.exclude.push(
-        ...explicitPublicAssets.map((dir) => joinURL(dir.baseURL, "*")).sort()
+        ...explicitPublicAssets
+          .map((dir) => joinURL(dir.baseURL, "*"))
+          .sort(comparePaths)
       );
 
       // Unprefixed assets
@@ -99,9 +101,7 @@ export const cloudflarePages = defineNitroPreset({
         ],
       });
       routes.exclude.push(
-        ...publicAssetFiles
-          .map((i) => withLeadingSlash(i))
-          .sort((a, b) => a.length - b.length)
+        ...publicAssetFiles.map((i) => withLeadingSlash(i)).sort(comparePaths)
       );
 
       // Only allow 100 routes
@@ -114,3 +114,7 @@ export const cloudflarePages = defineNitroPreset({
     },
   },
 });
+
+function comparePaths(a: string, b: string) {
+  return a.split("/").length - b.split("/").length || a.localeCompare(b);
+}

--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -98,12 +98,10 @@ export const cloudflarePages = defineNitroPreset({
           ".output/**",
         ],
       });
+      routes.exclude.push(...publicAssetFiles.map((i) => withLeadingSlash(i)));
 
-      for (const file of publicAssetFiles) {
-        if (routes.exclude.length < 99) {
-          routes.exclude.push(withLeadingSlash(file));
-        }
-      }
+      // Only allow 100 routes
+      routes.exclude.splice(100);
 
       await fse.writeFile(
         resolve(nitro.options.output.publicDir, "_routes.json"),

--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -27,6 +27,15 @@ export const cloudflare = defineNitroPreset({
   },
 });
 
+/**
+ * https://developers.cloudflare.com/pages/platform/functions/routing/#functions-invocation-routes
+ */
+interface CloudflarePagesRoutes {
+  version: 1;
+  include: string[];
+  exclude: string[];
+}
+
 export const cloudflarePages = defineNitroPreset({
   extends: "cloudflare",
   entry: "#internal/nitro/entries/cloudflare-pages",
@@ -58,7 +67,7 @@ export const cloudflarePages = defineNitroPreset({
         resolve(nitro.options.output.serverDir, "path.js.map"),
         resolve(nitro.options.output.serverDir, "[[path]].js.map")
       );
-      const routes = {
+      const routes: CloudflarePagesRoutes = {
         version: 1,
         include: ["/*"],
         exclude: [],

--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -95,9 +95,6 @@ export const cloudflarePages = defineNitroPreset({
           ...explicitPublicAssets.map((dir) =>
             withoutLeadingSlash(joinURL(dir.baseURL, "**"))
           ),
-          // TODO!
-          ".nitro/**",
-          ".output/**",
         ],
       });
       routes.exclude.push(

--- a/test/presets/cloudflare.test.ts
+++ b/test/presets/cloudflare.test.ts
@@ -34,6 +34,16 @@ describe("nitro:preset:cloudflare-pages", async () => {
         "exclude": [
           "/build/*",
           "/favicon.ico",
+          "/icon.png",
+          "/api/hello",
+          "/prerender/index.html",
+          "/prerender/index.html.br",
+          "/prerender/index.html.gz",
+          "/api/hey/index.html",
+          "/api/param/foo.json/index.html",
+          "/api/param/prerender3/index.html",
+          "/api/param/prerender4/index.html",
+          "/api/param/prerender1/index.html",
         ],
         "include": [
           "/*",

--- a/test/presets/cloudflare.test.ts
+++ b/test/presets/cloudflare.test.ts
@@ -33,17 +33,17 @@ describe("nitro:preset:cloudflare-pages", async () => {
       {
         "exclude": [
           "/build/*",
-          "/favicon.ico",
           "/icon.png",
           "/api/hello",
+          "/favicon.ico",
+          "/api/hey/index.html",
           "/prerender/index.html",
           "/prerender/index.html.br",
           "/prerender/index.html.gz",
-          "/api/hey/index.html",
           "/api/param/foo.json/index.html",
           "/api/param/prerender3/index.html",
-          "/api/param/prerender4/index.html",
           "/api/param/prerender1/index.html",
+          "/api/param/prerender4/index.html",
         ],
         "include": [
           "/*",

--- a/test/presets/cloudflare.test.ts
+++ b/test/presets/cloudflare.test.ts
@@ -1,6 +1,7 @@
+import { promises as fsp } from "node:fs";
 import { resolve } from "pathe";
 import { Miniflare } from "miniflare";
-import { describe } from "vitest";
+import { describe, it, expect } from "vitest";
 
 import { setupTest, testNitro } from "../tests";
 
@@ -18,5 +19,26 @@ describe("nitro:preset:cloudflare", async () => {
       });
       return res as unknown as Response;
     };
+  });
+});
+
+describe("nitro:preset:cloudflare-pages", async () => {
+  const ctx = await setupTest("cloudflare-pages");
+
+  it("should generate a _routes.json", async () => {
+    const config = await fsp
+      .readFile(resolve(ctx.outDir, "public/_routes.json"), "utf8")
+      .then((r) => JSON.parse(r));
+    expect(config).toMatchInlineSnapshot(`
+      {
+        "exclude": [
+          "/build/*",
+        ],
+        "include": [
+          "/*",
+        ],
+        "version": 1,
+      }
+    `);
   });
 });

--- a/test/presets/cloudflare.test.ts
+++ b/test/presets/cloudflare.test.ts
@@ -33,6 +33,7 @@ describe("nitro:preset:cloudflare-pages", async () => {
       {
         "exclude": [
           "/build/*",
+          "/favicon.ico",
         ],
         "include": [
           "/*",

--- a/test/presets/cloudflare.test.ts
+++ b/test/presets/cloudflare.test.ts
@@ -33,16 +33,16 @@ describe("nitro:preset:cloudflare-pages", async () => {
       {
         "exclude": [
           "/build/*",
+          "/favicon.ico",
           "/icon.png",
           "/api/hello",
-          "/favicon.ico",
-          "/api/hey/index.html",
           "/prerender/index.html",
           "/prerender/index.html.br",
           "/prerender/index.html.gz",
+          "/api/hey/index.html",
           "/api/param/foo.json/index.html",
-          "/api/param/prerender3/index.html",
           "/api/param/prerender1/index.html",
+          "/api/param/prerender3/index.html",
           "/api/param/prerender4/index.html",
         ],
         "include": [

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -39,8 +39,17 @@ export async function setupTest(preset: string) {
     dev: ctx.isDev,
     rootDir: ctx.rootDir,
     serveStatic:
-      preset !== "cloudflare" && preset !== "vercel-edge" && !ctx.isDev,
-    output: { dir: ctx.outDir },
+      preset !== "cloudflare" &&
+      preset !== "cloudflare-pages" &&
+      preset !== "vercel-edge" &&
+      !ctx.isDev,
+    output: {
+      dir: ctx.outDir,
+      serverDir:
+        preset === "cloudflare-pages"
+          ? "{{ output.dir }}/functions"
+          : undefined,
+    },
     routeRules: {
       "/rules/headers": { headers: { "cache-control": "s-maxage=60" } },
       "/rules/cors": {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/unjs/nitro/issues/497

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We can generate a `_routes.json` file to prevent hits on assets directories from hitting the function at all. We might also be able to add individual assets that are outside of these directories to the json but this runs the risk of hitting the 100 rule limit. (Maybe we can allow extending the default config, suggested by @colonelbundy.)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
