### PR TITLE
fix: only mock `debug` in production

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -45,8 +45,9 @@ export const getRollupConfig = (nitro: Nitro) => {
   const builtinPreset: Preset = {
     alias: {
       // General
-      debug: "unenv/runtime/npm/debug",
       consola: "unenv/runtime/npm/consola",
+      // only mock debug in production
+      ...(nitro.options.dev ? {} : { debug: "unenv/runtime/npm/debug" }),
       ...nitro.options.alias,
     },
   };


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/19236

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This moves our mock for `debug` out of default settings and is now only applied in production mode.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
