### PR TITLE
feat(vercel, netlify): introduce `isr` route rule

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -310,11 +310,6 @@ export async function loadOptions(
         routeRules.cache.maxAge = routeConfig.swr;
       }
     }
-    // Cache: static
-    if (routeConfig.static) {
-      routeRules.cache = routeRules.cache || {};
-      routeRules.cache.static = true;
-    }
     // Cache: false
     if (routeConfig.cache === false) {
       routeRules.cache = false;

--- a/src/presets/netlify.ts
+++ b/src/presets/netlify.ts
@@ -83,19 +83,15 @@ async function writeRedirects(nitro: Nitro) {
     (a, b) => a[0].split(/\/(?!\*)/).length - b[0].split(/\/(?!\*)/).length
   );
 
-  // Rewrite static cached paths to builder functions
+  // Rewrite static ISR paths to builder functions
   for (const [key, value] of rules.filter(
-    ([_, value]) =>
-      value.cache === false ||
-      (value.cache && value.cache.swr === false) ||
-      (value.cache && (value.cache?.static || value.cache?.swr))
+    ([_, value]) => value.isr !== undefined
   )) {
-    contents =
-      value.cache === false || value.cache.swr === false
-        ? `${key.replace("/**", "/*")}\t/.netlify/functions/server 200\n` +
-          contents
-        : `${key.replace("/**", "/*")}\t/.netlify/builders/server 200\n` +
-          contents;
+    contents = value.isr
+      ? `${key.replace("/**", "/*")}\t/.netlify/builders/server 200\n` +
+        contents
+      : `${key.replace("/**", "/*")}\t/.netlify/functions/server 200\n` +
+        contents;
   }
 
   for (const [key, routeRules] of rules.filter(

--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -26,7 +26,6 @@ export interface CacheOptions<T = any> {
   group?: string;
   integrity?: any;
   maxAge?: number;
-  static?: boolean; // TODO
   swr?: boolean;
   staleMaxAge?: number;
   base?: string;

--- a/src/runtime/entries/netlify.ts
+++ b/src/runtime/entries/netlify.ts
@@ -12,17 +12,16 @@ export const handler: Handler = async function handler(event, context) {
   const url = withQuery(event.path, query);
   const routeRules = getRouteRulesForPath(url);
 
-  if (routeRules.cache && (routeRules.cache.swr || routeRules.cache.static)) {
+  if (routeRules.isr) {
     const builder = await import("@netlify/functions").then(
       (r) => r.builder || r.default.builder
     );
-    const ttl =
-      typeof routeRules.cache.swr === "number" ? routeRules.cache.swr : 60;
-    const swrHandler = routeRules.cache.swr
+    const ttl = typeof routeRules.isr === "number" ? routeRules.isr : false;
+    const builderHandler = ttl
       ? (((event, context) =>
           lambda(event, context).then((r) => ({ ...r, ttl }))) as Handler)
       : lambda;
-    return builder(swrHandler)(event, context) as any;
+    return builder(builderHandler)(event, context) as any;
   }
 
   return lambda(event, context);

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -136,6 +136,7 @@ export interface NitroRouteConfig {
   redirect?: string | { to: string; statusCode?: HTTPStatusCode };
   prerender?: boolean;
   proxy?: string | ({ to: string } & ProxyOptions);
+  isr?: number | boolean;
 
   // Shortcuts
   cors?: boolean;

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -35,6 +35,26 @@ export default defineNitroConfig({
   routeRules: {
     "/api/param/prerender4": { prerender: true },
     "/api/param/prerender2": { prerender: false },
+    "/rules/headers": { headers: { "cache-control": "s-maxage=60" } },
+    "/rules/cors": {
+      cors: true,
+      headers: { "access-control-allow-methods": "GET" },
+    },
+    "/rules/dynamic": { cache: false, isr: false },
+    "/rules/redirect": { redirect: "/base" },
+    "/rules/isr/**": { isr: true },
+    "/rules/isr-ttl/**": { isr: 60 },
+    "/rules/swr/**": { swr: true },
+    "/rules/swr-ttl/**": { swr: 60 },
+    "/rules/redirect/obj": {
+      redirect: { to: "https://nitro.unjs.io/", statusCode: 308 },
+    },
+    "/rules/nested/**": { redirect: "/base", headers: { "x-test": "test" } },
+    "/rules/nested/override": { redirect: { to: "/other" } },
+    "/rules/_/noncached/cached": { swr: true },
+    "/rules/_/noncached/**": { swr: false, cache: false, isr: false },
+    "/rules/_/cached/noncached": { cache: false, swr: false, isr: false },
+    "/rules/_/cached/**": { swr: true },
   },
   prerender: {
     crawlLinks: true,

--- a/test/presets/netlify.test.ts
+++ b/test/presets/netlify.test.ts
@@ -45,12 +45,9 @@ describe("nitro:preset:netlify", async () => {
       /rules/nested/*	/base	302
       /rules/redirect	/base	302
       /rules/_/cached/noncached	/.netlify/functions/server 200
-      /rules/_/noncached/cached	/.netlify/builders/server 200
-      /rules/_/cached/*	/.netlify/builders/server 200
       /rules/_/noncached/*	/.netlify/functions/server 200
-      /rules/swr-ttl/*	/.netlify/builders/server 200
-      /rules/swr/*	/.netlify/builders/server 200
-      /rules/static	/.netlify/builders/server 200
+      /rules/isr-ttl/*	/.netlify/builders/server 200
+      /rules/isr/*	/.netlify/builders/server 200
       /rules/dynamic	/.netlify/functions/server 200
       /* /.netlify/functions/server 200"
     `);

--- a/test/presets/vercel.test.ts
+++ b/test/presets/vercel.test.ts
@@ -24,120 +24,116 @@ describe("nitro:preset:vercel", async () => {
           .readFile(resolve(ctx.outDir, "config.json"), "utf8")
           .then((r) => JSON.parse(r));
         expect(config).toMatchInlineSnapshot(`
-        {
-          "overrides": {
-            "api/hey/index.html": {
-              "path": "api/hey",
-            },
-            "api/param/foo.json/index.html": {
-              "path": "api/param/foo.json",
-            },
-            "api/param/prerender1/index.html": {
-              "path": "api/param/prerender1",
-            },
-            "api/param/prerender3/index.html": {
-              "path": "api/param/prerender3",
-            },
-            "api/param/prerender4/index.html": {
-              "path": "api/param/prerender4",
-            },
-            "prerender/index.html": {
-              "path": "prerender",
-            },
-          },
-          "routes": [
-            {
-              "headers": {
-                "Location": "https://nitro.unjs.io/",
+          {
+            "overrides": {
+              "api/hey/index.html": {
+                "path": "api/hey",
               },
-              "src": "/rules/redirect/obj",
-              "status": 308,
-            },
-            {
-              "headers": {
-                "Location": "/other",
+              "api/param/foo.json/index.html": {
+                "path": "api/param/foo.json",
               },
-              "src": "/rules/nested/override",
-              "status": 307,
-            },
-            {
-              "headers": {
-                "cache-control": "s-maxage=60",
+              "api/param/prerender1/index.html": {
+                "path": "api/param/prerender1",
               },
-              "src": "/rules/headers",
-            },
-            {
-              "headers": {
-                "access-control-allow-headers": "*",
-                "access-control-allow-methods": "GET",
-                "access-control-allow-origin": "*",
-                "access-control-max-age": "0",
+              "api/param/prerender3/index.html": {
+                "path": "api/param/prerender3",
               },
-              "src": "/rules/cors",
-            },
-            {
-              "headers": {
-                "Location": "/base",
+              "api/param/prerender4/index.html": {
+                "path": "api/param/prerender4",
               },
-              "src": "/rules/redirect",
-              "status": 307,
-            },
-            {
-              "headers": {
-                "Location": "/base",
-                "x-test": "test",
+              "prerender/index.html": {
+                "path": "prerender",
               },
-              "src": "/rules/nested/.*",
-              "status": 307,
             },
-            {
-              "headers": {
-                "cache-control": "public, max-age=3600, immutable",
+            "routes": [
+              {
+                "headers": {
+                  "Location": "https://nitro.unjs.io/",
+                },
+                "src": "/rules/redirect/obj",
+                "status": 308,
               },
-              "src": "/build/.*",
-            },
-            {
-              "continue": true,
-              "headers": {
-                "cache-control": "public,max-age=31536000,immutable",
+              {
+                "headers": {
+                  "Location": "/other",
+                },
+                "src": "/rules/nested/override",
+                "status": 307,
               },
-              "src": "/build(.*)",
-            },
-            {
-              "handle": "filesystem",
-            },
-            {
-              "dest": "/__nitro",
-              "src": "/rules/_/cached/noncached",
-            },
-            {
-              "dest": "/__nitro",
-              "src": "(?<url>/rules/_/noncached/.*)",
-            },
-            {
-              "dest": "/__nitro--rules---cached?url=$url",
-              "src": "(?<url>/rules/_/cached/.*)",
-            },
-            {
-              "dest": "/__nitro",
-              "src": "/rules/dynamic",
-            },
-            {
-              "dest": "/__nitro--rules-swr?url=$url",
-              "src": "(?<url>/rules/swr/.*)",
-            },
-            {
-              "dest": "/__nitro--rules-swr-ttl?url=$url",
-              "src": "(?<url>/rules/swr-ttl/.*)",
-            },
-            {
-              "dest": "/__nitro",
-              "src": "/(.*)",
-            },
-          ],
-          "version": 3,
-        }
-      `);
+              {
+                "headers": {
+                  "cache-control": "s-maxage=60",
+                },
+                "src": "/rules/headers",
+              },
+              {
+                "headers": {
+                  "access-control-allow-headers": "*",
+                  "access-control-allow-methods": "GET",
+                  "access-control-allow-origin": "*",
+                  "access-control-max-age": "0",
+                },
+                "src": "/rules/cors",
+              },
+              {
+                "headers": {
+                  "Location": "/base",
+                },
+                "src": "/rules/redirect",
+                "status": 307,
+              },
+              {
+                "headers": {
+                  "Location": "/base",
+                  "x-test": "test",
+                },
+                "src": "/rules/nested/.*",
+                "status": 307,
+              },
+              {
+                "headers": {
+                  "cache-control": "public, max-age=3600, immutable",
+                },
+                "src": "/build/.*",
+              },
+              {
+                "continue": true,
+                "headers": {
+                  "cache-control": "public,max-age=31536000,immutable",
+                },
+                "src": "/build(.*)",
+              },
+              {
+                "handle": "filesystem",
+              },
+              {
+                "dest": "/__nitro",
+                "src": "/rules/_/cached/noncached",
+              },
+              {
+                "dest": "/__nitro",
+                "src": "(?<url>/rules/_/noncached/.*)",
+              },
+              {
+                "dest": "/__nitro",
+                "src": "/rules/dynamic",
+              },
+              {
+                "dest": "/__nitro--rules-isr?url=$url",
+                "src": "(?<url>/rules/isr/.*)",
+              },
+              {
+                "dest": "/__nitro--rules-isr-ttl?url=$url",
+                "src": "(?<url>/rules/isr-ttl/.*)",
+              },
+              {
+                "dest": "/__nitro",
+                "src": "/(.*)",
+              },
+            ],
+            "version": 3,
+          }
+        `);
       });
     }
   );

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -53,27 +53,6 @@ export async function setupTest(preset: string) {
     output: {
       dir: ctx.outDir,
     },
-    routeRules: {
-      "/rules/headers": { headers: { "cache-control": "s-maxage=60" } },
-      "/rules/cors": {
-        cors: true,
-        headers: { "access-control-allow-methods": "GET" },
-      },
-      "/rules/dynamic": { cache: false },
-      "/rules/redirect": { redirect: "/base" },
-      "/rules/static": { static: true },
-      "/rules/swr/**": { swr: true },
-      "/rules/swr-ttl/**": { swr: 60 },
-      "/rules/redirect/obj": {
-        redirect: { to: "https://nitro.unjs.io/", statusCode: 308 },
-      },
-      "/rules/nested/**": { redirect: "/base", headers: { "x-test": "test" } },
-      "/rules/nested/override": { redirect: { to: "/other" } },
-      "/rules/_/noncached/cached": { swr: true },
-      "/rules/_/noncached/**": { swr: false, cache: false },
-      "/rules/_/cached/noncached": { cache: false, swr: false },
-      "/rules/_/cached/**": { swr: true },
-    },
     timing:
       preset !== "cloudflare" &&
       preset !== "cloudflare-pages" &&


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

Resolves #946

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We had been experimenting vercel ISR and netlify Builders feature via an implicit cache route rule. 

Introducing a new `isr` flag, unblocks to combine nitro native cache (SWR) with platform native rules and giving the flexibility to use the most effective caching mechanism. (Currently, on these platforms nitro cache/storage cannot be used)

Note: This is a semi-breaking change for this platforms however switching `swr` to built-in behavior still preserves in memory cache so caching keeps working only can be changed to either isr or permanent by mounting `/storage` for production.

This PR also drops (almost unused) `static` cache rule.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
