### PR TITLE
types: avoid overriding app runtime config namespace

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -19,6 +19,7 @@ import type {
   NitroOptions,
   NitroRouteConfig,
   NitroRouteRules,
+  NitroRuntimeConfig,
 } from "./types";
 import { runtimeDir, pkgDir } from "./dirs";
 import * as _PRESETS from "./presets";
@@ -368,7 +369,7 @@ export function normalizeRuntimeConfig(config: NitroConfig) {
     nitro: {},
   });
   runtimeConfig.nitro.routeRules = config.routeRules;
-  return runtimeConfig;
+  return runtimeConfig as NitroRuntimeConfig;
 }
 
 export function normalizeRouteRules(

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -31,7 +31,20 @@ export type NitroDynamicConfig = Pick<
   "runtimeConfig" | "routeRules"
 >;
 
+export interface NitroRuntimeConfigApp {
+  baseURL: string;
+  [key: string]: unknown;
+}
+
+export interface NitroRuntimeConfigNitro {
+  routeRules?: {
+    [path: string]: NitroRouteConfig;
+  }
+}
+
 export interface NitroRuntimeConfig {
+  app: NitroRuntimeConfigApp;
+  nitro: NitroRuntimeConfigNitro;
   [key: string]: unknown;
 }
 

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -39,7 +39,7 @@ export interface NitroRuntimeConfigApp {
 export interface NitroRuntimeConfigNitro {
   routeRules?: {
     [path: string]: NitroRouteConfig;
-  }
+  };
 }
 
 export interface NitroRuntimeConfig {

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -43,7 +43,7 @@ export interface NitroRuntimeConfig {
       [path: string]: NitroRouteConfig;
     };
   };
-  [key: string]: unknown;
+  [key: string]: any;
 }
 
 export interface Nitro {

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -36,15 +36,13 @@ export interface NitroRuntimeConfigApp {
   [key: string]: unknown;
 }
 
-export interface NitroRuntimeConfigNitro {
-  routeRules?: {
-    [path: string]: NitroRouteConfig;
-  };
-}
-
 export interface NitroRuntimeConfig {
   app: NitroRuntimeConfigApp;
-  nitro: NitroRuntimeConfigNitro;
+  nitro: {
+    routeRules?: {
+      [path: string]: NitroRouteConfig;
+    };
+  };
   [key: string]: unknown;
 }
 

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -33,7 +33,7 @@ export type NitroDynamicConfig = Pick<
 
 export interface NitroRuntimeConfigApp {
   baseURL: string;
-  [key: string]: unknown;
+  [key: string]: any;
 }
 
 export interface NitroRuntimeConfig {

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -32,10 +32,7 @@ export type NitroDynamicConfig = Pick<
 >;
 
 export interface NitroRuntimeConfig {
-  app: {
-    baseURL: string;
-  };
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface Nitro {


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently it's not possible to augment `runtimeConfig.app` whilst also using Nitro types for runtime config.

This PR makes it possible to augment `app`. It also exposes the `nitro` type. (I can also make augmentation disallowed for this if that is desirable.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
