### PR TITLE
fix: remove duplicate import in generated code

### DIFF
--- a/src/rollup/plugins/storage.ts
+++ b/src/rollup/plugins/storage.ts
@@ -24,7 +24,6 @@ export function storage(nitro: Nitro) {
   const driverImports = [...new Set(mounts.map((m) => m.driver))];
 
   const bundledStorageCode = `
-import { prefixStorage } from 'unstorage'
 import overlay from 'unstorage/drivers/overlay'
 import memory from 'unstorage/drivers/memory'
 


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We already have an import generated below:

https://github.com/unjs/nitro/blob/d8ebc8cbf1825ce12d99c98697f8a487479d4a08/src/rollup/plugins/storage.ts#L45

We can avoid the double import, which will cause a build failure whenever bundled storage is in use (e.g. nuxt/content).

```
 ERROR  RollupError: Identifier 'prefixStorage' has already been declared (Note that you need plugins to import files that are not JavaScript)


12: 
13: 
14: import { prefixStorage } from 'unstorage'
             ^
15: import overlay from 'unstorage/drivers/overlay'
16: import memory from 'unstorage/drivers/memory'


 ERROR  Identifier 'prefixStorage' has already been declared (Note that you need plugins to import files that are not JavaScript)              23:23:40

  at error (node_modules/.pnpm/rollup@3.19.1/node_modules/rollup/dist/es/shared/node-entry.js:2125:30)
  at Module.error (node_modules/.pnpm/rollup@3.19.1/node_modules/rollup/dist/es/shared/node-entry.js:13316:16)
  at Module.tryParse (node_modules/.pnpm/rollup@3.19.1/node_modules/rollup/dist/es/shared/node-entry.js:13993:25)
  at Module.setSource (node_modules/.pnpm/rollup@3.19.1/node_modules/rollup/dist/es/shared/node-entry.js:13603:39)
  at ModuleLoader.addModuleSource (node_modules/.pnpm/rollup@3.19.1/node_modules/rollup/dist/es/shared/node-entry.js:23569:20)
```

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
