### PR TITLE
feat: `future.nativeSWR`

### DIFF
--- a/docs/content/3.config.md
+++ b/docs/content/3.config.md
@@ -58,6 +58,16 @@ Server runtime configuration.
 
 Enable experimental features. Currently, none are available!
 
+### `future`
+
+- Default: `{}`
+
+New features pending for a major version to avoid breaking changes.
+
+#### `nativeSWR`
+
+Uses built-in SWR functionality (using caching layer and storage) for Netlify and Vercel presets instead of falling back to ISR behavior.
+
 ### `storage`
 
 - Default: `{}`

--- a/src/options.ts
+++ b/src/options.ts
@@ -43,6 +43,7 @@ const NitroDefaults: NitroConfig = {
 
   // Features
   experimental: {},
+  future: {},
   storage: {},
   devStorage: {},
   bundledStorage: [],

--- a/src/presets/netlify.ts
+++ b/src/presets/netlify.ts
@@ -17,7 +17,11 @@ export const netlify = defineNitroPreset({
     },
   },
   hooks: {
-    "rollup:before": (nitro: Nitro) => deprecateSWR(nitro),
+    "rollup:before": (nitro: Nitro) => {
+      if (!nitro.options.future.nativeSWR) {
+        deprecateSWR(nitro);
+      }
+    },
     async compiled(nitro: Nitro) {
       await writeHeaders(nitro);
       await writeRedirects(nitro);
@@ -210,7 +214,7 @@ function deprecateSWR(nitro: Nitro) {
   }
   if (hasLegacyOptions) {
     console.warn(
-      "[nitro] Nitro now uses `isr` option to configure ISR behavior on Netlify. Backwards-compatible support for `static` and `swr` support with Builder Functions will be removed in the next major release."
+      "[nitro] Nitro now uses `isr` option to configure ISR behavior on Netlify. Backwards-compatible support for `static` and `swr` support with Builder Functions will be removed in the future versions."
     );
   }
 }

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -22,7 +22,11 @@ export const vercel = defineNitroPreset({
     preview: "",
   },
   hooks: {
-    "rollup:before": (nitro: Nitro) => deprecateSWR(nitro),
+    "rollup:before": (nitro: Nitro) => {
+      if (!nitro.options.future.nativeSWR) {
+        deprecateSWR(nitro);
+      }
+    },
     async compiled(nitro: Nitro) {
       const buildConfigPath = resolve(nitro.options.output.dir, "config.json");
       const buildConfig = generateBuildConfig(nitro);
@@ -270,7 +274,7 @@ function deprecateSWR(nitro: Nitro) {
   }
   if (hasLegacyOptions) {
     console.warn(
-      "[nitro] Nitro now uses `isr` option to configure ISR behavior on Vercel. Backwards-compatible support for `static` and `swr` options within the Vercel Build Options API will be removed in the next major release."
+      "[nitro] Nitro now uses `isr` option to configure ISR behavior on Vercel. Backwards-compatible support for `static` and `swr` options within the Vercel Build Options API will be removed in the future versions."
     );
   }
 }

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -203,6 +203,9 @@ export interface NitroOptions extends PresetOptions {
     wasm?: boolean | RollupWasmOptions;
     legacyExternals?: boolean;
   };
+  future: {
+    nativeSWR: boolean;
+  };
   serverAssets: ServerAssetDir[];
   publicAssets: PublicAssetDir[];
 


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

> Uses built-in SWR functionality (using caching layer and storage) for Netlify and Vercel presets instead of falling back to ISR behavior.

New `future` namespace will be used for potentially breaking but stable changes with an opt-in method until next major nitro versions. This way we can better collaborate with consumer frameworks such as Nuxt.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
