### PR TITLE
refactor: rename `build` option to `static`

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -25,7 +25,7 @@ export async function prepare(nitro: Nitro) {
   if (!nitro.options.noPublicDir) {
     await prepareDir(nitro.options.output.publicDir);
   }
-  if (nitro.options.build) {
+  if (!nitro.options.static) {
     await prepareDir(nitro.options.output.serverDir);
   }
 }
@@ -257,7 +257,7 @@ async function _build(nitro: Nitro, rollupConfig: RollupConfig) {
   await writeTypes(nitro);
   await _snapshot(nitro);
 
-  if (nitro.options.build) {
+  if (!nitro.options.static) {
     nitro.logger.info(
       `Building Nitro Server (preset: \`${nitro.options.preset}\`)`
     );
@@ -281,7 +281,7 @@ async function _build(nitro: Nitro, rollupConfig: RollupConfig) {
   };
   await writeFile(nitroConfigPath, JSON.stringify(buildInfo, null, 2));
 
-  if (nitro.options.build) {
+  if (!nitro.options.static) {
     nitro.logger.success("Nitro server built");
     if (nitro.options.logLevel > 1) {
       process.stdout.write(

--- a/src/options.ts
+++ b/src/options.ts
@@ -168,7 +168,7 @@ export async function loadOptions(
   };
 
   // Resolve possibly template paths
-  if (options.build && !options.entry) {
+  if (!options.static && !options.entry) {
     throw new Error(
       `Nitro entry is missing! Is "${options.preset}" preset correct?`
     );

--- a/src/options.ts
+++ b/src/options.ts
@@ -147,7 +147,7 @@ export async function loadOptions(
   options.preset =
     presetOverride ||
     (layers.find((l) => l.config.preset)?.config.preset as string) ||
-    (detectTarget({ static: !options.build }) ?? "node-server");
+    (detectTarget({ static: options.static }) ?? "node-server");
 
   options.rootDir = resolve(options.rootDir || ".");
   options.workspaceDir = await findWorkspaceDir(options.rootDir).catch(

--- a/src/options.ts
+++ b/src/options.ts
@@ -28,7 +28,6 @@ const NitroDefaults: NitroConfig = {
   // General
   debug: isDebug,
   logLevel: isTest ? 1 : 3,
-  build: true,
   runtimeConfig: { app: {}, nitro: {} },
   appConfig: {},
   appConfigFiles: [],

--- a/src/presets/netlify.ts
+++ b/src/presets/netlify.ts
@@ -98,7 +98,7 @@ async function writeRedirects(nitro: Nitro) {
   )
     ? "/* /404.html 404"
     : "";
-  let contents = nitro.options.build
+  let contents = !nitro.options.static
     ? "/* /.netlify/functions/server 200"
     : staticFallback;
 

--- a/src/presets/netlify.ts
+++ b/src/presets/netlify.ts
@@ -106,7 +106,7 @@ async function writeRedirects(nitro: Nitro) {
     (a, b) => a[0].split(/\/(?!\*)/).length - b[0].split(/\/(?!\*)/).length
   );
 
-  if (nitro.options.build) {
+  if (!nitro.options.static) {
     // Rewrite static ISR paths to builder functions
     for (const [key, value] of rules.filter(
       ([_, value]) => value.isr !== undefined

--- a/src/presets/static.ts
+++ b/src/presets/static.ts
@@ -1,7 +1,7 @@
 import { defineNitroPreset } from "../preset";
 
 export const _static = defineNitroPreset({
-  build: false,
+  static: true,
   output: {
     dir: "{{ rootDir }}/.output",
     publicDir: "{{ output.dir }}/public",

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -184,7 +184,7 @@ function generateBuildConfig(nitro: Nitro) {
     ],
   });
 
-  // Early return if we are not building a serverless function
+  // Early return if we are building a static site
   if (nitro.options.static) {
     return config;
   }

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -185,7 +185,7 @@ function generateBuildConfig(nitro: Nitro) {
   });
 
   // Early return if we are not building a serverless function
-  if (!nitro.options.build) {
+  if (nitro.options.static) {
     return config;
   }
 

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -158,7 +158,7 @@ export interface NitroOptions extends PresetOptions {
   debug: boolean;
   // eslint-disable-next-line @typescript-eslint/ban-types
   preset: KebabCase<keyof typeof _PRESETS> | (string & {});
-  build: boolean;
+  static: boolean;
   logLevel: LogLevel;
   runtimeConfig: {
     app: {


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

rename `build` option (unreleased) to `static` for better readability of the option purpose.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
