### PR TITLE
fix: use `event.handled` guard before sending response

### DIFF
--- a/src/dev/error.ts
+++ b/src/dev/error.ts
@@ -1,7 +1,7 @@
-import { setResponseStatus } from "h3";
+import { H3Event, setResponseStatus } from "h3";
 import { NitroErrorHandler } from "../types";
 
-function errorHandler(error, event) {
+function errorHandler(error: any, event: H3Event) {
   event.node.res.setHeader("Content-Type", "text/html; charset=UTF-8");
   setResponseStatus(event, 503, "Server Unavailable");
 
@@ -14,6 +14,10 @@ function errorHandler(error, event) {
     title = "Reloading server...";
     body =
       "<progress></progress><script>document.querySelector('progress').indeterminate=true</script>";
+  }
+
+  if (event.handled) {
+    return;
   }
 
   event.node.res.end(`<!DOCTYPE html>

--- a/src/runtime/error.ts
+++ b/src/runtime/error.ts
@@ -44,12 +44,14 @@ export default <NitroErrorHandler>function (error, event) {
 
   setResponseStatus(event, statusCode, statusMessage);
 
-  if (isJsonRequest(event)) {
-    event.node.res.setHeader("Content-Type", "application/json");
-    event.node.res.end(JSON.stringify(errorObject));
-  } else {
-    event.node.res.setHeader("Content-Type", "text/html");
-    event.node.res.end(renderHTMLError(errorObject));
+  if (!event.handled) {
+    if (isJsonRequest(event)) {
+      event.node.res.setHeader("Content-Type", "application/json");
+      event.node.res.end(JSON.stringify(errorObject));
+    } else {
+      event.node.res.setHeader("Content-Type", "text/html");
+      event.node.res.end(renderHTMLError(errorObject));
+    }
   }
 };
 

--- a/src/runtime/renderer.ts
+++ b/src/runtime/renderer.ts
@@ -16,16 +16,18 @@ export function defineRenderHandler(handler: RenderHandler) {
   return eventHandler(async (event) => {
     // TODO: Use serve-placeholder
     if (event.node.req.url.endsWith("/favicon.ico")) {
-      event.node.res.setHeader("Content-Type", "image/x-icon");
-      event.node.res.end(
-        "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-      );
+      if (!event.handled) {
+        event.node.res.setHeader("Content-Type", "image/x-icon");
+        event.node.res.end(
+          "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+        );
+      }
       return;
     }
 
     const response = await handler(event);
     if (!response) {
-      if (!event.node.res.writableEnded) {
+      if (!event.handled) {
         event.node.res.statusCode =
           event.node.res.statusCode === 200 ? 500 : event.node.res.statusCode;
         event.node.res.end(

--- a/src/runtime/static.ts
+++ b/src/runtime/static.ts
@@ -61,8 +61,10 @@ export default eventHandler((event) => {
 
   const ifNotMatch = event.node.req.headers["if-none-match"] === asset.etag;
   if (ifNotMatch) {
-    event.node.res.statusCode = 304;
-    event.node.res.end();
+    if (!event.handled) {
+      event.node.res.statusCode = 304;
+      event.node.res.end();
+    }
     return;
   }
 
@@ -73,8 +75,10 @@ export default eventHandler((event) => {
     asset.mtime &&
     new Date(ifModifiedSinceH) >= mtimeDate
   ) {
-    event.node.res.statusCode = 304;
-    event.node.res.end();
+    if (!event.handled) {
+      event.node.res.statusCode = 304;
+      event.node.res.end();
+    }
     return;
   }
 


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Use the new h3 `event.handled` flag (https://github.com/unjs/h3/pull/410) to guard `node.res.end` calls and avoid responding to an already ended request similar to https://github.com/unjs/h3/pull/411

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
