### PR TITLE
feat: add ability to use nested routers from ServerDir files

### DIFF
--- a/docs/content/1.guide/3.routing.md
+++ b/docs/content/1.guide/3.routing.md
@@ -99,6 +99,20 @@ Check out [h3 JSDocs](https://www.jsdocs.io/package/h3#package-index-functions) 
 export default eventHandler(event => `Default page`)
 ```
 
+### Using a Nested Router
+
+```js
+// api/{todo}.ts
+const db = ['todo 1', 'todo 2']
+export default createRouter()
+  .get('/', eventHandler(() => db))
+  .post('/', eventHandler(async (event) => {
+    const { todo } = await readBody(event)
+    db.push(todo)
+    return todo
+  }))
+```
+
 ## Route Rules
 
 Nitro allows you to add logic at the top-level of your configuration, useful for redirecting, proxying, caching and adding headers to routes.

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -83,6 +83,8 @@ function createNitroApp(): NitroApp {
         "/"
       );
       h3App.use(middlewareBase, handler);
+    } else if (typeof handler === 'object') { // Router
+      h3App.use(h.route, handler)
     } else {
       const routeRules = getRouteRulesForPath(
         h.route.replace(/:\w+|\*\*/g, "_")

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -41,6 +41,7 @@ export function scanMiddleware(nitro: Nitro) {
 export function scanRoutes(nitro: Nitro, dir: string, prefix = "/") {
   return scanServerDir(nitro, dir, (file) => {
     let route = file.path
+      .replace(/{(\w+)}/g, "$1")
       .replace(/\.[A-Za-z]+$/, "")
       .replace(/\[\.{3}]/g, "**")
       .replace(/\[\.{3}(\w+)]/g, "**:$1")
@@ -56,9 +57,11 @@ export function scanRoutes(nitro: Nitro, dir: string, prefix = "/") {
 
     route = route.replace(/\/index$/, "") || "/";
 
+    const isRouter = /{(\w+)}/g.test(file.path)
+
     return {
       handler: file.fullPath,
-      lazy: true,
+      lazy: !isRouter,
       route,
       method,
     };


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/18571

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

These changes allow routers to be added to the h3 app using the same file-based routing system present in nitro.
Typically, this makes it possible to have one router per file.
For example, a todo file with GET /, POST /, PUT /:id, DELETE /:id ...
```js
// api/{todo}.ts
const db = ['todo 1', 'todo 2']
export default createRouter()
  .get('/', eventHandler(() => db))
  .post('/', eventHandler(async (event) => {
    const { todo } = await readBody(event)
    db.push(todo)
    return todo
  }))
  .put('/:id', …)
```

In this modification, I use the syntax _{route-name}_.ts to determine that it's a router that should be added (not a function handler). Does this make sense to you? I was hesitating with _route-name_.use.ts or _route-name_.router.ts, but the dot is used to specify HTTP request method, so it might be a bit confusing.

Resolves nuxt/nuxt#18571

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
