### PR TITLE
refactor(cloudflare): use `wrangler deploy` instead of `publish`

### DIFF
--- a/docs/content/2.deploy/providers/cloudflare.md
+++ b/docs/content/2.deploy/providers/cloudflare.md
@@ -46,7 +46,7 @@ npx wrangler dev .output/server/index.mjs --site .output/public --local
 
 ### Deploy from your local machine using wrangler
 
-Install [wrangler2](https://github.com/cloudflare/wrangler2) and login to your Cloudflare account:
+Install [wrangler](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler#quick-start) and login to your Cloudflare account:
 
 ```bash
 npm i wrangler -g
@@ -72,7 +72,7 @@ wrangler dev .output/server/index.mjs --site .output/public
 Publish:
 
 ```bash
-wrangler publish
+wrangler deploy
 ```
 
 ### Deploy within CI/CD using GitHub Actions

--- a/src/presets/cloudflare-module.ts
+++ b/src/presets/cloudflare-module.ts
@@ -8,7 +8,7 @@ export const cloudflareModule = defineNitroPreset({
   entry: "#internal/nitro/entries/cloudflare-module",
   commands: {
     preview: "npx wrangler dev ./server/index.mjs --site ./public --local",
-    deploy: "npx wrangler publish",
+    deploy: "npx wrangler deploy",
   },
   rollupConfig: {
     external: "__STATIC_CONTENT_MANIFEST",

--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -8,7 +8,7 @@ export const cloudflare = defineNitroPreset({
   entry: "#internal/nitro/entries/cloudflare",
   commands: {
     preview: "npx wrangler dev ./server/index.mjs --site ./public --local",
-    deploy: "npx wrangler publish",
+    deploy: "npx wrangler deploy",
   },
   hooks: {
     async compiled(nitro: Nitro) {


### PR DESCRIPTION
See https://github.com/cloudflare/workers-sdk/issues/3067

Happening already today:
<img width="840" alt="CleanShot 2023-07-02 at 11 38 49@2x" src="https://github.com/unjs/nitro/assets/904724/b92c046f-5781-4d50-9652-91de95b07315">
