### PR TITLE
fix(azure): support custom baseURL

### DIFF
--- a/src/presets/azure.ts
+++ b/src/presets/azure.ts
@@ -8,6 +8,7 @@ export const azure = defineNitroPreset({
   entry: "#internal/nitro/entries/azure",
   output: {
     serverDir: "{{ output.dir }}/server/functions",
+    publicDir: "{{ output.dir }}/public/{{ baseURL }}",
   },
   commands: {
     preview:
@@ -135,6 +136,14 @@ async function writeRoutes(nitro: Nitro) {
     JSON.stringify(config, null, 2)
   );
   if (!indexFileExists) {
-    await writeFile(resolve(nitro.options.output.publicDir, "index.html"), "");
+    const baseURLSegments = nitro.options.baseURL.split("/").filter(Boolean);
+    const relativePrefix = baseURLSegments.map(() => "..").join("/");
+    await writeFile(
+      resolve(
+        nitro.options.output.publicDir,
+        relativePrefix ? `${relativePrefix}/index.html` : "index.html"
+      ),
+      ""
+    );
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/unjs/nitro/issues/1061
https://github.com/nuxt/nuxt/issues/19385

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds support for custom baseURLs by nesting the public directory with the correct prefix. (We still have to write our empty `index.html` in the root, though.)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
