### PR TITLE
feat(firebase): support renaming exported server function

### DIFF
--- a/docs/content/2.deploy/providers/firebase.md
+++ b/docs/content/2.deploy/providers/firebase.md
@@ -244,3 +244,33 @@ You may be warned that other cloud functions will be deleted when you deploy you
 ```bash
 firebase deploy --only functions:server,hosting
 ```
+
+## Advanced
+
+### Renaming Function
+
+When deploying multiple apps within the same Firebase project, you must give your server a unique name in order to avoid overwriting
+your functions.
+
+You can specify a new name for the deployed Firebase function in your configuration:
+
+::code-group
+```ts [nitro.config.ts]
+import { defineNitroConfig } from 'nitropack/config'
+
+export default defineNitroConfig({
+  firebase: {
+    serverFunctionName: "<new_function_name>"
+  }
+})
+```
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  nitro: {
+    firebase: {
+      serverFunctionName: "<new_function_name>"
+    }
+  }
+})
+```
+::

--- a/src/runtime/entries/firebase-gen-1.ts
+++ b/src/runtime/entries/firebase-gen-1.ts
@@ -6,7 +6,7 @@ import { useAppConfig } from "#internal/nitro";
 
 const firebaseConfig = useAppConfig().nitro.firebase;
 
-export const server = functions
+export const __firebaseServerFunctionName__ = functions
   .region(firebaseConfig.region ?? functions.RESET_VALUE)
   .runWith(firebaseConfig.runtimeOptions ?? functions.RESET_VALUE)
   .https.onRequest(toNodeListener(nitroApp.h3App));

--- a/src/runtime/entries/firebase-gen-2.ts
+++ b/src/runtime/entries/firebase-gen-2.ts
@@ -6,7 +6,7 @@ import { useAppConfig } from "#internal/nitro";
 
 const firebaseConfig = useAppConfig().nitro.firebase;
 
-export const server = onRequest(
+export const __firebaseServerFunctionName__ = onRequest(
   {
     // Must be set to public to allow all public requests by default
     invoker: "public",

--- a/src/runtime/entries/firebase-gen-default.ts
+++ b/src/runtime/entries/firebase-gen-default.ts
@@ -1,2 +1,2 @@
-// we need this file to detect if the user is passing a `gen` property
-export { server } from "./firebase-gen-1";
+// We need this file to detect if the user is not passing a `gen` property
+export { __firebaseServerFunctionName__ } from "./firebase-gen-1";

--- a/src/types/presets.ts
+++ b/src/types/presets.ts
@@ -63,6 +63,13 @@ interface FirebaseOptionsBase {
    * @see https://cloud.google.com/functions/docs/concepts/nodejs-runtime
    */
   nodeVersion?: "20" | "18" | "16";
+  /**
+   * When deploying multiple apps within the same Firebase project
+   * you must give your server a unique name in order to avoid overwriting your functions.
+   *
+   * @default "server"
+   */
+  serverFunctionName?: string;
 }
 
 interface FirebaseOptionsGen1 extends FirebaseOptionsBase {


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#266  

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
Adds a new option to nitro config that allows giving a custom name to deployed firebase functions.

This is done using rollup replace. I changed the exported name for the server in the firebase entry to `__firebaseServerFunctionName__` to ensure it is unique to the firebase server export. The placeholder name is then replaced with `firebase.serverFunctionName` in the config, which is given a default value of `"server"`.
<!-- Why is this change required? What problem does it solve? -->
This change gives an intuitive way to deploy multiple servers to the same firebase project without having them be overwritten. The workaround given in #266 is not very intuitive, and could potentially break other deployments in the future.

I would also recommend adding the same option to V2 functions in #1142, since there doesn't appear to be a way to change the deployed function name in the V2 [HttpOptions](https://firebase.google.com/docs/reference/functions/2nd-gen/node/firebase-functions.https.httpsoptions) (I don't think [`labels`](https://firebase.google.com/docs/reference/functions/2nd-gen/node/firebase-functions.https.httpsoptions.md#httpshttpsoptionslabels) does this, but correct me if I am wrong)

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Resolves #266

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

I have tested building my own project and the function renaming appears to work as expected. The only difference is that `export { s as server } from './chunks/nitro/firebase.mjs'` becomes `export { _ as server } from './chunks/nitro/firebase.mjs'` since the export now starts with `_` before the placeholder gets replaced. I don't think this will cause any issues, but I am not 100% sure.