### PR TITLE
fix(cloudflare-pages): pass CfRequestContext to nitro localCall

### DIFF
--- a/src/runtime/entries/cloudflare-pages.ts
+++ b/src/runtime/entries/cloudflare-pages.ts
@@ -44,8 +44,9 @@ export async function onRequest(ctx: CFRequestContext) {
     host: url.hostname,
     protocol: url.protocol,
     body,
-    // TODO: Allow passing custom context
-    // cf: ctx,
+    context: {
+      cf: ctx,
+    },
     // TODO: Handle redirects?
     // redirect: ctx.request.redirect
   });


### PR DESCRIPTION

### 🔗 Linked issue

#773

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)


### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

in the cloudflare-pages adapter I've added the CfRequestContext that the onRequest function receives from Cloudflare to the nitroApp localCall so that users can access such context in their nitro application

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
