### PR TITLE
docs: add cdn docs for multi deployment handling

### DIFF
--- a/docs/content/2.deploy/providers/netlify.md
+++ b/docs/content/2.deploy/providers/netlify.md
@@ -38,7 +38,7 @@ On-demand Builders are serverless functions used to generate web content as need
 ## Handling atomic deploys
 
 Netlify uses atomic deploys, which means that all old chunk files will become invalid when a deploy occurs.
-This causes errors when existing clients try to load chunk files which no longer exists.
+This causes errors when existing clients try to load chunk files which no longer exist.
 
 Nuxt, for example, has default behaviour to reload the page in some circumstances, but this is not always
 desirable and it is possible to do better by serving Netlify's permanent link to each deploy, which remains valid.

--- a/docs/content/2.deploy/providers/netlify.md
+++ b/docs/content/2.deploy/providers/netlify.md
@@ -57,3 +57,11 @@ Then in the `_redirects` file which Netlify will pick up, proxy it:
 
 Proxying is better than serving the files directly because some security software (e.g. Streamline3)
 will block scripts served from a different domain.
+
+For example, you might be using the custom domain `https://example.com`, and your Netlify account might be
+`example.netlify.app`. In this case, `process.env.DEPLOY_URL` might be something like `https://5b243e66dd6a547b4fee73ae--example.netlify.app`.
+
+Setting the `cdnURL` above will cause Nuxt to load scripts from `https://example.com/netlify/5b243e66dd6a547b4fee73ae--example.netlify.app/*`,
+a non-existent directory within the custom domain.
+[Netlify will proxy](https://docs.netlify.com/routing/redirects/rewrites-proxies/) this back to files under the original `DEPLOY_URL`
+address without the HTTP client being aware of the domain change.

--- a/docs/content/2.deploy/providers/netlify.md
+++ b/docs/content/2.deploy/providers/netlify.md
@@ -35,3 +35,25 @@ Nitro output can directly run the server at the edge. Closer to your users.
 
 On-demand Builders are serverless functions used to generate web content as needed that’s automatically cached on Netlify’s Edge CDN. They enable you to build pages for your site when a user visits them for the first time and then cache them at the edge for subsequent visits.  ([Read More](https://docs.netlify.com/configure-builds/on-demand-builders/))
 
+## Handling atomic deploys
+
+Netlify uses atomic deploys, which means that all old chunk files will become invalid when a deploy occurs.
+This causes errors when existing clients try to load chunk files which no longer exists.
+
+Nuxt, for example, has default behaviour to reload the page in some circumstances, but this is not always
+desirable and it is possible to do better by serving Netlify's permanent link to each deploy, which remains valid.
+
+For example in Nuxt, add this to `nuxt.config.ts`
+
+    $production: {
+        app: {
+            cdnURL: '/netlify/' + process.env.DEPLOY_URL?.replace('https://', ''),
+        },
+    },
+
+Then in the `_redirects` file which Netlify will pick up, proxy it:
+
+    /netlify/* https://:splat 200!
+
+Proxying is better than serving the files directly because some security software (e.g. Streamline3)
+will block scripts served from a different domain.


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/20950
Original PR by @edwh #1300 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When using Nuxt on Netlify, deploying a new version renders chunk names in existing clients invalid because of Netlify's atomic deploys.  That causes errors if the client later tries to fetch new chunk files, either when loading async components or new routes.   This documentation PR explains how to avoid that.

It may also apply to Vercel but I don't use that, so I've not looked into or tested the corresponding change there.

### 📝 Checklist

- [X] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
