### PR TITLE
fix: resolve types relative to custom tsconfig path

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -68,16 +68,20 @@ export async function writeTypes(nitro: Nitro) {
     Partial<Record<RouterMethod | "default", string[]>>
   > = {};
 
+  const typesDir = dirname(
+    resolve(nitro.options.buildDir, nitro.options.typescript.tsconfigPath)
+  );
+
   const middleware = [...nitro.scannedHandlers, ...nitro.options.handlers];
 
   for (const mw of middleware) {
     if (typeof mw.handler !== "string" || !mw.route) {
       continue;
     }
-    const relativePath = relative(
-      join(nitro.options.buildDir, "types"),
-      mw.handler
-    ).replace(/\.[a-z]+$/, "");
+    const relativePath = relative(typesDir, mw.handler).replace(
+      /\.[a-z]+$/,
+      ""
+    );
 
     if (!routeTypes[mw.route]) {
       routeTypes[mw.route] = {};
@@ -202,23 +206,9 @@ declare module 'nitropack' {
       },
       include: [
         "./nitro.d.ts",
-        join(
-          relative(
-            join(nitro.options.buildDir, "types"),
-            nitro.options.rootDir
-          ),
-          "**/*"
-        ),
+        join(relative(typesDir, nitro.options.rootDir), "**/*"),
         ...(nitro.options.srcDir !== nitro.options.rootDir
-          ? [
-              join(
-                relative(
-                  join(nitro.options.buildDir, "types"),
-                  nitro.options.srcDir
-                ),
-                "**/*"
-              ),
-            ]
+          ? [join(relative(typesDir, nitro.options.srcDir), "**/*")]
           : []),
       ],
     };

--- a/src/build.ts
+++ b/src/build.ts
@@ -205,7 +205,10 @@ declare module 'nitropack' {
           : {},
       },
       include: [
-        "./nitro.d.ts",
+        relative(
+          typesDir,
+          join(nitro.options.buildDir, "types/nitro.d.ts")
+        ).replace(/^(?=[^.])/, "./"),
         join(relative(typesDir, nitro.options.rootDir), "**/*"),
         ...(nitro.options.srcDir !== nitro.options.rootDir
           ? [join(relative(typesDir, nitro.options.srcDir), "**/*")]


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We now support a custom tsconfig path, but in that PR I neglected to ensure that the paths were resolved relative to the custom path if it were in a different directory.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
