### PR TITLE
fix: sanitize `statusMessage` of disallowed chars

### DIFF
--- a/src/dev/error.ts
+++ b/src/dev/error.ts
@@ -1,9 +1,9 @@
+import { setResponseStatus } from "h3";
 import { NitroErrorHandler } from "../types";
 
 function errorHandler(error, event) {
   event.node.res.setHeader("Content-Type", "text/html; charset=UTF-8");
-  event.node.res.statusCode = 503;
-  event.node.res.statusMessage = "Server Unavailable";
+  setResponseStatus(event, 503, "Server Unavailable");
 
   let body;
   let title;

--- a/src/runtime/error.ts
+++ b/src/runtime/error.ts
@@ -43,7 +43,12 @@ export default <NitroErrorHandler>function (error, event) {
 
   event.node.res.statusCode = statusCode;
   if (statusMessage) {
-    event.node.res.statusMessage = statusMessage;
+    // Allowed characters: horizontal tabs, spaces or visible ascii characters: https://www.rfc-editor.org/rfc/rfc7230#section-3.1.2
+    event.node.res.statusMessage = statusMessage.replace(
+      // eslint-disable-next-line no-control-regex
+      /[^\u0009\u0020-\u007E]/g,
+      ""
+    );
   }
 
   if (isJsonRequest(event)) {

--- a/src/runtime/error.ts
+++ b/src/runtime/error.ts
@@ -1,4 +1,5 @@
 // import ansiHTML from 'ansi-html'
+import { setResponseStatus } from "h3";
 import type { NitroErrorHandler } from "../types";
 import { normalizeError, isJsonRequest } from "./utils";
 
@@ -41,15 +42,7 @@ export default <NitroErrorHandler>function (error, event) {
     );
   }
 
-  event.node.res.statusCode = statusCode;
-  if (statusMessage) {
-    // Allowed characters: horizontal tabs, spaces or visible ascii characters: https://www.rfc-editor.org/rfc/rfc7230#section-3.1.2
-    event.node.res.statusMessage = statusMessage.replace(
-      // eslint-disable-next-line no-control-regex
-      /[^\u0009\u0020-\u007E]/g,
-      ""
-    );
-  }
+  setResponseStatus(event, statusCode, statusMessage);
 
   if (isJsonRequest(event)) {
     event.node.res.setHeader("Content-Type", "application/json");

--- a/src/runtime/renderer.ts
+++ b/src/runtime/renderer.ts
@@ -1,4 +1,4 @@
-import { H3Event, eventHandler } from "h3";
+import { H3Event, eventHandler, setResponseStatus } from "h3";
 import { useNitroApp } from "./app";
 
 export interface RenderResponse {
@@ -48,12 +48,7 @@ export function defineRenderHandler(handler: RenderHandler) {
       for (const header in response.headers) {
         event.node.res.setHeader(header, response.headers[header]);
       }
-      if (response.statusCode) {
-        event.node.res.statusCode = response.statusCode;
-      }
-      if (response.statusMessage) {
-        event.node.res.statusMessage = response.statusMessage;
-      }
+      setResponseStatus(event, response.statusCode, response.statusMessage);
     }
 
     // Send response body


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It will break the response if we set any of these characters by accident (e.g. if a user includes in an error message).

Related: https://github.com/nuxt/nuxt/issues/14688

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
