### PR TITLE
fix: add `envPrefix` to `runtimeConfig.nitro` types

### DIFF
--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -39,7 +39,7 @@ export interface NitroRuntimeConfigApp {
 export interface NitroRuntimeConfig {
   app: NitroRuntimeConfigApp;
   nitro: {
-    envPrefix?: string
+    envPrefix?: string;
     routeRules?: {
       [path: string]: NitroRouteConfig;
     };

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -39,6 +39,7 @@ export interface NitroRuntimeConfigApp {
 export interface NitroRuntimeConfig {
   app: NitroRuntimeConfigApp;
   nitro: {
+    envPrefix?: string
     routeRules?: {
       [path: string]: NitroRouteConfig;
     };


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a missing type for `runtimeConfig.nitro` - apologies!

(This is not a blocker for Nuxt.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
