### PR TITLE
docs: add reference to install azure functions core tools to the swa section

### DIFF
--- a/docs/content/2.deploy/providers/azure.md
+++ b/docs/content/2.deploy/providers/azure.md
@@ -16,6 +16,8 @@ Azure Static Web Apps are designed to be deployed continuously in a [GitHub Acti
 
 ### Local preview
 
+Install [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local) if you want to test locally.
+
 You can invoke a development environment to preview before deploying.
 
 ```bash


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
I copied the text stating "Install [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local) if you want to test locally." from the Azure Functions Local Preview section of the documentation.

When I was building and previewing locally using the `azure` nitro preset, I found that the server would not run unless I installed Azure Functions Core Tools. However, that documentation was written in the Azure Functions section no in the Azure Static Web Apps section. Therefore I believe it is important to include this message in both sections to reduce issues/confusion from users.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
