### PR TITLE
fix: apply `chunkFileNames` on windows

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -73,7 +73,9 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
       entryFileNames: "index.mjs",
       chunkFileNames(chunkInfo) {
         let prefix = "";
-        const lastModule = normalize(chunkInfo.moduleIds[chunkInfo.moduleIds.length - 1]);
+        const lastModule = normalize(
+          chunkInfo.moduleIds[chunkInfo.moduleIds.length - 1]
+        );
         if (lastModule.startsWith(buildServerDir)) {
           prefix = join("app", relative(buildServerDir, dirname(lastModule)));
         } else if (lastModule.startsWith(runtimeAppDir)) {

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -73,7 +73,7 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
       entryFileNames: "index.mjs",
       chunkFileNames(chunkInfo) {
         let prefix = "";
-        const lastModule = chunkInfo.moduleIds[chunkInfo.moduleIds.length - 1];
+        const lastModule = normalize(chunkInfo.moduleIds[chunkInfo.moduleIds.length - 1]);
         if (lastModule.startsWith(buildServerDir)) {
           prefix = join("app", relative(buildServerDir, dirname(lastModule)));
         } else if (lastModule.startsWith(runtimeAppDir)) {


### PR DESCRIPTION
### 🔗 Linked issue

nuxt/nuxt#15244

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We currently use `startsWith` but the chunk on windows has backslashes so this needs to be normalised first to match our internal `buildServerDir`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
