### PR TITLE
[WIP] feat: support runtime hooks for graceful shutdown/restart

### DIFF
--- a/docs/content/2.deploy/1.node.md
+++ b/docs/content/2.deploy/1.node.md
@@ -39,6 +39,10 @@ You can customize server behavior using following environment variables:
 - `NITRO_PORT` or `PORT` (defaults to `3000`)
 - `NITRO_HOST` or `HOST`
 - `NITRO_SSL_CERT` and `NITRO_SSL_KEY` - if both are present, this will launch the server in HTTPS mode. In the vast majority of cases, this should not be used other than for testing, and the Nitro server should be run behind a reverse proxy like nginx or Cloudflare which terminates SSL.
+- `NITRO_SHUTDOWN` - Enables the graceful shutdown feature when set to `'true'`. If it's set to `'false'`, the graceful shutdown is bypassed to speed up the development process. Defaults to `'false'`.
+- `NITRO_SHUTDOWN_SIGNALS` - Allows you to specify which signals should be handled. Each signal should be separated with a space. Defaults to `'SIGINT SIGTERM'`.
+- `NITRO_SHUTDOWN_TIMEOUT` - Sets the amount of time (in milliseconds) before a forced shutdown occurs. Defaults to `'30000'` milliseconds.
+- `NITRO_SHUTDOWN_FORCE` - When set to true, it triggers `process.exit()` at the end of the shutdown process. If it's set to `'false'`, the process will simply let the event loop clear. Defaults to `'true'`.
 
 ## Cluster mode
 
@@ -48,7 +52,7 @@ For more performance and leveraging multi core handling, you can use cluster pre
 
 ### Environment Variables
 
-In addition to `node-server` environment variables, you can customiize behavior:
+In addition to `node-server` environment variables, you can customize behavior:
 
 - `NITRO_CLUSTER_WORKERS`: Number of cluster workers (default is Number of available cpu cores)
 

--- a/examples/graceful-shutdown/nitro.config.ts
+++ b/examples/graceful-shutdown/nitro.config.ts
@@ -1,0 +1,3 @@
+import { defineNitroConfig } from "nitropack/config";
+
+export default defineNitroConfig({});

--- a/examples/graceful-shutdown/package.json
+++ b/examples/graceful-shutdown/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "example-graceful-shutdown",
+  "private": true,
+  "scripts": {
+    "dev": "nitro dev",
+    "build": "nitro build"
+  },
+  "devDependencies": {
+    "nitropack": "latest"
+  }
+}

--- a/examples/graceful-shutdown/plugins/graceful-shutdown.ts
+++ b/examples/graceful-shutdown/plugins/graceful-shutdown.ts
@@ -1,0 +1,14 @@
+const delay = (sec: number) => new Promise(resolve => setTimeout(resolve, sec * 1000))
+
+async function disconnectDatabase() {
+  await delay(3)
+}
+
+export default defineNitroPlugin((_nitroApp) => {
+  _nitroApp.hooks.hookOnce('close', async () => {
+    console.log('disconnects database...')
+    // something you want to do, such like disconnected the database, or wait the task is done
+    await disconnectDatabase()
+    console.log('database is disconnected!')
+  })
+});

--- a/examples/graceful-shutdown/routes/index.ts
+++ b/examples/graceful-shutdown/routes/index.ts
@@ -1,0 +1,8 @@
+import { eventHandler } from "h3";
+
+const delay = (sec: number) => new Promise(resolve => setTimeout(resolve, sec * 1000))
+
+export default eventHandler(async () => {
+  await delay(5)
+  return "You will see the response first, then the shutdown process begins."
+});

--- a/examples/graceful-shutdown/tsconfig.json
+++ b/examples/graceful-shutdown/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nitro/types/tsconfig.json"
+}

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "gzip-size": "^7.0.0",
     "h3": "^1.6.5",
     "hookable": "^5.5.3",
+    "http-graceful-shutdown": "^3.1.13",
     "http-proxy": "^1.18.1",
     "is-primitive": "^3.0.1",
     "jiti": "^1.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       hookable:
         specifier: ^5.5.3
         version: 5.5.3
