### PR TITLE
fix(cloudflare): expose env from module context

### DIFF
--- a/src/runtime/entries/cloudflare-module.ts
+++ b/src/runtime/entries/cloudflare-module.ts
@@ -50,7 +50,7 @@ export default {
     }
 
     // Expose latest env to the global context
-    globalThis.__cf_env__ = env;
+    globalThis.__env__ = env;
 
     return nitroApp.localFetch(url.pathname + url.search, {
       context: {

--- a/src/runtime/entries/cloudflare-module.ts
+++ b/src/runtime/entries/cloudflare-module.ts
@@ -49,6 +49,9 @@ export default {
       body = Buffer.from(await request.arrayBuffer());
     }
 
+    // Expose latest env to the global context
+    globalThis.__cf_env__ = env;
+
     return nitroApp.localFetch(url.pathname + url.search, {
       context: {
         cf: (request as any).cf,

--- a/src/runtime/entries/cloudflare-pages.ts
+++ b/src/runtime/entries/cloudflare-pages.ts
@@ -36,6 +36,9 @@ export default {
       body = Buffer.from(await request.arrayBuffer());
     }
 
+    // Expose latest env to the global context
+    globalThis.__cf_env__ = env;
+
     return nitroApp.localFetch(url.pathname + url.search, {
       context: {
         cf: request.cf,

--- a/src/runtime/entries/cloudflare-pages.ts
+++ b/src/runtime/entries/cloudflare-pages.ts
@@ -37,7 +37,7 @@ export default {
     }
 
     // Expose latest env to the global context
-    globalThis.__cf_env__ = env;
+    globalThis.__env__ = env;
 
     return nitroApp.localFetch(url.pathname + url.search, {
       context: {


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

Related #1132, #272

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Cloudflare's module format only allowed accessing env bindings within the request accessible via `event.context.cloudflare.env`.

This makes it harder to make existing stateless utils such as `useStorage` and `useRuntimeConfig` work with this new format.

We might make it more restricted in the feature of how/where these composables are going to be used to properly address such limitations.

Workaround with this PR assumes `env` is safe to be shared across requests for **only internal usage** and exposing it as `__env__` global to be platform agnostic. User land use cases should **never** reply on this env.



### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
