### PR TITLE
feat: allow customising generated tsConfig

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -198,7 +198,7 @@ declare module 'nitropack' {
       nitro.options.typescript.tsconfigPath
     );
     const tsconfigDir = dirname(tsConfigPath);
-    const tsConfig: TSConfig = {
+    const tsConfig: TSConfig = defu(nitro.options.typescript.tsConfig, {
       compilerOptions: {
         forceConsistentCasingInFileNames: true,
         strict: nitro.options.typescript.strict,
@@ -224,7 +224,7 @@ declare module 'nitropack' {
           ? [join(relative(tsconfigDir, nitro.options.srcDir), "**/*")]
           : []),
       ],
-    };
+    });
     buildFiles.push({
       path: tsConfigPath,
       contents: JSON.stringify(tsConfig, null, 2),

--- a/src/options.ts
+++ b/src/options.ts
@@ -101,6 +101,7 @@ const NitroDefaults: NitroConfig = {
     generateTsConfig: true,
     tsconfigPath: "types/tsconfig.json",
     internalPaths: false,
+    tsConfig: {},
   },
   nodeModulesDirs: [],
   hooks: {},

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -12,6 +12,7 @@ import type { Storage, BuiltinDriverName } from "unstorage";
 import type { ServerOptions as HTTPProxyOptions } from "http-proxy";
 import type { ProxyOptions } from "h3";
 import type { ResolvedConfig, ConfigWatcher } from "c12";
+import type { TSConfig } from "pkg-types";
 import type { NodeExternalsOptions } from "../rollup/plugins/externals";
 import type { RollupConfig } from "../rollup/config";
 import type { Options as EsbuildOptions } from "../rollup/plugins/esbuild";
@@ -262,6 +263,7 @@ export interface NitroOptions extends PresetOptions {
     generateTsConfig?: boolean;
     /** the path of the generated `tsconfig.json`, relative to buildDir */
     tsconfigPath: string;
+    tsConfig?: Partial<TSConfig>;
   };
   hooks: NestedHooks<NitroHooks>;
   nodeModulesDirs: string[];


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/21074

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Users or consuming frameworks might need to customise the generated `tsConfig` - this makes that possible via nitro options.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
