### PR TITLE
fix(proxy): append request query params for single proxy route rules

### DIFF
--- a/src/runtime/route-rules.ts
+++ b/src/runtime/route-rules.ts
@@ -7,7 +7,7 @@ import {
 } from "h3";
 import defu from "defu";
 import { createRouter as createRadixRouter, toRouteMatcher } from "radix3";
-import { joinURL, withoutBase } from "ufo";
+import { joinURL, withQuery, getQuery, withoutBase } from "ufo";
 import { useRuntimeConfig } from "./config";
 import type { NitroRouteRules } from "nitropack";
 
@@ -42,6 +42,11 @@ export function createRouteRulesHandler() {
           targetPath = withoutBase(targetPath, strpBase);
         }
         target = joinURL(target.slice(0, -3), targetPath);
+      } else {
+        const query = getQuery(event.path);
+        if (query) {
+          target = withQuery(target, query);
+        }
       }
       return proxyRequest(event, target, {
         fetch: $fetch.raw as any,

--- a/src/runtime/route-rules.ts
+++ b/src/runtime/route-rules.ts
@@ -42,11 +42,9 @@ export function createRouteRulesHandler() {
           targetPath = withoutBase(targetPath, strpBase);
         }
         target = joinURL(target.slice(0, -3), targetPath);
-      } else {
+      } else if (event.path.includes("?")) {
         const query = getQuery(event.path);
-        if (query) {
-          target = withQuery(target, query);
-        }
+        target = withQuery(target, query);
       }
       return proxyRequest(event, target, {
         fetch: $fetch.raw as any,

--- a/test/fixture/api/echo.ts
+++ b/test/fixture/api/echo.ts
@@ -1,0 +1,7 @@
+export default eventHandler((event) => {
+  return {
+    url: event.node.req.url,
+    method: event.node.req.method,
+    headers: event.node.req.headers,
+  };
+});

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -55,7 +55,7 @@ export default defineNitroConfig({
     "/rules/_/noncached/**": { swr: false, cache: false, isr: false },
     "/rules/_/cached/noncached": { cache: false, swr: false, isr: false },
     "/rules/_/cached/**": { swr: true },
-    "/api/proxy": { proxy: "/api/echo" },
+    "/api/proxy/**": { proxy: "/api/echo" },
   },
   prerender: {
     crawlLinks: true,

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -55,6 +55,7 @@ export default defineNitroConfig({
     "/rules/_/noncached/**": { swr: false, cache: false, isr: false },
     "/rules/_/cached/noncached": { cache: false, swr: false, isr: false },
     "/rules/_/cached/**": { swr: true },
+    "/api/proxy": { proxy: "/api/echo" },
   },
   prerender: {
     crawlLinks: true,

--- a/test/presets/nitro-dev.test.ts
+++ b/test/presets/nitro-dev.test.ts
@@ -6,8 +6,12 @@ describe("nitro:preset:nitro-dev", async () => {
   testNitro(
     ctx,
     () => {
-      return async ({ url }) => {
-        const res = await ctx.fetch(url);
+      return async ({ url, headers, method, body }) => {
+        const res = await ctx.fetch(url, {
+          headers,
+          method,
+          body,
+        });
         return res;
       };
     },

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -301,10 +301,10 @@ export function testNitro(
     const { data } = await callHandler({
       url: "/api/proxy?foo=bar",
       headers: {
-        "x-test": 123,
+        "x-test": "foobar",
       },
     });
-    expect(data.headers["x-test"]).toBe("123");
+    expect(data.headers["x-test"]).toBe("foobar");
     expect(data.url).toBe("/api/echo?foo=bar");
   });
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -2,7 +2,7 @@ import { resolve } from "pathe";
 import { listen, Listener } from "listhen";
 import destr from "destr";
 import { fetch, FetchOptions } from "ofetch";
-import { expect, it, afterAll } from "vitest";
+import { expect, it, afterAll, beforeAll } from "vitest";
 import { fileURLToPath } from "mlly";
 import { joinURL } from "ufo";
 import * as _nitro from "../src";
@@ -121,7 +121,7 @@ export function testNitro(
     };
   }
 
-  it("setup handler", async () => {
+  beforeAll(async () => {
     _handler = await getHandler();
   });
 
@@ -296,6 +296,17 @@ export function testNitro(
       additionalTests(ctx, callHandler);
     }
   }
+
+  it("runtime proxy", async () => {
+    const { data } = await callHandler({
+      url: "/api/proxy?foo=bar",
+      headers: {
+        "x-test": 123,
+      },
+    });
+    expect(data.headers["x-test"]).toBe("123");
+    expect(data.url).toBe("/api/echo?foo=bar");
+  });
 
   it("app config", async () => {
     const { data } = await callHandler({


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When a routeing rule like `/proxy: { proxy: 'to' }` exists, the query params was being ignored. Added fix + tests. (thanks @Atinux for reporting) 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
