### PR TITLE
refactor: show `/_vfs` structure in nested tree

### DIFF
--- a/src/dev/vfs.ts
+++ b/src/dev/vfs.ts
@@ -78,16 +78,14 @@ export function createVFSHandler(nitro: Nitro) {
           return Object.keys(value).length === 0
             ? `
             <li class="flex flex-nowrap">
-              <a href="/_vfs/${
-                encodedUrl
-              }" class="w-full text-sm px-2 py-1 border-b border-gray-10 ${linkClass}">
+              <a href="/_vfs/${encodedUrl}" class="w-full text-sm px-2 py-1 border-b border-gray-10 ${linkClass}">
                 ${fname}
               </a>
             </li>
             `
             : `
             <li>
-              <details ${url.startsWith(`/${encodedUrl}`) ? 'open' : ''}>
+              <details ${url.startsWith(`/${encodedUrl}`) ? "open" : ""}>
                 <summary class="w-full text-sm px-2 py-1 border-b border-gray-10 hover:bg-gray-800 text-gray-200">
                   ${fname}
                 </summary>

--- a/src/dev/vfs.ts
+++ b/src/dev/vfs.ts
@@ -68,25 +68,26 @@ export function createVFSHandler(nitro: Nitro) {
         .map(([fname, value = {}]) => {
           const subpath = [...path, fname];
           const key = subpath.join("/");
+          const encodedUrl = encodeURIComponent(key);
 
           const linkClass =
-            url === `/${encodeURIComponent(key)}`
+            url === `/${encodedUrl}`
               ? "bg-gray-700 text-white"
               : "hover:bg-gray-800 text-gray-200";
 
           return Object.keys(value).length === 0
             ? `
             <li class="flex flex-nowrap">
-              <a href="/_vfs/${encodeURIComponent(
-                key
-              )}" class="w-full text-sm px-2 py-1 border-b border-gray-10 ${linkClass}">
+              <a href="/_vfs/${
+                encodedUrl
+              }" class="w-full text-sm px-2 py-1 border-b border-gray-10 ${linkClass}">
                 ${fname}
               </a>
             </li>
             `
             : `
             <li>
-              <details>
+              <details ${url.startsWith(`/${encodedUrl}`) ? 'open' : ''}>
                 <summary class="w-full text-sm px-2 py-1 border-b border-gray-10 hover:bg-gray-800 text-gray-200">
                   ${fname}
                 </summary>

--- a/src/dev/vfs.ts
+++ b/src/dev/vfs.ts
@@ -39,20 +39,58 @@ export function createVFSHandler(nitro: Nitro) {
       };
     }
 
-    const items = Object.keys(vfsEntries)
-      .map((key) => {
+    const directories: Record<string, any> = { [nitro.options.rootDir]: {} };
+    const fpaths = Object.keys(vfsEntries)
+
+    for (const item of fpaths) {
+      const segments = item.replace(nitro.options.rootDir, '').split('/').filter(Boolean);
+      let currentDir = item.startsWith(nitro.options.rootDir) ? directories[nitro.options.rootDir] : directories;
+
+      for (const segment of segments) {
+        if (!currentDir[segment]) {
+          currentDir[segment] = {};
+        }
+
+        currentDir = currentDir[segment];
+      }
+    }
+
+    const generateHTML = (directory: Record<string, any>, path: string[] = []): string =>
+      Object.entries(directory).map(([fname, value = {}]) => {
+        const subpath = [...path, fname];
+        const key = subpath.join('/');
+
         const linkClass =
           url === `/${encodeURIComponent(key)}`
             ? "bg-gray-700 text-white"
             : "hover:bg-gray-800 text-gray-200";
-        return `<li class="flex flex-nowrap"><a href="/_vfs/${encodeURIComponent(
-          key
-        )}" class="w-full text-sm px-2 py-1 border-b border-gray-10 ${linkClass}">${key.replace(
-          nitro.options.rootDir,
-          ""
-        )}</a></li>`;
-      })
-      .join("\n");
+
+        return (Object.keys(value).length === 0)
+          ? `
+            <li class="flex flex-nowrap">
+              <a href="/_vfs/${encodeURIComponent(key)}" class="w-full text-sm px-2 py-1 border-b border-gray-10 ${linkClass}">
+                ${fname}
+              </a>
+            </li>
+            `
+          : `
+            <li>
+              <details>
+                <summary class="w-full text-sm px-2 py-1 border-b border-gray-10 hover:bg-gray-800 text-gray-200">
+                  ${fname}
+                </summary>
+                <ul class="ml-4">
+                  ${generateHTML(value, subpath)}
+                </ul>
+              </details>
+            </li>
+            `
+      }).join('');
+
+
+    const rootDirectory = directories[nitro.options.rootDir];
+    delete directories[nitro.options.rootDir];
+    const items = generateHTML(rootDirectory, [nitro.options.rootDir]) + generateHTML(directories);
 
     const files = `
       <div class="h-full overflow-auto border-r border-gray:10">
@@ -76,7 +114,7 @@ export function createVFSHandler(nitro: Nitro) {
         </div>
       `;
 
