### PR TITLE
feat: type `useRuntimeConfig` with `NitroRuntimeConfig`

### DIFF
--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -97,7 +97,7 @@ function createNitroApp(): NitroApp {
     }
   }
 
-  h3App.use(config.app.baseURL, router);
+  h3App.use(config.app.baseURL as string, router.handler);
 
   const app: NitroApp = {
     hooks,

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -15,17 +15,19 @@ const ENV_PREFIX_ALT =
 const _sharedRuntimeConfig = _deepFreeze(
   _applyEnv(klona(_inlineRuntimeConfig))
 );
-export function useRuntimeConfig(event?: H3Event): NitroRuntimeConfig {
+export function useRuntimeConfig<
+  T extends NitroRuntimeConfig = NitroRuntimeConfig
+>(event?: H3Event): T {
   // Backwards compatibility with ambient context
   if (!event) {
-    return _sharedRuntimeConfig as NitroRuntimeConfig;
+    return _sharedRuntimeConfig as T;
   }
   // Reuse cached runtime config from event context
   if (event.context.nitro.runtimeConfig) {
     return event.context.nitro.runtimeConfig;
   }
   // Prepare runtime config for event context
-  const runtimeConfig = klona(_inlineRuntimeConfig) as NitroRuntimeConfig;
+  const runtimeConfig = klona(_inlineRuntimeConfig) as T;
   _applyEnv(runtimeConfig);
   event.context.nitro.runtimeConfig = runtimeConfig;
   return runtimeConfig;

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -30,6 +30,13 @@ export type NitroDynamicConfig = Pick<
   "runtimeConfig" | "routeRules"
 >;
 
+export interface NitroRuntimeConfig {
+  app: {
+    baseURL: string;
+  };
+  [key: string]: any;
+}
+
 export interface Nitro {
   options: NitroOptions;
   scannedHandlers: NitroEventHandler[];
@@ -170,12 +177,7 @@ export interface NitroOptions extends PresetOptions {
   preset: KebabCase<keyof typeof _PRESETS> | (string & {});
   static: boolean;
   logLevel: LogLevel;
-  runtimeConfig: {
-    app: {
-      baseURL: string;
-    };
-    [key: string]: any;
-  };
+  runtimeConfig: NitroRuntimeConfig;
   appConfig: AppConfig;
   appConfigFiles: string[];
 

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -99,7 +99,7 @@ describe("API routes", () => {
 
   it("generates types for routes matching prefix", () => {
     expectTypeOf($fetch("/api/hey/**")).toEqualTypeOf<Promise<string>>();
-    expectTypeOf($fetch("/api/param/{id}/**")).toEqualTypeOf<Promise<any>>();
+    expectTypeOf($fetch("/api/param/{id}/**")).toEqualTypeOf<Promise<string>>();
     expectTypeOf(
       $fetch("/api/typed/user/{someUserId}/post/{somePostId}/**")
     ).toEqualTypeOf<
@@ -128,7 +128,9 @@ describe("API routes", () => {
   });
 
   it("generates types for routes matching Api keys with /** globs", () => {
-    expectTypeOf($fetch("/api/wildcard/foo/bar")).toEqualTypeOf<Promise<any>>();
+    expectTypeOf($fetch("/api/wildcard/foo/bar")).toEqualTypeOf<
+      Promise<string>
+    >();
     expectTypeOf($fetch("/api/typed/todos/parent/child")).toEqualTypeOf<
       Promise<{ internalApiKey: "/api/typed/todos/**" }>
     >();
@@ -201,17 +203,23 @@ describe("API routes", () => {
     >();
 
     expectTypeOf($fetch("/api/serialized/error")).toEqualTypeOf<
-      Promise<unknown>
+      Promise<{
+        statusCode: number;
+        statusMessage?: string;
+        data?: any;
+        message: string;
+      }>
     >();
 
     expectTypeOf($fetch("/api/serialized/void")).toEqualTypeOf<
       Promise<unknown>
     >();
 
-    expectTypeOf($fetch("/api/serialized/null")).toEqualTypeOf<Promise<null>>();
+    expectTypeOf($fetch("/api/serialized/null")).toEqualTypeOf<Promise<any>>();
 
     expectTypeOf($fetch("/api/serialized/function")).toEqualTypeOf<
-      Promise<object>
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      Promise<{}>
     >();
 
     expectTypeOf($fetch("/api/serialized/map")).toEqualTypeOf<

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
     coverage: {
       reporter: ["text", "clover", "json"],
     },
+    include: ["test/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a follow-up addition for #1284 fixing types and also allows to easily extend (globally) runtime config types:

```ts
declare module 'nuxt/schema' {
  interface NitroRuntimeConfig {
    apiSecret: string
  }
}
```


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
