### PR TITLE
feat: support concurrency + interval when prerendering

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -72,6 +72,8 @@ const NitroDefaults: NitroConfig = {
   errorHandler: "#internal/nitro/error",
   routeRules: {},
   prerender: {
+    concurrency: 1,
+    interval: 0,
     crawlLinks: false,
     ignore: [],
     routes: [],

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -85,10 +85,11 @@ export async function prerender(nitro: Nitro) {
 
   // Start prerendering
   const generatedRoutes = new Set();
+  const skippedRoutes = new Set();
   const displayedLengthWarns = new Set();
   const canPrerender = (route = "/") => {
-    // Skip if route is already generated
-    if (generatedRoutes.has(route)) {
+    // Skip if route is already generated or skipped
+    if (generatedRoutes.has(route) || skippedRoutes.has(route)) {
       return false;
     }
 
@@ -139,10 +140,10 @@ export async function prerender(nitro: Nitro) {
 
     // Check if we should render route
     if (!canPrerender(route)) {
+      skippedRoutes.add(route)
       return;
     }
     generatedRoutes.add(route);
-    routes.delete(route);
 
     // Create result object
     const _route: PrerenderGenerateRoute = { route };
@@ -223,33 +224,57 @@ export async function prerender(nitro: Nitro) {
       ? `Prerendering ${routes.size} initial routes with crawler`
       : `Prerendering ${routes.size} routes`
   );
-  for (let i = 0; i < 100 && routes.size > 0; i++) {
-    for (const route of routes) {
-      const _route = await generateRoute(route).catch(
-        (error) => ({ route, error } as PrerenderGenerateRoute)
+
+  async function processRoute (route: string) {
+    const _route = await generateRoute(route).catch(
+      (error) => ({ route, error } as PrerenderGenerateRoute)
+    );
+
+    if (!_route || _route.skip) {
+      return;
+    }
+
+    await nitro.hooks.callHook("prerender:route", _route);
+
+    if (_route.error) {
+      nitro.logger.log(
+        chalk[_route.error.statusCode === 404 ? "yellow" : "red"](
+          `  ├─ ${_route.route} (${
+            _route.generateTimeMS
+          }ms) ${`(${_route.error})`}`
+        )
       );
-
-      if (!_route || _route.skip) {
-        continue;
-      }
-
-      await nitro.hooks.callHook("prerender:route", _route);
-
-      if (_route.error) {
-        nitro.logger.log(
-          chalk[_route.error.statusCode === 404 ? "yellow" : "red"](
-            `  ├─ ${_route.route} (${
-              _route.generateTimeMS
-            }ms) ${`(${_route.error})`}`
-          )
-        );
-      } else {
-        nitro.logger.log(
-          chalk.gray(`  ├─ ${_route.route} (${_route.generateTimeMS}ms)`)
-        );
-      }
+    } else {
+      nitro.logger.log(
+        chalk.gray(`  ├─ ${_route.route} (${_route.generateTimeMS}ms)`)
+      );
     }
   }
+
+  const tasks = new Set<Promise<void>>();
+
+  function refillQueue() {
+    const workers = Math.min(nitro.options.prerender.concurrency  - tasks.size, routes.size)
+    return Promise.all(Array.from({ length: workers }, () => queueNext()))
+  }
+
+  function queueNext () {
+    const route = routes.values().next().value
+    if (!route) { return }
+
+    routes.delete(route)
+    const task = new Promise((resolve) => setTimeout(resolve, nitro.options.prerender.interval)).then(() => processRoute(route))
+
+    tasks.add(task)
+    return task.then(() => {
+      tasks.delete(task)
+      if (routes.size > 0) {
+        return refillQueue()
+      }
+    })
+  }
+
+  await refillQueue()
 
   if (nitro.options.compressPublicAssets) {
     await compressPublicAssets(nitro);

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -229,6 +229,8 @@ export interface NitroOptions extends PresetOptions {
   errorHandler: string;
   devErrorHandler: NitroErrorHandler;
   prerender: {
+    concurrency: number;
+    interval: number;
     crawlLinks: boolean;
     ignore: string[];
     routes: string[];


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/15543
https://github.com/nuxt/nuxt/issues/4122


### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds support for `prerender.concurrency` and `prerender.interval`. I expect we might want to iterate on the implementation (it's late!) but basically this keeps the queue full (so it's not batched, which was a problem previously - see https://github.com/nuxt/nuxt/issues/4122).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
