### PR TITLE
feat: add `github-pages` preset

### DIFF
--- a/docs/content/2.deploy/providers/github-pages.md
+++ b/docs/content/2.deploy/providers/github-pages.md
@@ -1,0 +1,69 @@
+# GitHub Pages
+
+Deploy Nitro apps to GitHub Pages.
+
+**Preset:** `github-pages` ([switch to this preset](/deploy/#changing-the-deployment-preset))
+
+Nitro supports deploying on [GitHub Pages](https://pages.github.com/) with minimal configuration.
+
+## Setup
+
+Follow the steps to [create a GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-github-pages-site).
+
+## Deployment
+
+Here is an example GitHub Actions workflow to deploy your site to GitHub Pages using the `github-pages` preset:
+
+```yml
+# https://github.com/actions/deploy-pages#usage
+name: Deploy to GitHub Pages
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: corepack enable
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+
+      # Pick your own package manager and build script
+      - run: npm install
+      - run: npm run build
+        env:
+          NITRO_PRESET: github-pages
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./.output/public
+
+  # Deployment job
+  deploy:
+    # Add a dependency to the build job
+    needs: build
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1
+```

--- a/src/presets/github-pages.ts
+++ b/src/presets/github-pages.ts
@@ -7,6 +7,12 @@ export const githubPages = defineNitroPreset({
   commands: {
     deploy: "npx gh-pages -d ./public",
   },
+  prerender: {
+    routes: [
+      // https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-custom-404-page-for-your-github-pages-site
+      "/404.html",
+    ],
+  },
   hooks: {
     async compiled(nitro) {
       await fsp.writeFile(

--- a/src/presets/github-pages.ts
+++ b/src/presets/github-pages.ts
@@ -1,0 +1,18 @@
+import fsp from "node:fs/promises";
+import { join } from "pathe";
+import { defineNitroPreset } from "../preset";
+
+export const githubPages = defineNitroPreset({
+  extends: "static",
+  commands: {
+    deploy: "npx gh-pages -d ./public",
+  },
+  hooks: {
+    async compiled(nitro) {
+      await fsp.writeFile(
+        join(nitro.options.output.publicDir, ".nojekyll"),
+        ""
+      );
+    },
+  },
+});

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -24,4 +24,4 @@ export * from "./cleavr";
 export * from "./layer0";
 export * from "./lagon";
 export { _static as static } from "./static";
-export * from './github-pages'
+export * from "./github-pages";

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -24,3 +24,4 @@ export * from "./cleavr";
 export * from "./layer0";
 export * from "./lagon";
 export { _static as static } from "./static";
+export * from './github-pages'

--- a/src/presets/static.ts
+++ b/src/presets/static.ts
@@ -8,7 +8,7 @@ export const _static = defineNitroPreset({
   },
   prerender: {
     crawlLinks: true,
-    routes: ['/404.html']
+    routes: ["/404.html"],
   },
   commands: {
     preview: "npx serve ./public",

--- a/src/presets/static.ts
+++ b/src/presets/static.ts
@@ -8,7 +8,6 @@ export const _static = defineNitroPreset({
   },
   prerender: {
     crawlLinks: true,
-    routes: ["/404.html"],
   },
   commands: {
     preview: "npx serve ./public",

--- a/src/presets/static.ts
+++ b/src/presets/static.ts
@@ -8,6 +8,7 @@ export const _static = defineNitroPreset({
   },
   prerender: {
     crawlLinks: true,
+    routes: ['/404.html']
   },
   commands: {
     preview: "npx serve ./public",


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/unjs/nitro/issues/798

https://github.com/nuxt/nuxt/issues/12480
https://github.com/nuxt/nuxt/issues/12570

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a basic GitHub Pages preset. It creates a `.nojekyll` file and by default uses https://github.com/tschaub/gh-pages as deploy command.

### ✅ TODO

- [x] docs (including GH Actions workflow?)
- [ ] rethinking deploy command
- [ ] base URL support - this may need to be documentation

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
