### PR TITLE
fix(cloudflare-pages): only allow 100 rules

### DIFF
--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -101,8 +101,8 @@ export const cloudflarePages = defineNitroPreset({
         ...publicAssetFiles.map((i) => withLeadingSlash(i)).sort(comparePaths)
       );
 
-      // Only allow 100 routes
-      routes.exclude.splice(100);
+      // Only allow 100 rules (99 exclude + 1 include)
+      routes.exclude.splice(99);
 
       await fse.writeFile(
         resolve(nitro.options.output.publicDir, "_routes.json"),


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

CF only supports 100 rules, which includes the 'include' as well as the 'exclude' rule. Seems like this might have been lost in the refactor.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
