### PR TITLE
fix: scan middleware and print tree list in ascending alphabetical order

### DIFF
--- a/src/scan.ts
+++ b/src/scan.ts
@@ -104,7 +104,7 @@ function scanDirs(dirs: string[]): Promise<FileInfo[]> {
             fullPath: resolve(dir, fileName),
           };
         })
-        .sort((a, b) => b.path.localeCompare(a.path));
+        .sort((a, b) => a.path.localeCompare(b.path));
     })
   ).then((r) => r.flat());
 }

--- a/src/utils/tree.ts
+++ b/src/utils/tree.ts
@@ -23,7 +23,7 @@ export async function generateFSTree(dir: string) {
         return { file, path, size, gzip };
       })
     )
-  ).sort((a, b) => b.path.localeCompare(a.path));
+  ).sort((a, b) => a.path.localeCompare(b.path));
 
   let totalSize = 0;
   let totalGzip = 0;


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/19234

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

While not exactly a bug, I think it makes sense to scan middleware in alphabetical order rather than the reverse, and also print the generated files that way too.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
