### PR TITLE
feat(vercel): add support for specifying edge regions

### DIFF
--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -107,7 +107,7 @@ export const vercelEdge = defineNitroPreset({
       const functionConfig = {
         runtime: "edge",
         entrypoint: "index.mjs",
-        regions: nitro.options.vercel?.regions
+        regions: nitro.options.vercel?.regions,
       };
       await writeFile(
         functionConfigPath,

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -104,10 +104,13 @@ export const vercelEdge = defineNitroPreset({
         nitro.options.output.serverDir,
         ".vc-config.json"
       );
-      const functionConfig = {
+      const functionConfig: Record<string, any> = {
         runtime: "edge",
         entrypoint: "index.mjs",
       };
+      if (nitro.options.vercel?.regions) {
+        functionConfig.regions = nitro.options.vercel.regions;
+      }
       await writeFile(
         functionConfigPath,
         JSON.stringify(functionConfig, null, 2)

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -104,13 +104,11 @@ export const vercelEdge = defineNitroPreset({
         nitro.options.output.serverDir,
         ".vc-config.json"
       );
-      const functionConfig: Record<string, any> = {
+      const functionConfig = {
         runtime: "edge",
         entrypoint: "index.mjs",
+        regions: nitro.options.vercel?.regions
       };
-      if (nitro.options.vercel?.regions) {
-        functionConfig.regions = nitro.options.vercel.regions;
-      }
       await writeFile(
         functionConfigPath,
         JSON.stringify(functionConfig, null, 2)

--- a/src/types/presets.ts
+++ b/src/types/presets.ts
@@ -55,6 +55,11 @@ export interface VercelBuildConfigV3 {
 export interface PresetOptions {
   vercel: {
     config: VercelBuildConfigV3;
+    /**
+     * If you are using `vercel-edge`, you can specify the region(s) for your edge function.
+     * @see https://vercel.com/docs/concepts/functions/edge-functions#edge-function-regions
+     */
+    regions?: string[];
     functions?: {
       memory: number;
       maxDuration: number;


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This allows specifying the regions for edge functions in Vercel, which can be beneficial to ensure they are running close to a DB (for example).

**More info**: https://vercel.com/docs/concepts/functions/edge-functions#edge-function-regions

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
