### PR TITLE
perf: export `defineNitroConfig` from `nitro/config`

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -5,6 +5,7 @@ export default defineBuildConfig({
   name: "nitro",
   entries: [
     "src/index",
+    "src/config",
     "src/cli/cli",
     { input: "src/runtime/", outDir: "dist/runtime", format: "esm" },
   ],

--- a/config.d.ts
+++ b/config.d.ts
@@ -1,0 +1,1 @@
+export * from "./dist/config";

--- a/docs/content/1.guide/1.configuration.md
+++ b/docs/content/1.guide/1.configuration.md
@@ -12,7 +12,7 @@ If you are using [Nuxt](https://nuxt.com), use the `nitro` option in your Nuxt c
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from 'nitropack'
+import { defineNitroConfig } from 'nitropack/config'
 
 export default defineNitroConfig({
   // Nitro options

--- a/docs/content/1.guide/3.routing.md
+++ b/docs/content/1.guide/3.routing.md
@@ -117,7 +117,7 @@ When `cache` option is set, handlers matching pattern will be automatically wrap
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from 'nitropack'
+import { defineNitroConfig } from 'nitropack/config'
 
 export default defineNitroConfig({
   routeRules: {

--- a/docs/content/1.guide/4.storage.md
+++ b/docs/content/1.guide/4.storage.md
@@ -27,7 +27,7 @@ You can mount storage drivers using the `storage` option:
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from 'nitropack'
+import { defineNitroConfig } from 'nitropack/config'
 
 export default defineNitroConfig({
   storage: {

--- a/docs/content/1.guide/5.cache.md
+++ b/docs/content/1.guide/5.cache.md
@@ -14,7 +14,7 @@ To overwrite the production storage, set the `cache` mountpoint using the `stora
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitropack";
+import { defineNitroConfig } from "nitropack/config";
 
 export default defineNitroConfig({
   storage: {
@@ -123,7 +123,7 @@ Cache all the blog routes for 1 hour with `stale-while-revalidate` behavior:
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitropack";
+import { defineNitroConfig } from "nitropack/config";
 
 export default defineNitroConfig({
   routeRules: {
@@ -156,7 +156,7 @@ If we want to use a custom storage mountpoint, we can use the `base` option. Let
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitropack";
+import { defineNitroConfig } from "nitropack/config";
 
 export default defineNitroConfig({
   storage: {

--- a/docs/content/1.guide/6.assets.md
+++ b/docs/content/1.guide/6.assets.md
@@ -63,7 +63,7 @@ In order to add assets from a custom directory, path will need to be defined in 
 
 ::code-group
 ```js [nitro.config.ts]
-import { defineNitroConfig } from 'nitropack'
+import { defineNitroConfig } from 'nitropack/config'
 
 export default defineNitroConfig({
   serverAssets: [{
@@ -101,7 +101,7 @@ export default defineEventHandler(async () => {
 
 ::code-group
 ```js [nitro.config.ts]
-import { defineNitroConfig } from 'nitropack'
+import { defineNitroConfig } from 'nitropack/config'
 
 export default defineNitroConfig({
   serverAssets: [{

--- a/docs/content/1.guide/7.plugins.md
+++ b/docs/content/1.guide/7.plugins.md
@@ -31,7 +31,7 @@ If you have plugins in another directory, you can use the `plugins` option:
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from 'nitropack'
+import { defineNitroConfig } from 'nitropack/config'
 
 export default defineNitroConfig({
   plugins: ['my-plugins/hello.ts']

--- a/docs/content/2.deploy/0.index.md
+++ b/docs/content/2.deploy/0.index.md
@@ -38,7 +38,7 @@ NITRO_PRESET=aws-lambda nitro build
 **Example:** Using [nitro.config.ts](/config/)
 
 ```ts
-import { defineNitroConfig } from "nitropack";
+import { defineNitroConfig } from "nitropack/config";
 
 export default defineNitroConfig({
   preset: 'node-server'

--- a/docs/content/3.config.md
+++ b/docs/content/3.config.md
@@ -11,7 +11,7 @@ In order to customize Nitro's behavior, we create a file named `nitro.config.ts`
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitropack";
+import { defineNitroConfig } from "nitropack/config";
 
 export default defineNitroConfig({
   // options
@@ -251,7 +251,7 @@ Path to a custom runtime error handler. Replacing nitro's built-in error page.
 **Example:**
 
 ```js [nitro.config]
-import { defineNitroConfig } from "nitropack";
+import { defineNitroConfig } from "nitropack/config";
 
 export default defineNitroConfig({
   errorHandler: "~/error",

--- a/examples/api-routes/nitro.config.ts
+++ b/examples/api-routes/nitro.config.ts
@@ -1,3 +1,3 @@
-import { defineNitroConfig } from "nitropack";
+import { defineNitroConfig } from "nitropack/config";
 
 export default defineNitroConfig({});

--- a/examples/auto-imports/nitro.config.ts
+++ b/examples/auto-imports/nitro.config.ts
@@ -1,3 +1,3 @@
-import { defineNitroConfig } from "nitropack";
+import { defineNitroConfig } from "nitropack/config";
 
 export default defineNitroConfig({});

--- a/examples/cached-handler/nitro.config.ts
+++ b/examples/cached-handler/nitro.config.ts
@@ -1,3 +1,3 @@
-import { defineNitroConfig } from "nitropack";
+import { defineNitroConfig } from "nitropack/config";
 
 export default defineNitroConfig({});

--- a/examples/custom-error-handler/nitro.config.ts
+++ b/examples/custom-error-handler/nitro.config.ts
@@ -1,4 +1,4 @@
-import { defineNitroConfig } from "nitropack";
+import { defineNitroConfig } from "nitropack/config";
 import errorHandler from "./error";
 
 export default defineNitroConfig({

--- a/examples/hello-world/nitro.config.ts
+++ b/examples/hello-world/nitro.config.ts
@@ -1,3 +1,3 @@
-import { defineNitroConfig } from "nitropack";
+import { defineNitroConfig } from "nitropack/config";
 
 export default defineNitroConfig({});

--- a/examples/middleware/nitro.config.ts
+++ b/examples/middleware/nitro.config.ts
@@ -1,3 +1,3 @@
-import { defineNitroConfig } from "nitropack";
+import { defineNitroConfig } from "nitropack/config";
 
 export default defineNitroConfig({});

--- a/examples/plugins/nitro.config.ts
+++ b/examples/plugins/nitro.config.ts
@@ -1,4 +1,4 @@
-import { defineNitroConfig } from "nitropack";
+import { defineNitroConfig } from "nitropack/config";
 
 export default defineNitroConfig({
   plugins: ["~/plugins/test"],

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"
     },
+    "./config": {
+      "types": "./dist/config.d.ts",
+      "import": "./dist/config.mjs"
+    },
     "./cli": "./dist/cli.mjs",
     "./runtime/*": "./dist/runtime/*.mjs",
     "./dist/runtime/*": "./dist/runtime/*.mjs",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "nitropack": "./dist/cli.mjs"
   },
   "files": [
-    "dist"
+    "dist",
+    "*.d.ts"
   ],
   "scripts": {
     "build": "unbuild",

--- a/playground/nitro.config.ts
+++ b/playground/nitro.config.ts
@@ -1,3 +1,3 @@
-import { defineNitroConfig } from "../src";
+import { defineNitroConfig } from "nitropack/config";
 
 export default defineNitroConfig({});

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "paths": {
       "nitropack": ["../src/index"],
+      "nitropack/config": ["../src/config"],
       "#internal/nitro": ["../src/runtime/index"],
       "#internal/nitro/*": ["../src/runtime/*"]
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,5 @@
+import type { NitroConfig } from "./types";
+
+export function defineNitroConfig(config: NitroConfig): NitroConfig {
+  return config;
+}

--- a/src/options.ts
+++ b/src/options.ts
@@ -128,6 +128,12 @@ export async function loadOptions(
       preset: detectTarget() || "node-server",
     },
     defaults: NitroDefaults,
+    jitiOptions: {
+      alias: {
+        nitropack: "nitropack/config",
+        "nitropack/config": "nitropack/config",
+      },
+    },
     resolve(id: string) {
       const presets = _PRESETS as any as Map<string, NitroConfig>;
       let matchedPreset = presets[camelCase(id)] || presets[id];
@@ -369,6 +375,9 @@ export async function loadOptions(
   return options;
 }
 
+/**
+ * @deprecated Please import `defineNitroConfig` from nitropack/config instead
+ */
 export function defineNitroConfig(config: NitroConfig): NitroConfig {
   return config;
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -115,6 +115,7 @@ export async function loadOptions(
 
   // Load configuration and preset
   configOverrides = klona(configOverrides);
+  globalThis.defineNitroConfig = globalThis.defineNitroConfig || ((c) => c);
   const { config, layers } = await loadConfig({
     name: "nitro",
     cwd: configOverrides.rootDir,

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -1,4 +1,4 @@
-import { defineNitroConfig } from "../../src";
+import { defineNitroConfig } from "../../src/config";
 
 export default defineNitroConfig({
   compressPublicAssets: true,

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -1,7 +1,7 @@
 import { expectTypeOf } from "expect-type";
 import { describe, it } from "vitest";
 import { $Fetch } from "../..";
-import { defineNitroConfig } from "../../src/options";
+import { defineNitroConfig } from "../../src/config";
 
 interface TestResponse {
   message: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "resolveJsonModule": true,
     "paths": {
       "nitropack": ["./src/index"],
+      "nitropack/config": ["./src/config"],
       "#internal/nitro": ["./src/runtime/index"],
       "#internal/nitro/*": ["./src/runtime/*"]
     }


### PR DESCRIPTION
- perf: export `defineNitroConfig` from `nitropack/config`
- update usages

<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

By importing `defineNuxtConfig` from `nitro/config` subpath, startup time significantly reduces as JITI does not need to load whole nitro and it's deps as CJS

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
