### PR TITLE
fix(vercel-edge): fix route generation

### DIFF
--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -193,7 +193,10 @@ function generateBuildConfig(nitro: Nitro) {
           }
           return {
             src,
-            dest: generateEndpoint(key) + "?url=$url",
+            dest:
+              nitro.options.preset === "vercel-edge"
+                ? "/__nitro?url=$url"
+                : generateEndpoint(key) + "?url=$url",
           };
         }),
       // If we are using a prerender function for /, then we need to write this explicitly


### PR DESCRIPTION
It seems `routeRules` generates invalid routes when using the `vercel-edge` preset.

This is because nitro only creates pretender functions for the `vercel` preset:
https://github.com/unjs/nitro/blob/4585ca856b0fb4d5601e30fc36f9dbde4aef03de/src/presets/vercel.ts#L51-L85

and the `generateEndpoint` function isn't considering the `vercel-edge` preset:
https://github.com/unjs/nitro/blob/4585ca856b0fb4d5601e30fc36f9dbde4aef03de/src/presets/vercel.ts#L226-L234

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
