### PR TITLE
fix(options): default target to `static` when `static` override is set

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -148,7 +148,7 @@ export async function loadOptions(
       preset: presetOverride,
     },
     defaultConfig: {
-      preset: detectTarget({ static: configOverrides.static }) || "node-server",
+      preset: detectTarget({ static: configOverrides.static }),
     },
     defaults: NitroDefaults,
     jitiOptions: {
@@ -179,7 +179,7 @@ export async function loadOptions(
   options.preset =
     presetOverride ||
     (c12Config.layers.find((l) => l.config.preset)?.config.preset as string) ||
-    (detectTarget({ static: options.static }) ?? "node-server");
+    detectTarget({ static: options.static });
 
   options.rootDir = resolve(options.rootDir || ".");
   options.workspaceDir = await findWorkspaceDir(options.rootDir).catch(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -120,8 +120,8 @@ const autodetectableStaticProviders: Partial<
 
 export function detectTarget(options: { static?: boolean } = {}) {
   return options?.static
-    ? autodetectableStaticProviders[provider]
-    : autodetectableProviders[provider];
+    ? autodetectableStaticProviders[provider] || "node-server"
+    : autodetectableProviders[provider] || "static";
 }
 
 export async function isDirectory(path: string) {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/21728

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If we have enabled `static` then we should default to `static` preset rather than `node-server`. As we are only using `detectTarget` in these two places, I think we can also slightly simplify the code.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
