### PR TITLE
fix(rollup): replace `globalThis.process.` with `process.`

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -196,6 +196,7 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
       values: {
         "typeof window": '"undefined"',
         _import_meta_url_: "import.meta.url",
+        "globalThis.process.env.NODE_ENV": "process.env.NODE_ENV",
         "process.env.RUNTIME_CONFIG": () =>
           JSON.stringify(nitro.options.runtimeConfig, null, 2),
         ...Object.fromEntries(

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -196,7 +196,7 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
       values: {
         "typeof window": '"undefined"',
         _import_meta_url_: "import.meta.url",
-        "globalThis.process.env.NODE_ENV": "process.env.NODE_ENV",
+        "globalThis.process.": "process.",
         "process.env.RUNTIME_CONFIG": () =>
           JSON.stringify(nitro.options.runtimeConfig, null, 2),
         ...Object.fromEntries(


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->


### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

fix: https://github.com/unjs/nitro/issues/1346
fix: https://github.com/nuxt/nuxt/issues/21768

see vite PR logic: https://github.com/vitejs/vite/pull/12194

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Some packages uses `globalThis.process.env.NODE_ENV` instead of `process.env.NODE_ENV`, which isn't supported by default by rollup. Vite supports this and so does Nuxt, so this changes brings the exact same feature to the rollup config for Nitro.

See issue in [graphql-js](https://github.com/graphql/graphql-js/issues/3918)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
