### PR TITLE
fix(prerender): respect output path from main preset

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -60,10 +60,12 @@ export async function prerender(nitro: Nitro) {
   });
 
   // Set path to preview prerendered routes relative to the "host" nitro preset
-  let path = relative(nitro.options.output.dir, nitro.options.output.publicDir)
-  if (!path.startsWith('.')) { path = `./${path}` }
-  nitroRenderer.options.commands.preview = `npx serve ${path}`
-  nitroRenderer.options.output.dir = nitro.options.output.dir
+  let path = relative(nitro.options.output.dir, nitro.options.output.publicDir);
+  if (!path.startsWith(".")) {
+    path = `./${path}`;
+  }
+  nitroRenderer.options.commands.preview = `npx serve ${path}`;
+  nitroRenderer.options.output.dir = nitro.options.output.dir;
 
   await build(nitroRenderer);
 

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -1,5 +1,5 @@
 import { pathToFileURL } from "node:url";
-import { resolve, join } from "pathe";
+import { resolve, join, relative } from "pathe";
 import { joinURL, parseURL, withBase, withoutBase } from "ufo";
 import chalk from "chalk";
 import { createRouter as createRadixRouter, toRouteMatcher } from "radix3";
@@ -58,6 +58,13 @@ export async function prerender(nitro: Nitro) {
     logLevel: 0,
     preset: "nitro-prerender",
   });
+
+  // Set path to preview prerendered routes relative to the "host" nitro preset
+  let path = relative(nitro.options.output.dir, nitro.options.output.publicDir)
+  if (!path.startsWith('.')) { path = `./${path}` }
+  nitroRenderer.options.commands.preview = `npx serve ${path}`
+  nitroRenderer.options.output.dir = nitro.options.output.dir
+
   await build(nitroRenderer);
 
   // Import renderer entry

--- a/src/presets/nitro-prerender.ts
+++ b/src/presets/nitro-prerender.ts
@@ -6,8 +6,5 @@ export const nitroPrerender = defineNitroPreset({
   output: {
     serverDir: "{{ buildDir }}/prerender",
   },
-  commands: {
-    preview: "npx serve ./public",
-  },
   externals: { trace: false },
 });


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/19883

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

At the moment we hard code `nitro-prerender` preset command to assume a certain directory structure. This respects the 'host' nitro preset output directories to produce the preview command. 

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
