### PR TITLE
fix: return file URLs for absolute externals

### DIFF
--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -79,7 +79,10 @@ export function externals(opts: NodeExternalsOptions): Plugin {
           (i) => id.startsWith(i) || idWithoutNodeModules.startsWith(i)
         )
       ) {
-        return { id, external: true };
+        return {
+          id: isAbsolute(id) ? normalizeid(id) : id,
+          external: true,
+        };
       }
 
       // Resolve id using rollup resolver


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/19453

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We already normalize absolute paths to file URLs lower down; this ensures we do the same if we can early-return by virtue of having an id explicitly in `opts.external`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
