### PR TITLE
docs(vercel): add note about top level `api/` directory

### DIFF
--- a/docs/content/1.guide/3.routing.md
+++ b/docs/content/1.guide/3.routing.md
@@ -13,10 +13,6 @@ Nitro supports file-based routing for your API routes.
 
 Handler files inside `api/` and `routes/` directory will be automatically mapped to [unjs/h3](https://github.com/unjs/h3) routes.
 
-::alert{type=primary}
-Due to some providers like Vercel using  top-level `api/` directory as a feature, Nitro also supports `routes/api/` to create API routes.
-::
-
 ```md
 api/
   test.ts      <-- /api/test
@@ -24,6 +20,13 @@ routes/
   hello.ts     <-- /hello
 nitro.config.ts
 ```
+
+::alert{type=primary}
+Some providers like Vercel use a top-level `api/` directory as a feature. This
+means that routes placed in `/api` wont work. Since Nitro also supports
+`routes/api/` to create API routes, simple move your api folder to the
+`routes/` folder.
+::
 
 ::alert
 If you are using [Nuxt](https://nuxt.com), move the `api/` and `routes/` inside the `server/` directory.

--- a/docs/content/1.guide/3.routing.md
+++ b/docs/content/1.guide/3.routing.md
@@ -22,10 +22,8 @@ nitro.config.ts
 ```
 
 ::alert{type=primary}
-Some providers like Vercel use a top-level `api/` directory as a feature. This
-means that routes placed in `/api` wont work. Since Nitro also supports
-`routes/api/` to create API routes, simple move your api folder to the
-`routes/` folder.
+Some providers like Vercel use a top-level `api/` directory as a feature, therefore routes placed in `/api` wont work.
+You will have to use `routes/api/`.
 ::
 
 ::alert

--- a/docs/content/2.deploy/providers/vercel.md
+++ b/docs/content/2.deploy/providers/vercel.md
@@ -92,6 +92,14 @@ export default eventHandler(async (event) => {
 });
 ```
 
+## API routes
+
+Nitro `/api` directory isn't compatible with Vercel.
+Instead, you have to use :
+
+- `routes/api/` for standalone usage
+- `server/api/` for [Nuxt](https://nuxt.com).
+
 ## Custom Build Output Configuration
 
 You can provide additional [build output configuration](https://vercel.com/docs/build-output-api/v3) using `vercel.config` key inside `nitro.config`. It will be merged with built-in auto generated config.

--- a/docs/content/2.deploy/providers/vercel.md
+++ b/docs/content/2.deploy/providers/vercel.md
@@ -98,7 +98,7 @@ Nitro `/api` directory isn't compatible with Vercel.
 Instead, you have to use :
 
 - `routes/api/` for standalone usage
-- `server/api/` for [Nuxt](https://nuxt.com).
+- `server/api/` with [Nuxt](https://nuxt.com).
 
 ## Custom Build Output Configuration
 


### PR DESCRIPTION
After following the initial project scaffolded via the command `npx giget@latest nitro nitro-app` I found that after deploying to vercel via `vercel` command my routes were not at the expected place of domian.com/api/hello/.

I added this documentation to hopefully help future developers wishing to deploy to vercel not waste time understanding the mapping of routes. 

I found the solution via this GitHub discussion

https://github.com/unjs/nitro/discussions/233

<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
