### PR TITLE
fix: don't simplify type of serialized return

### DIFF
--- a/src/types/fetch.ts
+++ b/src/types/fetch.ts
@@ -1,6 +1,6 @@
 import type { RouterMethod } from "h3";
 import type { FetchRequest, FetchOptions, FetchResponse } from "ofetch";
-import type { Serialize, Simplify } from "./serialize";
+import type { Serialize } from "./serialize";
 import type { MatchedRoutes } from "./utils";
 
 // An interface to extend in a local project
@@ -13,15 +13,12 @@ export type NitroFetchRequest =
   // eslint-disable-next-line @typescript-eslint/ban-types
   | (string & {});
 
+// TODO: re-enable Simplify
 export type MiddlewareOf<
   Route extends string,
   Method extends RouterMethod | "default"
 > = Method extends keyof InternalApi[MatchedRoutes<Route>]
-  ? Simplify<
-      Serialize<
-        Exclude<InternalApi[MatchedRoutes<Route>][Method], Error | void>
-      >
-    >
+  ? Exclude<Serialize<InternalApi[MatchedRoutes<Route>][Method]>, Error | void>
   : never;
 
 export type TypedInternalResponse<

--- a/test/fixture/api/param/[id].ts
+++ b/test/fixture/api/param/[id].ts
@@ -1,3 +1,3 @@
 export default eventHandler((event) => {
-  return event.context.params.id;
+  return event.context.params!.id;
 });

--- a/test/fixture/api/serialized/error.ts
+++ b/test/fixture/api/serialized/error.ts
@@ -1,0 +1,5 @@
+export default defineEventHandler(() => {
+  return createError({
+    statusCode: 400,
+  });
+});

--- a/test/fixture/api/serialized/null.ts
+++ b/test/fixture/api/serialized/null.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler(() => {
+  return null;
+});

--- a/test/fixture/api/serialized/void.ts
+++ b/test/fixture/api/serialized/void.ts
@@ -1,0 +1,1 @@
+export default defineEventHandler(() => {});

--- a/test/fixture/api/wildcard/[...param].ts
+++ b/test/fixture/api/wildcard/[...param].ts
@@ -1,3 +1,3 @@
 export default eventHandler((event) => {
-  return event.context.params.param as string;
+  return event.context.params!.param as string;
 });

--- a/test/fixture/routes/icon.png.ts
+++ b/test/fixture/routes/icon.png.ts
@@ -6,7 +6,7 @@ export default eventHandler((event) => {
   event.res.end(buff);
 });
 
-function base64ToArray(base64) {
+function base64ToArray(base64: string) {
   const str = atob(base64);
   const bytes = new Uint8Array(str.length);
   for (let i = 0; i < str.length; i++) {

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -14,7 +14,7 @@ describe("API routes", () => {
   const dynamicString: string = "";
 
   it("generates types for middleware, unknown and manual typed routes", () => {
-    expectTypeOf($fetch("/")).toMatchTypeOf<Promise<unknown>>(); // middleware
+    expectTypeOf($fetch("/")).toEqualTypeOf<Promise<unknown>>(); // middleware
     expectTypeOf($fetch("/api/unknown")).toEqualTypeOf<Promise<unknown>>();
     expectTypeOf($fetch<TestResponse>("/test")).toEqualTypeOf<
       Promise<TestResponse>
@@ -176,47 +176,47 @@ describe("API routes", () => {
   });
 
   it("generates the correct type depending on the method used", () => {
-    expectTypeOf($fetch("/api/methods", { method: "get" })).toMatchTypeOf<
+    expectTypeOf($fetch("/api/methods", { method: "get" })).toEqualTypeOf<
       Promise<"Index get">
     >();
-    expectTypeOf($fetch("/api/methods", { method: "post" })).toMatchTypeOf<
+    expectTypeOf($fetch("/api/methods", { method: "post" })).toEqualTypeOf<
       Promise<"Index post">
     >();
     expectTypeOf(
       $fetch("/api/methods/default", { method: "GET" })
-    ).toMatchTypeOf<Promise<"Default route">>();
+    ).toEqualTypeOf<Promise<"Default route">>();
     expectTypeOf(
       $fetch("/api/methods/default", { method: "PUT" })
-    ).toMatchTypeOf<Promise<"Default route">>();
+    ).toEqualTypeOf<Promise<"Default route">>();
     expectTypeOf(
       $fetch("/api/methods/default", { method: "POST" })
-    ).toMatchTypeOf<Promise<"Default override">>();
+    ).toEqualTypeOf<Promise<"Default override">>();
   });
 
   it("generates types matching JSON serialization output", () => {
-    expectTypeOf($fetch("/api/serialized/date")).toMatchTypeOf<
+    expectTypeOf($fetch("/api/serialized/date")).toEqualTypeOf<
       Promise<{
         createdAt: string;
       }>
     >();
 
-    expectTypeOf($fetch("/api/serialized/function")).toMatchTypeOf<
+    expectTypeOf($fetch("/api/serialized/function")).toEqualTypeOf<
       Promise<object>
     >();
 
-    expectTypeOf($fetch("/api/serialized/map")).toMatchTypeOf<
+    expectTypeOf($fetch("/api/serialized/map")).toEqualTypeOf<
       Promise<{
         foo: Record<string, never>;
       }>
     >();
 
-    expectTypeOf($fetch("/api/serialized/set")).toMatchTypeOf<
+    expectTypeOf($fetch("/api/serialized/set")).toEqualTypeOf<
       Promise<{
         foo: Record<string, never>;
       }>
     >();
 
-    expectTypeOf($fetch("/api/serialized/tuple")).toMatchTypeOf<
+    expectTypeOf($fetch("/api/serialized/tuple")).toEqualTypeOf<
       Promise<[string, string]>
     >();
   });

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -200,6 +200,16 @@ describe("API routes", () => {
       }>
     >();
 
+    expectTypeOf($fetch("/api/serialized/error")).toEqualTypeOf<
+      Promise<unknown>
+    >();
+
+    expectTypeOf($fetch("/api/serialized/void")).toEqualTypeOf<
+      Promise<unknown>
+    >();
+
+    expectTypeOf($fetch("/api/serialized/null")).toEqualTypeOf<Promise<null>>();
+
     expectTypeOf($fetch("/api/serialized/function")).toEqualTypeOf<
       Promise<object>
     >();


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/19654

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We are experiencing issue comparing routes triggered by https://github.com/unjs/nitro/pull/1002. This slightly decreases complexity but we really need to find a solution for this on larger projects. (And ideally to replicate regression locally in type fixture by, as a first step, enabling `strict: true` in nitro and increasing type complexity.)

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
