### PR TITLE
docs: moved 'yarn build' to new line in sample code

### DIFF
--- a/docs/content/2.deploy/providers/azure.md
+++ b/docs/content/2.deploy/providers/azure.md
@@ -19,7 +19,8 @@ Azure Static Web Apps are designed to be deployed continuously in a [GitHub Acti
 You can invoke a development environment to preview before deploying.
 
 ```bash
-NITRO_PRESET=azure yarn build
+NITRO_PRESET=azure 
+yarn build
 npx @azure/static-web-apps-cli start .output/public --api-location .output/server
 ```
 


### PR DESCRIPTION


<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

[ x ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

As someone who hasn't used server-side for Nuxt much, this was very confusing.  I was setting the `NITRO_PRESET` environment variable to `azure yarn build` rather than `NITRO_PRESET=azure` then running `yarn build` as it should be

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ x ] I have updated the documentation accordingly.
