### PR TITLE
fix: render json errors for CORS requests

### DIFF
--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -41,6 +41,7 @@ export function isJsonRequest(event: H3Event) {
     hasReqHeader(event, "accept", "application/json") ||
     hasReqHeader(event, "user-agent", "curl/") ||
     hasReqHeader(event, "user-agent", "httpie/") ||
+    hasReqHeader(event, "sec-fetch-mode", "cors") ||
     event.node.req.url?.endsWith(".json")
   );
 }


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/19093

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As `$fetch` is setting `Accept: */*` we can't detect JSON request purely by content-type. I think `sec-fetch-mode` might allow us to make another smart guess - CORS requests should probably also be JSON.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
