### PR TITLE
feat: set `node: true` on cloudflare-pages preset

### DIFF
--- a/src/presets/cloudflare-pages.ts
+++ b/src/presets/cloudflare-pages.ts
@@ -22,6 +22,7 @@ export const cloudflarePages = defineNitroPreset({
     // https://github.com/unjs/nitro/pull/933
     _mime: "mime/index.js",
   },
+  node: true,
   rollupConfig: {
     output: {
       entryFileNames: "_worker.js",


### PR DESCRIPTION

### 🔗 Linked issue

#1314 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Cloudflare pages supports node by default, but the `cloudflare-pages.ts` preset has this option set to `false` as it is inherited from the base preset. This PR adds an explicit `node: true` to the cloudflare-pages preset.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