+      http-graceful-shutdown:
+        specifier: ^3.1.13
+        version: 3.1.13
       http-proxy:
         specifier: ^1.18.1
         version: 1.18.1
@@ -272,6 +275,12 @@ importers:
         version: link:../..
 
   examples/custom-error-handler:
+    devDependencies:
+      nitropack:
+        specifier: link:../..
+        version: link:../..
+
+  examples/graceful-shutdown:
     devDependencies:
       nitropack:
         specifier: link:../..
@@ -3261,6 +3270,15 @@ packages:
       setprototypeof: 1.2.0
       statuses: 2.0.1
       toidentifier: 1.0.1
+    dev: false
+
+  /http-graceful-shutdown@3.1.13:
+    resolution: {integrity: sha512-Ci5LRufQ8AtrQ1U26AevS8QoMXDOhnAHCJI3eZu1com7mZGHxREmw3dNj85ftpQokQCvak8nI2pnFS8zyM1M+Q==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /http-proxy@1.18.1:

--- a/src/runtime/entries/node-cluster.ts
+++ b/src/runtime/entries/node-cluster.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import cluster from "node:cluster";
 
 if (cluster.isPrimary) {
+  let isShuttingDown = false;
   const numberOfWorkers =
     Number.parseInt(process.env.NITRO_CLUSTER_WORKERS) ||
     (os.cpus().length > 0 ? os.cpus().length : 1);
@@ -9,8 +10,52 @@ if (cluster.isPrimary) {
     cluster.fork();
   }
   cluster.on("exit", () => {
+    if (isShuttingDown) {
+      return;
+    }
     cluster.fork();
   });
+
+  // graceful shutdown
+  if (process.env.NITRO_SHUTDOWN === "true") {
+    function shutdownWorkers() {
+      return new Promise((resolve) => {
+        const interval = setInterval(() => {
+          for (const worker of Object.values(cluster.workers)) {
+            // some workers is not dead
+            if (!worker.isDead()) {
+              return;
+            }
+          }
+
+          // all workers are dead
+          clearInterval(interval);
+          return resolve(true);
+        }, 3 * 1000);
+      });
+    }
+
+    const terminationSignals: NodeJS.Signals[] = ["SIGTERM", "SIGINT"];
+    const signals = process.env.NITRO_SHUTDOWN_SIGNALS
+      ? (process.env.NITRO_SHUTDOWN_SIGNALS.split(" ").map((str) =>
+          str.trim()
+        ) as NodeJS.Signals[])
+      : terminationSignals;
+    const forceExit = process.env.NITRO_SHUTDOWN_FORCE !== "false";
+
+    async function onShutdown() {
+      isShuttingDown = true;
+      await shutdownWorkers();
+      if (forceExit) {
+        // eslint-disable-next-line unicorn/no-process-exit
+        process.exit(1);
+      }
+    }
+
+    for (const signal of signals) {
+      process.once(signal, onShutdown);
+    }
+  }
 } else {
   // eslint-disable-next-line unicorn/prefer-top-level-await
   import("./node-server").catch((error) => {

--- a/src/runtime/entries/node-server.ts
+++ b/src/runtime/entries/node-server.ts
@@ -4,6 +4,7 @@ import type { AddressInfo } from "node:net";
 import { Server as HttpsServer } from "node:https";
 import destr from "destr";
 import { toNodeListener } from "h3";
+import gracefulShutdown from "http-graceful-shutdown";
 import { nitroApp } from "../app";
 import { useRuntimeConfig } from "#internal/nitro";
 
@@ -20,18 +21,20 @@ const port = (destr(process.env.NITRO_PORT || process.env.PORT) ||
 const host = process.env.NITRO_HOST || process.env.HOST;
 
 // @ts-ignore
-const s = server.listen(port, host, (err) => {
+const listener = server.listen(port, host, (err) => {
   if (err) {
     console.error(err);
     // eslint-disable-next-line unicorn/no-process-exit
     process.exit(1);
   }
   const protocol = cert && key ? "https" : "http";
-  const i = s.address() as AddressInfo;
+  const addressInfo = listener.address() as AddressInfo;
   const baseURL = (useRuntimeConfig().app.baseURL || "").replace(/\/$/, "");
   const url = `${protocol}://${
-    i.family === "IPv6" ? `[${i.address}]` : i.address
-  }:${i.port}${baseURL}`;
+    addressInfo.family === "IPv6"
+      ? `[${addressInfo.address}]`
+      : addressInfo.address
+  }:${addressInfo.port}${baseURL}`;
   console.log(`Listening ${url}`);
 });
 
@@ -49,6 +52,24 @@ if (process.env.DEBUG) {
   process.on("uncaughtException", (err) =>
     console.error("[nitro] [dev] [uncaughtException] " + err)
   );
+}
+
+// graceful shutdown
+if (process.env.NITRO_SHUTDOWN === "true") {
+  // https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html
+  const terminationSignals: NodeJS.Signals[] = ["SIGTERM", "SIGINT"];
+  const signals =
+    process.env.NITRO_SHUTDOWN_SIGNALS || terminationSignals.join(" ");
+  const timeout =
+    Number.parseInt(process.env.NITRO_SHUTDOWN_TIMEOUT, 10) || 30 * 1000;
+  const forceExit = process.env.NITRO_SHUTDOWN_FORCE !== "false";
+
+  async function onShutdown(signal?: NodeJS.Signals) {
+    await nitroApp.hooks.callHook("close");
+  }
+
+  // https://github.com/sebhildebrandt/http-graceful-shutdown
+  gracefulShutdown(listener, { signals, timeout, forceExit, onShutdown });
 }
 
 export default {};


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1224 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pull request brings the addition of a graceful shutdown feature to the `nitro-node-cluster`, `nitro-node`, and `nitro-dev` presets. This enhancement ensures all ongoing requests are successfully processed before the server terminates, minimizing the risk of sudden connection losses. Furthermore, it allows developers to integrate their cleanup routines such as closing database connections prior to server halt.

We have introduced four new environment variables for customizing this behavior:

- NITRO_SHUTDOWN - Enables the graceful shutdown feature when set to true. If it's set to false, the graceful shutdown is bypassed to speed up the development process. Defaults to 'false'.
- NITRO_SHUTDOWN_SIGNALS - Allows you to specify which signals should be handled. Each signal should be separated with a space. Defaults to 'SIGINT SIGTERM'.
- NITRO_SHUTDOWN_TIMEOUT - Sets the amount of time (in milliseconds) before a forced shutdown occurs. Defaults to 30000 milliseconds.
- NITRO_SHUTDOWN_FORCE - When set to true, it triggers process.exit() at the end of the shutdown process. If it's set to false, the process will simply let the event loop clear. Defaults to 'true'.

We've also added an example (examples/graceful-shutdown) demonstrating how to utilize these new features in a Nitro server application. The example shows the server awaiting the completion of the HTTP response before initiating the shutdown process and handling server shutdowns gracefully.

To start the server, use the following command:

```shell
NITRO_PRESET=node-cluster pnpm nitro build examples/graceful-shutdown
NITRO_SHUTDOWN=true node examples/graceful-shutdown/.output/server/index.mjs
```

Then, send an HTTP request with `curl localhost:3000`. The server will respond after a three-second delay. During this delay, you can send a SIGINT signal to Nitro (using `Ctrl+C`). The server will then wait for the HTTP response to complete before initiating the shutdown process.

I have added the [http-graceful-shutdown](https://github.com/sebhildebrandt/http-graceful-shutdown) package to our dependencies to manage the shutdown process.

This enhancement is crucial for offering better control over the shutdown process in production environments, ensuring all ongoing tasks are finished before server termination, thereby avoiding potential data loss or corruption.

Regarding `nitro-dev`, I've identified that the graceful shutdown feature isn't functioning as anticipated. This issue appears to be related to the worker implementation in `src/dev/server.ts` and `src/cli/commands/dev.ts`. I would appreciate it if someone could provide some guidance on resolving this issue.

While the graceful shutdown feature has successfully passed our initial tests, I have yet to add specific tests for it. I need  assist in introducing relevant tests to verify its effectiveness.

I kindly invite @pi to review these changes. Your feedback on the **`nitro-dev`** issue and **test coverage** would be greatly appreciated.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
