### PR TITLE
fix: separate `typesDir` from `tsConfigDir`

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -94,6 +94,7 @@ const NitroDefaults: NitroConfig = {
 
   // Advanced
   typescript: {
+    strict: false,
     generateTsConfig: true,
     tsconfigPath: "types/tsconfig.json",
     internalPaths: false,

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -241,6 +241,7 @@ export interface NitroOptions extends PresetOptions {
 
   // Advanced
   typescript: {
+    strict?: boolean;
     internalPaths?: boolean;
     generateTsConfig?: boolean;
     /** the path of the generated `tsconfig.json`, relative to buildDir */


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes a regression where we were expecting the `tsConfigPath` passed in to be a child of `types`, and therefore produce the wrong paths within a generated `tsconfig.json`.

It also adds a new `forceConsistentCasingInFileNames` option, and allows configuring of the `strict` option (disabled by default to avoid a breaking change, although I would recommend always enabling strict mode, and perhaps this could be made default in a future version).

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
