### PR TITLE
feat(lagon): write Lagon config on build

### DIFF
--- a/src/presets/lagon.ts
+++ b/src/presets/lagon.ts
@@ -1,5 +1,5 @@
 import type { PackageJson } from "pkg-types";
-import { resolve } from "pathe";
+import { resolve, relative } from "pathe";
 import { defineNitroPreset } from "../preset";
 import { writeFile } from "../utils";
 
@@ -19,7 +19,26 @@ export const lagon = defineNitroPreset({
 
   hooks: {
     async compiled(nitro) {
-      // TODO: write lagon config when it's supported
+      // Write Lagon config
+      const root = nitro.options.output.dir;
+      const indexPath = relative(
+        root,
+        resolve(nitro.options.output.serverDir, "index.mjs")
+      );
+      const assetsDir = relative(root, nitro.options.output.publicDir);
+
+      await writeFile(
+        resolve(root, ".lagon", "config.json"),
+        JSON.stringify({
+          // Boths fields are required but only
+          // used when deploying the function
+          function_id: "",
+          organization_id: "",
+          index: indexPath,
+          client: null,
+          assets: assetsDir,
+        })
+      );
 
       // Write package.json for deployment
       await writeFile(
@@ -28,9 +47,8 @@ export const lagon = defineNitroPreset({
           <PackageJson>{
             private: true,
             scripts: {
-              dev: "npx -p esbuild -p @lagon/cli lagon dev ./server/index.mjs -p ./public",
-              deploy:
-                "npx -p esbuild -p @lagon/cli lagon deploy ./server/index.mjs -p ./public",
+              dev: "npx -p esbuild -p @lagon/cli lagon dev",
+              deploy: "npx -p esbuild -p @lagon/cli lagon deploy",
             },
           },
           null,

--- a/src/presets/lagon.ts
+++ b/src/presets/lagon.ts
@@ -3,6 +3,18 @@ import { resolve, relative } from "pathe";
 import { defineNitroPreset } from "../preset";
 import { writeFile } from "../utils";
 
+/**
+ * Both function_id and organization_id fields are required but only used when deploying the function
+ * Ref: https://github.com/lagonapp/lagon/blob/06093d051898d7603f356b9cae5e3f14078d480a/crates/cli/src/utils/deployments.rs#L34
+ */
+export interface LagonFunctionConfig {
+  function_id: string;
+  organization_id: string;
+  index: string;
+  client?: string;
+  assets?: string;
+}
+
 export const lagon = defineNitroPreset({
   extends: "base-worker",
   entry: "#internal/nitro/entries/lagon",
@@ -29,9 +41,7 @@ export const lagon = defineNitroPreset({
 
       await writeFile(
         resolve(root, ".lagon", "config.json"),
-        JSON.stringify({
-          // Boths fields are required but only
-          // used when deploying the function
+        JSON.stringify(<LagonFunctionConfig>{
           function_id: "",
           organization_id: "",
           index: indexPath,


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/unjs/nitro/issues/966

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Since `@lagon/cli@0.5.0`, Lagon supports configuration files (https://github.com/lagonapp/lagon/releases/tag/%40lagon%2Fcli%400.5.0)

This PR outputs Lagon's configuration file when the build is complete. It's written inside `${output.dir}/.lagon/config.json` (e.g `.output/.lagon/config.json`) and allows to start the dev server / deploy the function without specifying the function's entry point (`server/index.mjs`) and the public directory (`public`) manually.

Notes:
- Fields are written in snake_case
- All paths are relative to the parent of the `.lagon` folder
- `function_id` & `organization_id` fields are empty, they are used to detect if the function has been deployed or not
- `client` field is a path to a client-side JS script that can be bundled and injected into the assets, but is useless for Nitro.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
