### PR TITLE
feat: add support for sourceMap values: hidden, inline

### DIFF
--- a/docs/content/3.config/index.md
+++ b/docs/content/3.config/index.md
@@ -361,7 +361,8 @@ Avoid creating chunks.
 
 ### `sourceMap`
 
-Enable source-map generation
+Enable source-map generation. See [options](https://rollupjs.org/configuration-options/#output-sourcemap)
+- Default: `true`
 
 ### `node`
 

--- a/playground/nitro.config.ts
+++ b/playground/nitro.config.ts
@@ -1,3 +1,5 @@
 import { defineNitroConfig } from "../src";
 
-export default defineNitroConfig({});
+export default defineNitroConfig({
+  sourceMap: "hidden",
+});

--- a/playground/nitro.config.ts
+++ b/playground/nitro.config.ts
@@ -1,5 +1,3 @@
 import { defineNitroConfig } from "../src";
 
-export default defineNitroConfig({
-  sourceMap: "hidden",
-});
+export default defineNitroConfig({});

--- a/src/rollup/plugins/esbuild.ts
+++ b/src/rollup/plugins/esbuild.ts
@@ -14,7 +14,7 @@ const defaultLoaders: { [ext: string]: Loader } = {
 export type Options = {
   include?: FilterPattern;
   exclude?: FilterPattern;
-  sourceMap?: boolean;
+  sourceMap?: boolean | "inline" | "hidden";
   minify?: boolean;
   target: string | string[];
   jsxFactory?: string;
@@ -82,7 +82,8 @@ export function esbuild(options: Options): Plugin {
         loader,
         target: options.target,
         define: options.define,
-        sourcemap: options.sourceMap,
+        sourcemap:
+          options.sourceMap === "hidden" ? "external" : options.sourceMap,
         sourcefile: id,
       });
 

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -213,7 +213,7 @@ export interface NitroOptions extends PresetOptions {
   alias: Record<string, string>;
   minify: boolean;
   inlineDynamicImports: boolean;
-  sourceMap: boolean;
+  sourceMap: boolean | "inline" | "hidden";
   node: boolean;
   moduleSideEffects: string[];
   esbuild?: {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/19253

### ❓ Type of change

- [x]  📖 Documentation (updates to the documentation or readme)
- [ ]  🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ]  👌 Enhancement (improving an existing functionality like performance)
- [x]  ✨ New feature (a non-breaking change that adds functionality)
- [ ]  ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds support of more values for `sourceMap` config option. Now additionally `inline` and `hidden` are available in accordance with Rollup: https://rollupjs.org/configuration-options/#output-sourcemap

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
