### PR TITLE
feat: add `static` preset

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -28,6 +28,7 @@ const NitroDefaults: NitroConfig = {
   // General
   debug: isDebug,
   logLevel: isTest ? 1 : 3,
+  build: true,
   runtimeConfig: { app: {}, nitro: {} },
   appConfig: {},
   appConfigFiles: [],
@@ -169,12 +170,14 @@ export async function loadOptions(
   };
 
   // Resolve possibly template paths
-  if (!options.entry) {
+  if (options.build && !options.entry) {
     throw new Error(
       `Nitro entry is missing! Is "${options.preset}" preset correct?`
     );
   }
-  options.entry = resolvePath(options.entry, options);
+  if (options.entry) {
+    options.entry = resolvePath(options.entry, options);
+  }
   options.output.dir = resolvePath(
     options.output.dir || NitroDefaults.output.dir,
     options

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -23,3 +23,4 @@ export * from "./vercel";
 export * from "./cleavr";
 export * from "./layer0";
 export * from "./lagon";
+export * from "./static";

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -23,4 +23,4 @@ export * from "./vercel";
 export * from "./cleavr";
 export * from "./layer0";
 export * from "./lagon";
-export * from "./static";
+export { _static as static } from "./static";

--- a/src/presets/static.ts
+++ b/src/presets/static.ts
@@ -1,6 +1,6 @@
 import { defineNitroPreset } from "../preset";
 
-export const baseStatic = defineNitroPreset({
+export const _static = defineNitroPreset({
   build: false,
   output: {
     dir: "{{ rootDir }}/.output",

--- a/src/presets/static.ts
+++ b/src/presets/static.ts
@@ -1,6 +1,6 @@
 import { defineNitroPreset } from "../preset";
 
-export const baseStatic = defineNitroPreset({
+export const static = defineNitroPreset({
   build: false,
   output: {
     dir: "{{ rootDir }}/.output",

--- a/src/presets/static.ts
+++ b/src/presets/static.ts
@@ -1,6 +1,6 @@
 import { defineNitroPreset } from "../preset";
 
-export const static = defineNitroPreset({
+export const baseStatic = defineNitroPreset({
   build: false,
   output: {
     dir: "{{ rootDir }}/.output",

--- a/src/presets/static.ts
+++ b/src/presets/static.ts
@@ -6,6 +6,9 @@ export const baseStatic = defineNitroPreset({
     dir: "{{ rootDir }}/.output",
     publicDir: "{{ output.dir }}/public",
   },
+  prerender: {
+    crawlLinks: true
+  },
   commands: {
     preview: "npx serve ./public",
   },

--- a/src/presets/static.ts
+++ b/src/presets/static.ts
@@ -7,7 +7,7 @@ export const baseStatic = defineNitroPreset({
     publicDir: "{{ output.dir }}/public",
   },
   prerender: {
-    crawlLinks: true
+    crawlLinks: true,
   },
   commands: {
     preview: "npx serve ./public",

--- a/src/presets/static.ts
+++ b/src/presets/static.ts
@@ -1,0 +1,12 @@
+import { defineNitroPreset } from "../preset";
+
+export const baseStatic = defineNitroPreset({
+  build: false,
+  output: {
+    dir: "{{ rootDir }}/.output",
+    publicDir: "{{ output.dir }}/public",
+  },
+  commands: {
+    preview: "npx serve ./public",
+  },
+});

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -158,6 +158,7 @@ export interface NitroOptions extends PresetOptions {
   debug: boolean;
   // eslint-disable-next-line @typescript-eslint/ban-types
   preset: KebabCase<keyof typeof _PRESETS> | (string & {});
+  build: boolean;
   logLevel: LogLevel;
   runtimeConfig: {
     app: {

--- a/test/presets/static.test.ts
+++ b/test/presets/static.test.ts
@@ -1,0 +1,17 @@
+import fsp from 'node:fs/promises';
+import { resolve } from "pathe";
+import { describe, it, expect } from "vitest";
+import { setupTest } from "../tests";
+
+describe("nitro:preset:base-static", async () => {
+  const ctx = await setupTest("base-static");
+  it("should not generate a server folder", async () => {
+    const contents = await fsp.readdir(resolve(ctx.outDir));
+    expect(contents).toMatchInlineSnapshot(`
+      [
+        "nitro.json",
+        "public",
+      ]
+    `)
+  });
+});

--- a/test/presets/static.test.ts
+++ b/test/presets/static.test.ts
@@ -1,10 +1,10 @@
-import fsp from 'node:fs/promises';
+import fsp from "node:fs/promises";
 import { resolve } from "pathe";
 import { describe, it, expect } from "vitest";
 import { setupTest } from "../tests";
 
-describe("nitro:preset:base-static", async () => {
-  const ctx = await setupTest("base-static");
+describe("nitro:preset:static", async () => {
+  const ctx = await setupTest("static");
   it("should not generate a server folder", async () => {
     const contents = await fsp.readdir(resolve(ctx.outDir));
     expect(contents).toMatchInlineSnapshot(`
@@ -12,6 +12,6 @@ describe("nitro:preset:base-static", async () => {
         "nitro.json",
         "public",
       ]
-    `)
+    `);
   });
 });


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/unjs/nitro/issues/797

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a basic static preset that can be extended to create `vercel-static`, `github-pages` and more.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
