### PR TITLE
feat: support app config

### DIFF
--- a/src/imports.ts
+++ b/src/imports.ts
@@ -15,6 +15,7 @@ export const nitroImports: Preset[] = [
       "nitroPlugin",
       "defineRenderHandler",
       "getRouteRules",
+      "useAppConfig",
     ],
   },
 ];

--- a/src/options.ts
+++ b/src/options.ts
@@ -8,7 +8,12 @@ import escapeRE from "escape-string-regexp";
 import { withLeadingSlash, withoutTrailingSlash, withTrailingSlash } from "ufo";
 import { isTest, isDebug } from "std-env";
 import { findWorkspaceDir } from "pkg-types";
-import { resolvePath, detectTarget, provideFallbackValues } from "./utils";
+import {
+  resolvePath,
+  resolveFile,
+  detectTarget,
+  provideFallbackValues,
+} from "./utils";
 import type {
   NitroConfig,
   NitroOptions,
@@ -24,6 +29,8 @@ const NitroDefaults: NitroConfig = {
   debug: isDebug,
   logLevel: isTest ? 1 : 3,
   runtimeConfig: { app: {}, nitro: {} },
+  appConfig: {},
+  appConfigFiles: [],
 
   // Dirs
   scanDirs: [],
@@ -235,6 +242,19 @@ export async function loadOptions(
     options.imports.dirs.push(
       ...options.scanDirs.map((dir) => join(dir, "utils/*"))
     );
+  }
+
+  // Normalize app.config file paths
+  options.appConfigFiles = options.appConfigFiles
+    .map((file) => resolveFile(resolvePath(file, options)))
+    .filter(Boolean);
+
+  // Detect app.config from scanDirs
+  for (const dir of options.scanDirs) {
+    const configFile = resolveFile("app.config", dir);
+    if (configFile && !options.appConfigFiles.includes(configFile)) {
+      options.appConfigFiles.push(configFile);
+    }
   }
 
   // Backward compatibility for options.routes

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -34,6 +34,7 @@ import { esbuild } from "./plugins/esbuild";
 import { raw } from "./plugins/raw";
 import { storage } from "./plugins/storage";
 import { importMeta } from "./plugins/import-meta";
+import { appConfig } from "./plugins/app-config";
 
 export type RollupConfig = InputOptions & { output: OutputOptions };
 
@@ -244,6 +245,9 @@ export const getRollupConfig = (nitro: Nitro) => {
 
   // Storage
   rollupConfig.plugins.push(storage(nitro));
+
+  // App.config
+  rollupConfig.plugins.push(appConfig(nitro));
 
   // Handlers
   rollupConfig.plugins.push(handlers(nitro));

--- a/src/rollup/plugins/app-config.ts
+++ b/src/rollup/plugins/app-config.ts
@@ -1,0 +1,25 @@
+import { genImport } from "knitwork";
+import type { Nitro } from "../../types";
+import { virtual } from "./virtual";
+
+export function appConfig(nitro: Nitro) {
+  return virtual(
+    {
+      "#internal/nitro/virtual/app-config": () => `
+import { defuFn } from 'defu';
+
+const inlineAppConfig = ${JSON.stringify(nitro.options.appConfig, null, 2)};
+
+${nitro.options.appConfigFiles
+  .map((file, i) => genImport(file, "appConfig" + i) + ";")
+  .join("\n")}
+
+export const appConfig = defuFn(${[
+        ...nitro.options.appConfigFiles.map((_, i) => "appConfig" + i),
+        "inlineAppConfig",
+      ].join(", ")});
+      `,
+    },
+    nitro.vfs
+  );
+}

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -20,7 +20,6 @@ import { useRuntimeConfig } from "./config";
 import { cachedEventHandler } from "./cache";
 import { createRouteRulesHandler, getRouteRulesForPath } from "./route-rules";
 import { plugins } from "#internal/nitro/virtual/plugins";
-import { appConfig } from "#internal/nitro/virtual/app-config";
 import errorHandler from "#internal/nitro/virtual/error-handler";
 import { handlers } from "#internal/nitro/virtual/server-handlers";
 
@@ -116,5 +115,3 @@ function createNitroApp(): NitroApp {
 export const nitroApp: NitroApp = createNitroApp();
 
 export const useNitroApp = () => nitroApp;
-
-export const useAppConfig = () => appConfig;

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -20,6 +20,7 @@ import { useRuntimeConfig } from "./config";
 import { cachedEventHandler } from "./cache";
 import { createRouteRulesHandler, getRouteRulesForPath } from "./route-rules";
 import { plugins } from "#internal/nitro/virtual/plugins";
+import { appConfig } from "#internal/nitro/virtual/app-config";
 import errorHandler from "#internal/nitro/virtual/error-handler";
 import { handlers } from "#internal/nitro/virtual/server-handlers";
 
@@ -115,3 +116,5 @@ function createNitroApp(): NitroApp {
 export const nitroApp: NitroApp = createNitroApp();
 
 export const useNitroApp = () => nitroApp;
+
+export const useAppConfig = () => appConfig;

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -14,7 +14,8 @@ export default runtimeConfig; // TODO: Remove in next major version
 export const useRuntimeConfig = () => runtimeConfig;
 
 // App config
-export const useAppConfig = () => _appConfig;
+const appConfig = deepFreeze(_appConfig);
+export const useAppConfig = () => appConfig;
 
 // --- Utils ---
 

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,5 +1,5 @@
 export { useStorage } from "#internal/nitro/virtual/storage";
-export { useRuntimeConfig } from "./config";
+export { useRuntimeConfig, useAppConfig } from "./config";
 export * from "./cache";
 export { useNitroApp } from "./app";
 export * from "./plugin";

--- a/src/runtime/virtual/app-config.d.ts
+++ b/src/runtime/virtual/app-config.d.ts
@@ -1,0 +1,3 @@
+import type { AppConfig } from "nitropack";
+
+export const appConfig: AppConfig;

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -87,6 +87,10 @@ export interface NitroConfig
   rollupConfig?: Partial<RollupConfig>;
 }
 
+export interface AppConfig {
+  [key: string]: any;
+}
+
 export interface PublicAssetDir {
   baseURL?: string;
   fallthrough?: boolean;
@@ -154,6 +158,8 @@ export interface NitroOptions extends PresetOptions {
     };
     [key: string]: any;
   };
+  appConfig: AppConfig;
+  appConfigFiles: string[];
 
   // Dirs
   workspaceDir: string;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -77,6 +77,23 @@ export function resolvePath(
   return resolve(base || nitroOptions.srcDir, path);
 }
 
+export function resolveFile(
+  path: string,
+  base = ".",
+  extensions = [".js", ".ts", ".mjs", ".cjs", ".json"]
+): string | undefined {
+  path = resolve(base, path);
+  if (existsSync(path)) {
+    return path;
+  }
+  for (const ext of extensions) {
+    const p = path + ext;
+    if (existsSync(p)) {
+      return p;
+    }
+  }
+}
+
 export function replaceAll(input: string, from: string, to: string) {
   return input.replace(new RegExp(from, "g"), to);
 }

--- a/test/fixture/app.config.ts
+++ b/test/fixture/app.config.ts
@@ -1,0 +1,3 @@
+export default {
+  "app-config": true,
+};

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -20,6 +20,10 @@ export default defineNitroConfig({
       dir: "files",
     },
   ],
+  appConfig: {
+    "nitro-config": true,
+  },
+  appConfigFiles: ["~/server.config.ts"],
   publicAssets: [
     {
       baseURL: "build",

--- a/test/fixture/routes/app-config.ts
+++ b/test/fixture/routes/app-config.ts
@@ -1,0 +1,7 @@
+import { appConfig } from "#internal/nitro/virtual/app-config";
+
+export default eventHandler(() => {
+  return {
+    appConfig,
+  };
+});

--- a/test/fixture/routes/app-config.ts
+++ b/test/fixture/routes/app-config.ts
@@ -1,5 +1,3 @@
-import { useAppConfig } from "#imports";
-
 export default eventHandler(() => {
   const appConfig = useAppConfig();
 

--- a/test/fixture/routes/app-config.ts
+++ b/test/fixture/routes/app-config.ts
@@ -1,6 +1,8 @@
-import { appConfig } from "#internal/nitro/virtual/app-config";
+import { useAppConfig } from "#imports";
 
 export default eventHandler(() => {
+  const appConfig = useAppConfig();
+
   return {
     appConfig,
   };

--- a/test/fixture/server.config.ts
+++ b/test/fixture/server.config.ts
@@ -1,0 +1,3 @@
+export default {
+  "server-config": true,
+};

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -317,6 +317,21 @@ export function testNitro(
     }
   }
 
+  it("app config", async () => {
+    const { data } = await callHandler({
+      url: "/app-config",
+    });
+    expect(data).toMatchInlineSnapshot(`
+      {
+        "appConfig": {
+          "app-config": true,
+          "nitro-config": true,
+          "server-config": true,
+        },
+      }
+    `);
+  });
+
   if (ctx.nitro!.options.timing) {
     it("set server timing header", async () => {
       const { data, status, headers } = await callHandler({


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

#728

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

App config, is an alternative to runtime config for bundled application wide configuration. It's main distinction from runtime config is that it supports development HMR and any js value time (while runtime config is limited to JSON serializable ones).

By default `app.config.{ext}` is scanned from all layer's srcDir. Additional app configs to be merged, can be specified by `appConfigFiles: []` option and `appConfig` can be used for inlined app config (sharing serialization limitations. Normal file is always better and recommended)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
