### PR TITLE
docs: add an example for `devHandlers` config

### DIFF
--- a/docs/content/3.config.md
+++ b/docs/content/3.config.md
@@ -249,6 +249,28 @@ There are situations in that we directly want to provide a handler instance with
 
 We can use `devHandlers` but note that they are **only available in development mode** and **not in production build**.
 
+For example:
+
+```ts
+import { defineNitroConfig } from 'nitropack/config'
+import { eventHandler } from 'h3'
+
+export default defineNitroConfig({
+  devHandlers: [
+    {
+      route: '/',
+      handler: eventHandler((event) => {
+       console.log(event)
+      })
+    }
+  ]
+})
+```
+
+::alert{type=info}
+Note that `eventHandler` is a helper function from [`h3`](https://github.com/unjs/h3) library.
+::
+
 ### `devProxy`
 
 Proxy configuration for development server.

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 importers:
 


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Add an example for the `devHandlers` usage. I'm currently learning Nitro and I did not find how to remove the warning ` Implicit event handler conversion is deprecated. Use 'eventHandler()' or 'fromNodeMiddleware()' to define event handlers. ` during an hour.

So I think that this could help people.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
