### PR TITLE
feat: allow customising generated tsconfig path

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -175,12 +175,7 @@ export async function writeTypes(nitro: Nitro) {
       ],
     };
     await writeFile(
-      join(
-        nitro.options.buildDir,
-        typeof nitro.options.typescript.generateTsConfig === "string"
-          ? nitro.options.typescript.generateTsConfig
-          : "types/tsconfig.json"
-      ),
+      join(nitro.options.buildDir, nitro.options.typescript.tsconfigPath),
       JSON.stringify(tsConfig, null, 2)
     );
   }

--- a/src/build.ts
+++ b/src/build.ts
@@ -175,7 +175,7 @@ export async function writeTypes(nitro: Nitro) {
       ],
     };
     await writeFile(
-      join(nitro.options.buildDir, nitro.options.typescript.tsconfigPath),
+      resolve(nitro.options.buildDir, nitro.options.typescript.tsconfigPath),
       JSON.stringify(tsConfig, null, 2)
     );
   }

--- a/src/build.ts
+++ b/src/build.ts
@@ -175,7 +175,12 @@ export async function writeTypes(nitro: Nitro) {
       ],
     };
     await writeFile(
-      join(nitro.options.buildDir, "types/tsconfig.json"),
+      join(
+        nitro.options.buildDir,
+        typeof nitro.options.typescript.generateTsConfig === "string"
+          ? nitro.options.typescript.generateTsConfig
+          : "types/tsconfig.json"
+      ),
       JSON.stringify(tsConfig, null, 2)
     );
   }

--- a/src/options.ts
+++ b/src/options.ts
@@ -87,6 +87,7 @@ const NitroDefaults: NitroConfig = {
   // Advanced
   typescript: {
     generateTsConfig: true,
+    tsconfigPath: "types/tsconfig.json",
     internalPaths: false,
   },
   nodeModulesDirs: [],

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -228,7 +228,8 @@ export interface NitroOptions extends PresetOptions {
   // Advanced
   typescript: {
     internalPaths?: boolean;
-    generateTsConfig?: boolean | string;
+    generateTsConfig?: boolean;
+    tsconfigPath: string;
   };
   hooks: NestedHooks<NitroHooks>;
   nodeModulesDirs: string[];

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -229,6 +229,7 @@ export interface NitroOptions extends PresetOptions {
   typescript: {
     internalPaths?: boolean;
     generateTsConfig?: boolean;
+    /** the path of the generated `tsconfig.json`, relative to buildDir */
     tsconfigPath: string;
   };
   hooks: NestedHooks<NitroHooks>;

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -228,7 +228,7 @@ export interface NitroOptions extends PresetOptions {
   // Advanced
   typescript: {
     internalPaths?: boolean;
-    generateTsConfig?: boolean;
+    generateTsConfig?: boolean | string;
   };
   hooks: NestedHooks<NitroHooks>;
   nodeModulesDirs: string[];


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/13920

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This allows customising the `types/tsconfig.json` path in case we want it to be in a different location or file name.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
