### PR TITLE
feat(storage): default data storage for `node` and dev presets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ jspm_packages
 # Nitro
 nitro.d.ts
 .nitro
+.data
 
 package-lock.json
 

--- a/playground/routes/index.ts
+++ b/playground/routes/index.ts
@@ -1,4 +1,8 @@
-// eslint-disable-next-line require-await
 export default eventHandler(async (event) => {
-  return {};
+  const kvStorage = useStorage("data");
+  const counter = (Number(await kvStorage.getItem("counter")) || 0) + 1;
+  await kvStorage.setItem("counter", counter);
+  return {
+    counter,
+  };
 });

--- a/playground/routes/index.ts
+++ b/playground/routes/index.ts
@@ -1,8 +1,4 @@
+// eslint-disable-next-line require-await
 export default eventHandler(async (event) => {
-  const kvStorage = useStorage("data");
-  const counter = (Number(await kvStorage.getItem("counter")) || 0) + 1;
-  await kvStorage.setItem("counter", counter);
-  return {
-    counter,
-  };
+  return {};
 });

--- a/src/options.ts
+++ b/src/options.ts
@@ -341,7 +341,7 @@ export async function loadOptions(
     options.storage.data === undefined &&
     options.devStorage.data === undefined
   ) {
-    options.storage.data = {
+    options.devStorage.data = {
       driver: "fs",
       base: resolve(options.rootDir, ".data/kv"),
     };

--- a/src/options.ts
+++ b/src/options.ts
@@ -335,6 +335,23 @@ export async function loadOptions(
     };
   }
 
+  // Runtime storage
+  if (
+    options.dev &&
+    options.storage.data === undefined &&
+    options.devStorage.data === undefined
+  ) {
+    options.storage.data = {
+      driver: "fs",
+      base: resolve(options.rootDir, ".data/kv"),
+    };
+  } else if (options.node && options.storage.data === undefined) {
+    options.storage.data = {
+      driver: "fs",
+      base: "./.data/kv",
+    };
+  }
+
   // Resolve plugin paths
   options.plugins = options.plugins.map((p) => resolvePath(p, options));
 


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The storage interface from `useStorage` is by default all in memory. In order to write stateful KV logic, users therefore require to configure `storage` mountpoints.

This PR adds a default `data` mountpoint using fs driver for all node based presets and development mode. (only if not configured by user) This way data will be persisted in `.data/kv` by default only for `data:` .

```ts
export default eventHandler(async (event) => {
  const kvStorage = useStorage("data");
  const counter = (Number(await kvStorage.getItem("counter")) || 0) + 1;
  await kvStorage.setItem("counter", counter);
  return {
    counter,
  };
});
``` 

Next steps:
- Support auto config storage for other worker presets when env/binding exits
- Document this feature + `.data` dir and gitignore
- Use data storage for cache as well (or consider persisting `.nitro`/`.nuxt` partially)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
