### PR TITLE
fix: use json response for  errors in `/api/` routes

### DIFF
--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -42,7 +42,8 @@ export function isJsonRequest(event: H3Event) {
     hasReqHeader(event, "user-agent", "curl/") ||
     hasReqHeader(event, "user-agent", "httpie/") ||
     hasReqHeader(event, "sec-fetch-mode", "cors") ||
-    event.node.req.url?.endsWith(".json")
+    event.path.startsWith("/api/") ||
+    event.path.endsWith(".json")
   );
 }
 


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

resolves #951

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

To avoid breaking changes, this PR uses json response again for routes starting with `/api` 

PS: This is temporary. We might find better solutions to show pretty error pages for API later. Also notes in https://github.com/unjs/nitro/pull/951#issuecomment-1438677976


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
