### PR TITLE
types: support type generic for `useRuntimeConfig`

### DIFF
--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -14,17 +14,17 @@ const ENV_PREFIX_ALT =
 const _sharedRuntimeConfig = _deepFreeze(
   _applyEnv(klona(_inlineRuntimeConfig))
 );
-export function useRuntimeConfig(event?: H3Event) {
+export function useRuntimeConfig<T extends object>(event?: H3Event): T {
   // Backwards compatibility with ambient context
   if (!event) {
-    return _sharedRuntimeConfig;
+    return _sharedRuntimeConfig as T;
   }
   // Reuse cached runtime config from event context
   if (event.context.nitro.runtimeConfig) {
     return event.context.nitro.runtimeConfig;
   }
   // Prepare runtime config for event context
-  const runtimeConfig = klona(_inlineRuntimeConfig);
+  const runtimeConfig = klona<T>(_inlineRuntimeConfig);
   _applyEnv(runtimeConfig);
   event.context.nitro.runtimeConfig = runtimeConfig;
   return runtimeConfig;


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1283 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds the ability for the user to provide a type hunt configuration to the useRuntimeConfig() call as:

```ts
const { db } = useRuntimeConfig<{
    db: LibSQLDatabase
}>()
```

### Misc

I'd gladly accept help and guidance on how we could infer the types from the nitro.config.ts file ... cc @danielroe 

### 📝 Checklist

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
