### PR TITLE
chore: workaround for `describe.skipIf` not working

### DIFF
--- a/test/presets/vercel-edge.test.ts
+++ b/test/presets/vercel-edge.test.ts
@@ -12,7 +12,7 @@ const describeIf = (condition, title, factory) =>
         it.skip("skipped", () => {});
       });
 
-describeIf(!isWindows, "nitro:preset:vercel-edge", async () => {
+describe.runIf(!isWindows)("nitro:preset:vercel-edge", async () => {
   const ctx = await setupTest("vercel-edge");
   testNitro(ctx, async () => {
     // TODO: Add add-event-listener

--- a/test/presets/vercel-edge.test.ts
+++ b/test/presets/vercel-edge.test.ts
@@ -1,11 +1,18 @@
 import { promises as fsp } from "node:fs";
 import { resolve } from "pathe";
-import { describe } from "vitest";
+import { describe, it } from "vitest";
 import { EdgeRuntime } from "edge-runtime";
 import { isWindows } from "std-env";
 import { setupTest, testNitro } from "../tests";
 
-describe.skipIf(isWindows)("nitro:preset:vercel-edge", async () => {
+const describeIf = (condition, title, factory) =>
+  condition
+    ? describe(title, factory)
+    : describe(title, () => {
+        it.skip("skipped", () => {});
+      });
+
+describeIf(!isWindows, "nitro:preset:vercel-edge", async () => {
   const ctx = await setupTest("vercel-edge");
   testNitro(ctx, async () => {
     // TODO: Add add-event-listener

--- a/test/presets/vercel-edge.test.ts
+++ b/test/presets/vercel-edge.test.ts
@@ -1,18 +1,10 @@
 import { promises as fsp } from "node:fs";
 import { resolve } from "pathe";
-import { describe, it } from "vitest";
 import { EdgeRuntime } from "edge-runtime";
 import { isWindows } from "std-env";
-import { setupTest, testNitro } from "../tests";
+import { describeIf, setupTest, testNitro } from "../tests";
 
-const describeIf = (condition, title, factory) =>
-  condition
-    ? describe(title, factory)
-    : describe(title, () => {
-        it.skip("skipped", () => {});
-      });
-
-describe.runIf(!isWindows)("nitro:preset:vercel-edge", async () => {
+describeIf(!isWindows, "nitro:preset:vercel-edge", async () => {
   const ctx = await setupTest("vercel-edge");
   testNitro(ctx, async () => {
     // TODO: Add add-event-listener

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -2,7 +2,7 @@ import { resolve } from "pathe";
 import { listen, Listener } from "listhen";
 import destr from "destr";
 import { fetch, FetchOptions } from "ofetch";
-import { expect, it, afterAll, beforeAll } from "vitest";
+import { expect, it, afterAll, beforeAll, describe } from "vitest";
 import { fileURLToPath } from "mlly";
 import { joinURL } from "ufo";
 import * as _nitro from "../src";
@@ -20,6 +20,14 @@ export interface Context {
   server?: Listener;
   isDev: boolean;
 }
+
+// https://github.com/unjs/nitro/pull/1240
+export const describeIf = (condition, title, factory) =>
+  condition
+    ? describe(title, factory)
+    : describe(title, () => {
+        it.skip("skipped", () => {});
+      });
 
 export async function setupTest(preset: string) {
   const fixtureDir = fileURLToPath(new URL("fixture", import.meta.url).href);


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Windows CI should skip `vercel-edge` but it is not skipping it with `describe.skipIf(isWindows)(...)` only in CI. (runIf seems broken too)

Failing: https://github.com/unjs/nitro/actions/runs/4989669099/jobs/8933890560#step:8:345

/cc @antfu 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
