### PR TITLE
feat: support regexps in external options

### DIFF
--- a/src/rollup/plugins/externals-legacy.ts
+++ b/src/rollup/plugins/externals-legacy.ts
@@ -8,8 +8,8 @@ import semver from "semver";
 import { isDirectory, retry } from "../../utils";
 
 export interface NodeExternalsOptions {
-  inline?: string[];
-  external?: string[];
+  inline?: Array<string | RegExp>;
+  external?: Array<string | RegExp>;
   outDir?: string;
   trace?: boolean;
   traceOptions?: NodeFileTraceOptions;
@@ -36,8 +36,12 @@ export function externals(opts: NodeExternalsOptions): Plugin {
   };
 
   // Normalize options
-  opts.inline = (opts.inline || []).map((p) => normalize(p));
-  opts.external = (opts.external || []).map((p) => normalize(p));
+  opts.inline = (opts.inline || []).map((p) =>
+    typeof p === "string" ? normalize(p) : p
+  );
+  opts.external = (opts.external || []).map((p) =>
+    typeof p === "string" ? normalize(p) : p
+  );
 
   return {
     name: "node-externals",
@@ -65,8 +69,10 @@ export function externals(opts: NodeExternalsOptions): Plugin {
 
       // Check for explicit inlines
       if (
-        opts.inline.some(
-          (i) => id.startsWith(i) || idWithoutNodeModules.startsWith(i)
+        opts.inline.some((i) =>
+          typeof i === "string"
+            ? id.startsWith(i) || idWithoutNodeModules.startsWith(i)
+            : i.test(id)
         )
       ) {
         return null;
@@ -74,8 +80,10 @@ export function externals(opts: NodeExternalsOptions): Plugin {
 
       // Check for explicit externals
       if (
-        opts.external.some(
-          (i) => id.startsWith(i) || idWithoutNodeModules.startsWith(i)
+        opts.external.some((i) =>
+          typeof i === "string"
+            ? id.startsWith(i) || idWithoutNodeModules.startsWith(i)
+            : i.test(id)
         )
       ) {
         return { id, external: true };

--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -9,8 +9,8 @@ import semver from "semver";
 import { isDirectory } from "../../utils";
 
 export interface NodeExternalsOptions {
-  inline?: string[];
-  external?: string[];
+  inline?: Array<string | RegExp>;
+  external?: Array<string | RegExp>;
   outDir?: string;
   trace?: boolean;
   traceOptions?: NodeFileTraceOptions;
@@ -37,8 +37,12 @@ export function externals(opts: NodeExternalsOptions): Plugin {
   };
 
   // Normalize options
-  opts.inline = (opts.inline || []).map((p) => normalize(p));
-  opts.external = (opts.external || []).map((p) => normalize(p));
+  opts.inline = (opts.inline || []).map((p) =>
+    typeof p === "string" ? normalize(p) : p
+  );
+  opts.external = (opts.external || []).map((p) =>
+    typeof p === "string" ? normalize(p) : p
+  );
 
   return {
     name: "node-externals",
@@ -66,8 +70,10 @@ export function externals(opts: NodeExternalsOptions): Plugin {
 
       // Check for explicit inlines
       if (
-        opts.inline.some(
-          (i) => id.startsWith(i) || idWithoutNodeModules.startsWith(i)
+        opts.inline.some((i) =>
+          typeof i === "string"
+            ? id.startsWith(i) || idWithoutNodeModules.startsWith(i)
+            : i.test(id)
         )
       ) {
         return null;
@@ -75,8 +81,10 @@ export function externals(opts: NodeExternalsOptions): Plugin {
 
       // Check for explicit externals
       if (
-        opts.external.some(
-          (i) => id.startsWith(i) || idWithoutNodeModules.startsWith(i)
+        opts.external.some((i) =>
+          typeof i === "string"
+            ? id.startsWith(i) || idWithoutNodeModules.startsWith(i)
+            : i.test(id)
         )
       ) {
         return { id, external: true };


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I'm hoping to move more inlining from vite server build -> nitro build to avoid duplication of libraries. (e.g. h3 createError, some vue dependencies, anything shared between vite + nitro builds, etc.)

Part of that means being able to respect Nuxt's `build.transpile` which may include RegExps, and the best way would be to be able to pass those options on to nitro externals options.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
