### PR TITLE
feat: config hmr support for `routeRules` and `rutimeConfig`

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -377,6 +377,8 @@ async function _watch(nitro: Nitro, rollupConfig: RollupConfig) {
     reloadWacher.close();
   });
 
+  nitro.hooks.hook("rollup:reload", () => reload());
+
   await reload();
 }
 

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -35,16 +35,23 @@ export default defineCommand({
         {
           watch: true,
           c12: {
-            async onUpdate({ getDiff }) {
+            async onUpdate({ getDiff, newConfig }) {
               const diff = getDiff();
+
               if (diff.length === 0) {
                 return; // No changes
               }
+
               consola.info(
                 "Nitro config updated:\n" +
                   diff.map((entry) => `  ${entry.toString()}`).join("\n")
               );
-              await reload();
+
+              await (diff.some((e) =>
+                ["routeRules", "runtimeConfig"].includes(e.key)
+              )
+                ? reload() // Full reload
+                : nitro.updateConfig(newConfig.config)); // Hot reload
             },
           },
         }

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -7,6 +7,8 @@ import { createDevServer } from "../../dev/server";
 import { commonArgs } from "../common";
 import type { Nitro } from "../../types";
 
+const hmrKeyRe = /^runtimeConfig\.|routeRules\./;
+
 export default defineCommand({
   meta: {
     name: "dev",
@@ -47,9 +49,7 @@ export default defineCommand({
                   diff.map((entry) => `  ${entry.toString()}`).join("\n")
               );
 
-              await (diff.some((e) =>
-                ["routeRules", "runtimeConfig"].includes(e.key)
-              )
+              await (!diff.every((e) => hmrKeyRe.test(e.key))
                 ? reload() // Full reload
                 : nitro.updateConfig(newConfig.config)); // Hot reload
             },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export * from "./build";
 export * from "./nitro";
 export * from "./scan";
 export * from "./dev/server";
-export * from "./options";
+export { LoadConfigOptions, loadOptions } from "./options";
 export * from "./types";
 export * from "./prerender";
 export * from "./preset";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,9 @@ export * from "./build";
 export * from "./nitro";
 export * from "./scan";
 export * from "./dev/server";
-export { LoadConfigOptions, loadOptions } from "./options";
 export * from "./types";
 export * from "./prerender";
 export * from "./preset";
+
+export { loadOptions } from "./options";
+export type { LoadConfigOptions } from "./options";

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -8,6 +8,7 @@ import type { NitroConfig, Nitro, NitroDynamicConfig } from "./types";
 import {
   LoadConfigOptions,
   loadOptions,
+  normalizeRouteRules,
   normalizeRuntimeConfig,
 } from "./options";
 import { scanPlugins } from "./scan";
@@ -30,7 +31,7 @@ export async function createNitro(
     close: () => nitro.hooks.callHook("close"),
     storage: undefined,
     async updateConfig(config: NitroDynamicConfig) {
-      nitro.options.routeRules = normalizeRuntimeConfig(
+      nitro.options.routeRules = normalizeRouteRules(
         config.routeRules ? config : nitro.options
       );
       nitro.options.runtimeConfig = normalizeRuntimeConfig(

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -4,8 +4,12 @@ import { createHooks, createDebugger } from "hookable";
 import { createUnimport } from "unimport";
 import { defu } from "defu";
 import { consola } from "consola";
-import type { NitroConfig, Nitro } from "./types";
-import { LoadConfigOptions, loadOptions } from "./options";
+import type { NitroConfig, Nitro, NitroDynamicConfig } from "./types";
+import {
+  LoadConfigOptions,
+  loadOptions,
+  normalizeRuntimeConfig,
+} from "./options";
 import { scanPlugins } from "./scan";
 import { createStorage } from "./storage";
 
@@ -25,6 +29,16 @@ export async function createNitro(
     scannedHandlers: [],
     close: () => nitro.hooks.callHook("close"),
     storage: undefined,
+    async updateConfig(config: NitroDynamicConfig) {
+      nitro.options.routeRules = normalizeRuntimeConfig(
+        config.routeRules ? config : nitro.options
+      );
+      nitro.options.runtimeConfig = normalizeRuntimeConfig(
+        config.runtimeConfig ? config : nitro.options
+      );
+      await nitro.hooks.callHook("rollup:reload");
+      consola.success("Nitro config hot reloaded!");
+    },
   };
 
   // Storage

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -169,7 +169,6 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
     server: true,
     client: false,
     dev: String(nitro.options.dev),
-    RUNTIME_CONFIG: nitro.options.runtimeConfig,
     DEBUG: nitro.options.dev,
   };
 
@@ -183,6 +182,8 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
       values: {
         "typeof window": '"undefined"',
         _import_meta_url_: "import.meta.url",
+        "process.env.RUNTIME_CONFIG": () =>
+          JSON.stringify(nitro.options.runtimeConfig, null, 2),
         ...Object.fromEntries(
           [".", ";", ")", "[", "]", "}", " "].map((d) => [
             `import.meta${d}`,

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -25,6 +25,11 @@ import type {
 import type { PresetOptions } from "./presets";
 import type { KebabCase } from "./utils";
 
+export type NitroDynamicConfig = Pick<
+  NitroConfig,
+  "runtimeConfig" | "routeRules"
+>;
+
 export interface Nitro {
   options: NitroOptions;
   scannedHandlers: NitroEventHandler[];
@@ -34,6 +39,7 @@ export interface Nitro {
   logger: ConsolaInstance;
   storage: Storage;
   close: () => Promise<void>;
+  updateConfig: (config: NitroDynamicConfig) => void | Promise<void>;
 
   /* @internal */
   _prerenderedRoutes?: PrerenderGenerateRoute[];
@@ -57,6 +63,7 @@ export interface NitroHooks {
   "rollup:before": (nitro: Nitro, config: RollupConfig) => HookResult;
   compiled: (nitro: Nitro) => HookResult;
   "dev:reload": () => HookResult;
+  "rollup:reload": () => HookResult;
   restart: () => HookResult;
   close: () => HookResult;
   "prerender:routes": (routes: Set<string>) => HookResult;


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR supports HMR config updates for `runtimeConfig` and `routeRules` objects for `nitro dev` to rebuild the app without full reload.

A manual hook `nitro.updateConfig()` is also exposed to update this configuration on demand programmatically (useful for integration with other frameworks like Nuxt)

<img width="504" alt="image" src="https://user-images.githubusercontent.com/5158436/233172437-fd0aa540-60b5-466a-869b-e1e68f4f488c.png">


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
