### PR TITLE
feat(types): type $fetch to match json serialization output

### DIFF
--- a/src/types/fetch.ts
+++ b/src/types/fetch.ts
@@ -1,5 +1,6 @@
 import type { RouterMethod } from "h3";
 import type { FetchRequest, FetchOptions, FetchResponse } from "ofetch";
+import type { Serialize, Simplify } from "./serialize";
 import type { MatchedRoutes } from "./utils";
 
 // An interface to extend in a local project
@@ -16,7 +17,7 @@ export type MiddlewareOf<
   Route extends string,
   Method extends RouterMethod | "default"
 > = Method extends keyof InternalApi[MatchedRoutes<Route>]
-  ? Exclude<InternalApi[MatchedRoutes<Route>][Method], Error | void>
+  ? Simplify<Serialize<Exclude<InternalApi[MatchedRoutes<Route>][Method], Error | void>>>
   : never;
 
 export type TypedInternalResponse<

--- a/src/types/fetch.ts
+++ b/src/types/fetch.ts
@@ -17,7 +17,11 @@ export type MiddlewareOf<
   Route extends string,
   Method extends RouterMethod | "default"
 > = Method extends keyof InternalApi[MatchedRoutes<Route>]
-  ? Simplify<Serialize<Exclude<InternalApi[MatchedRoutes<Route>][Method], Error | void>>>
+  ? Simplify<
+      Serialize<
+        Exclude<InternalApi[MatchedRoutes<Route>][Method], Error | void>
+      >
+    >
   : never;
 
 export type TypedInternalResponse<

--- a/src/types/serialize.ts
+++ b/src/types/serialize.ts
@@ -1,0 +1,56 @@
+/**
+ * @link https://github.com/remix-run/remix/blob/2248669ed59fd716e267ea41df5d665d4781f4a9/packages/remix-server-runtime/serialize.ts
+ */
+type JsonPrimitive =
+  | string
+  | number
+  | boolean
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  | String
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  | Number
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  | Boolean
+  | null;
+// eslint-disable-next-line @typescript-eslint/ban-types
+type NonJsonPrimitive = undefined | Function | symbol;
+
+/*
+ * `any` is the only type that can let you equate `0` with `1`
+ * See https://stackoverflow.com/a/49928360/1490091
+ */
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+type FilterKeys<TObj extends object, TFilter> = {
+  [TKey in keyof TObj]: TObj[TKey] extends TFilter ? TKey : never;
+}[keyof TObj];
+
+// prettier-ignore
+export type Serialize<T> =
+ IsAny<T> extends true ? any :
+ T extends JsonPrimitive ? T :
+ T extends Map<any,any> | Set<any> ? object :
+ T extends NonJsonPrimitive ? never :
+ T extends { toJSON(): infer U } ? U :
+ T extends [] ? [] :
+ T extends [unknown, ...unknown[]] ? SerializeTuple<T> :
+ T extends ReadonlyArray<infer U> ? (U extends NonJsonPrimitive ? null : Serialize<U>)[] :
+ T extends object ? SerializeObject<T> :
+ never;
+
+/** JSON serialize [tuples](https://www.typescriptlang.org/docs/handbook/2/objects.html#tuple-types) */
+type SerializeTuple<T extends [unknown, ...unknown[]]> = {
+  [k in keyof T]: T[k] extends NonJsonPrimitive ? null : Serialize<T[k]>;
+};
+
+/** JSON serialize objects (not including arrays) and classes */
+type SerializeObject<T extends object> = {
+  [k in keyof Omit<T, FilterKeys<T, NonJsonPrimitive>>]: Serialize<T[k]>;
+};
+
+/**
+ * @see https://github.com/ianstormtaylor/superstruct/blob/7973400cd04d8ad92bbdc2b6f35acbfb3c934079/src/utils.ts#L323-L325
+ */
+export type Simplify<TType> = TType extends any[] | Date
+  ? TType
+  : { [K in keyof TType]: TType[K] };

--- a/src/types/serialize.ts
+++ b/src/types/serialize.ts
@@ -29,7 +29,7 @@ type FilterKeys<TObj extends object, TFilter> = {
 export type Serialize<T> =
  IsAny<T> extends true ? any :
  T extends JsonPrimitive ? T :
- T extends Map<any,any> | Set<any> ? object :
+ T extends Map<any,any> | Set<any> ? Record<string, never> :
  T extends NonJsonPrimitive ? never :
  T extends { toJSON(): infer U } ? U :
  T extends [] ? [] :

--- a/test/fixture/api/serialized/date.ts
+++ b/test/fixture/api/serialized/date.ts
@@ -1,0 +1,1 @@
+export default defineEventHandler(() => ({ createdAt: new Date() }));

--- a/test/fixture/api/serialized/function.ts
+++ b/test/fixture/api/serialized/function.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler(() => {
+  return { foo: () => 'foo' }
+});

--- a/test/fixture/api/serialized/map.ts
+++ b/test/fixture/api/serialized/map.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler(() => {
+  return { foo: new Map<string, number>([["key", 2]]) };
+});

--- a/test/fixture/api/serialized/set.ts
+++ b/test/fixture/api/serialized/set.ts
@@ -1,3 +1,3 @@
 export default defineEventHandler(() => {
-  return { foo: new Set(["item1"]) };
+  return { foo: new Set(["item"]) };
 });

--- a/test/fixture/api/serialized/set.ts
+++ b/test/fixture/api/serialized/set.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler(() => {
+  return { foo: new Set(["item1"]) };
+});

--- a/test/fixture/api/serialized/tuple.ts
+++ b/test/fixture/api/serialized/tuple.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler(() => {
+  return ["foo", new Date()] as [string, Date];
+});

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -205,13 +205,13 @@ describe("API routes", () => {
 
     expectTypeOf($fetch("/api/serialized/map")).toMatchTypeOf<
       Promise<{
-        foo: object;
+        foo: Record<string, never>;
       }>
     >();
 
     expectTypeOf($fetch("/api/serialized/set")).toMatchTypeOf<
       Promise<{
-        foo: object;
+        foo: Record<string, never>;
       }>
     >();
 

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -191,4 +191,32 @@ describe("API routes", () => {
       $fetch("/api/methods/default", { method: "POST" })
     ).toMatchTypeOf<Promise<"Default override">>();
   });
+
+  it("generates types matching JSON serialization output", () => {
+    expectTypeOf($fetch("/api/serialized/date")).toMatchTypeOf<
+      Promise<{
+        createdAt: string;
+      }>
+    >();
+
+    expectTypeOf($fetch("/api/serialized/function")).toMatchTypeOf<
+      Promise<object>
+    >();
+
+    expectTypeOf($fetch("/api/serialized/map")).toMatchTypeOf<
+      Promise<{
+        foo: object;
+      }>
+    >();
+
+    expectTypeOf($fetch("/api/serialized/set")).toMatchTypeOf<
+      Promise<{
+        foo: object;
+      }>
+    >();
+
+    expectTypeOf($fetch("/api/serialized/tuple")).toMatchTypeOf<
+      Promise<[string, string]>
+    >();
+  });
 });


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

resolves #804, resolves https://github.com/unjs/nitro/issues/1000

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR transforms the output type of $Fetch to better match what JSON.stringify returns (using trpc and remix implementation).

This is potentially a breaking change.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
