### PR TITLE
docs: mention `bcrypt` incompatibility with workers

### DIFF
--- a/docs/content/2.deploy/2.workers.md
+++ b/docs/content/2.deploy/2.workers.md
@@ -55,3 +55,4 @@ The following libraries are known to be incompatible with edge workers because o
 - `ioredis`
 - `cassandra-driver`
 - `kafkajs`
+- `bcrypt`


### PR DESCRIPTION
When using `bcrypt` an error is thrown on bundle build. I used `bcryptjs` instead.

[error] Cannot resolve "aws-sdk" from "/opt/buildhome/repo/node_modules/@mapbox/node-pre-gyp/lib/util/s3_setup.js" and externals are not allowed!

- Node v18.16.0
- Nitro 2.4.1 
- Preset cloudflare-pages

<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
