### PR TITLE
fix(prerender): allow spaces in `href` value regex

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -239,7 +239,7 @@ export async function prerender(nitro: Nitro) {
   }
 }
 
-const LINK_REGEX = /href=["']?([^ "'>]+)/g;
+const LINK_REGEX = /href=["']?([^"'>]+)/g;
 
 function extractLinks(
   html: string,


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://github.com/unjs/nitro/issues/1029

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Removes the space character from the end group character set in `LINK_REGEX`. Only single/double quotes can end the match now, allowing for `href` paths with spaces in them.

Resolves https://github.com/unjs/nitro/issues/1029

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
