### PR TITLE
fix(types): exclude non serializable options from route rules

### DIFF
--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -125,7 +125,19 @@ type IntRange<F extends number, T extends number> = Exclude<
 type HTTPStatusCode = IntRange<100, 600>;
 
 export interface NitroRouteConfig {
-  cache?: CachedEventHandlerOptions | false;
+  cache?:
+    | Exclude<
+        CachedEventHandlerOptions,
+        | "getKey"
+        | "transform"
+        | "validate"
+        | "shouldInvalidateCache"
+        | "shouldBypassCache"
+        | "shouldInvalidateCache"
+        | "shouldBypassCache"
+        | "getKey"
+      >
+    | false;
   headers?: Record<string, string>;
   redirect?: string | { to: string; statusCode?: HTTPStatusCode };
   prerender?: boolean;

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -124,20 +124,14 @@ type IntRange<F extends number, T extends number> = Exclude<
 >;
 type HTTPStatusCode = IntRange<100, 600>;
 
+type ExcludeFunctions<G extends Record<string, any>> = Pick<
+  G,
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  { [P in keyof G]: NonNullable<G[P]> extends Function ? never : P }[keyof G]
+>;
+
 export interface NitroRouteConfig {
-  cache?:
-    | Exclude<
-        CachedEventHandlerOptions,
-        | "getKey"
-        | "transform"
-        | "validate"
-        | "shouldInvalidateCache"
-        | "shouldBypassCache"
-        | "shouldInvalidateCache"
-        | "shouldBypassCache"
-        | "getKey"
-      >
-    | false;
+  cache?: ExcludeFunctions<CachedEventHandlerOptions> | false;
   headers?: Record<string, string>;
   redirect?: string | { to: string; statusCode?: HTTPStatusCode };
   prerender?: boolean;

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -1,6 +1,7 @@
 import { expectTypeOf } from "expect-type";
 import { describe, it } from "vitest";
 import { $Fetch } from "../..";
+import { defineNitroConfig } from "../../src/options";
 
 interface TestResponse {
   message: string;
@@ -218,5 +219,22 @@ describe("API routes", () => {
     expectTypeOf($fetch("/api/serialized/tuple")).toMatchTypeOf<
       Promise<[string, string]>
     >();
+  });
+});
+
+describe("defineNitroConfig", () => {
+  it("should not accept functions to routeRules.cache", () => {
+    defineNitroConfig({
+      routeRules: {
+        "/**": {
+          cache: {
+            // @ts-expect-error
+            shouldBypassCache(event) {
+              return false;
+            },
+          },
+        },
+      },
+    });
   });
 });


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

closes #977

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We were wrongly typing non-supported cache options (nonserializable functions) for `cache` key in `routeRules`.



### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