-    return `
+    return /* html */ `
 <!doctype html>
 <html>
 <head>
@@ -94,7 +132,7 @@ export function createVFSHandler(nitro: Nitro) {
   </style>
 </head>
 <body class="bg-[#1E1E1E]">
-  <div un-cloak class="h-screen h-screen grid grid-cols-[300px_1fr]">
+  <div un-cloak class="h-screen grid grid-cols-[300px_1fr]">
     ${files}
     ${file}
   </div>

--- a/src/dev/vfs.ts
+++ b/src/dev/vfs.ts
@@ -40,11 +40,16 @@ export function createVFSHandler(nitro: Nitro) {
     }
 
     const directories: Record<string, any> = { [nitro.options.rootDir]: {} };
-    const fpaths = Object.keys(vfsEntries)
+    const fpaths = Object.keys(vfsEntries);
 
     for (const item of fpaths) {
-      const segments = item.replace(nitro.options.rootDir, '').split('/').filter(Boolean);
-      let currentDir = item.startsWith(nitro.options.rootDir) ? directories[nitro.options.rootDir] : directories;
+      const segments = item
+        .replace(nitro.options.rootDir, "")
+        .split("/")
+        .filter(Boolean);
+      let currentDir = item.startsWith(nitro.options.rootDir)
+        ? directories[nitro.options.rootDir]
+        : directories;
 
       for (const segment of segments) {
         if (!currentDir[segment]) {
@@ -55,25 +60,31 @@ export function createVFSHandler(nitro: Nitro) {
       }
     }
 
-    const generateHTML = (directory: Record<string, any>, path: string[] = []): string =>
-      Object.entries(directory).map(([fname, value = {}]) => {
-        const subpath = [...path, fname];
-        const key = subpath.join('/');
+    const generateHTML = (
+      directory: Record<string, any>,
+      path: string[] = []
+    ): string =>
+      Object.entries(directory)
+        .map(([fname, value = {}]) => {
+          const subpath = [...path, fname];
+          const key = subpath.join("/");
 
-        const linkClass =
-          url === `/${encodeURIComponent(key)}`
-            ? "bg-gray-700 text-white"
-            : "hover:bg-gray-800 text-gray-200";
+          const linkClass =
+            url === `/${encodeURIComponent(key)}`
+              ? "bg-gray-700 text-white"
+              : "hover:bg-gray-800 text-gray-200";
 
-        return (Object.keys(value).length === 0)
-          ? `
+          return Object.keys(value).length === 0
+            ? `
             <li class="flex flex-nowrap">
-              <a href="/_vfs/${encodeURIComponent(key)}" class="w-full text-sm px-2 py-1 border-b border-gray-10 ${linkClass}">
+              <a href="/_vfs/${encodeURIComponent(
+                key
+              )}" class="w-full text-sm px-2 py-1 border-b border-gray-10 ${linkClass}">
                 ${fname}
               </a>
             </li>
             `
-          : `
+            : `
             <li>
               <details>
                 <summary class="w-full text-sm px-2 py-1 border-b border-gray-10 hover:bg-gray-800 text-gray-200">
@@ -84,13 +95,15 @@ export function createVFSHandler(nitro: Nitro) {
                 </ul>
               </details>
             </li>
-            `
-      }).join('');
-
+            `;
+        })
+        .join("");
 
     const rootDirectory = directories[nitro.options.rootDir];
     delete directories[nitro.options.rootDir];
-    const items = generateHTML(rootDirectory, [nitro.options.rootDir]) + generateHTML(directories);
+    const items =
+      generateHTML(rootDirectory, [nitro.options.rootDir]) +
+      generateHTML(directories);
 
     const files = `
       <div class="h-full overflow-auto border-r border-gray:10">


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Taking advantage of `details` and `summary` with a generated structure, it should finally do a bit cleanup for the VFS.

Preview:

![image](https://github.com/unjs/nitro/assets/56732164/dfd49674-4e66-42b0-9b84-24387612bba9)

I'm definitely open to feedback and ideas on this if we look to polish it more. 🙂 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
