### PR TITLE
feat: `event.waitUntil` with cloudflare integration

### DIFF
--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -62,11 +62,13 @@ function createNitroApp(): NitroApp {
     eventHandler((event) => {
       // Init nitro context
       event.context.nitro = event.context.nitro || {};
+
       // Support platform context provided by local fetch
       const envContext = (event.node.req as any).__unenv__;
       if (envContext) {
         Object.assign(event.context, envContext);
       }
+
       // Assign bound fetch to context
       event.fetch = (req, init) =>
         fetchWithEvent(event, req, init, { fetch: localFetch });
@@ -74,6 +76,17 @@ function createNitroApp(): NitroApp {
         fetchWithEvent(event, req, init as RequestInit, {
           fetch: $fetch,
         })) as $Fetch<unknown, NitroFetchRequest>;
+
+      // https://github.com/unjs/nitro/issues/1420
+      event.waitUntil = (promise) => {
+        if (!event.context.nitro._waitUntilPromises) {
+          event.context.nitro._waitUntilPromises = [];
+        }
+        event.context.nitro._waitUntilPromises.push(promise);
+        if (envContext.waitUntil) {
+          envContext.waitUntil(promise);
+        }
+      };
     })
   );
 

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -83,7 +83,7 @@ function createNitroApp(): NitroApp {
           event.context.nitro._waitUntilPromises = [];
         }
         event.context.nitro._waitUntilPromises.push(promise);
-        if (envContext.waitUntil) {
+        if (envContext?.waitUntil) {
           envContext.waitUntil(promise);
         }
       };

--- a/src/runtime/entries/cloudflare-module.ts
+++ b/src/runtime/entries/cloudflare-module.ts
@@ -55,7 +55,7 @@ export default {
     return nitroApp.localFetch(url.pathname + url.search, {
       context: {
         cf: (request as any).cf,
-        waitUntil: context.waitUntil,
+        waitUntil: (promise) => context.waitUntil(promise),
         cloudflare: {
           request,
           env,

--- a/src/runtime/entries/cloudflare-module.ts
+++ b/src/runtime/entries/cloudflare-module.ts
@@ -55,6 +55,7 @@ export default {
     return nitroApp.localFetch(url.pathname + url.search, {
       context: {
         cf: (request as any).cf,
+        waitUntil: context.waitUntil,
         cloudflare: {
           request,
           env,

--- a/src/runtime/entries/cloudflare-pages.ts
+++ b/src/runtime/entries/cloudflare-pages.ts
@@ -42,6 +42,7 @@ export default {
     return nitroApp.localFetch(url.pathname + url.search, {
       context: {
         cf: request.cf,
+        waitUntil: context.waitUntil,
         cloudflare: {
           request,
           env,

--- a/src/runtime/entries/cloudflare-pages.ts
+++ b/src/runtime/entries/cloudflare-pages.ts
@@ -42,7 +42,7 @@ export default {
     return nitroApp.localFetch(url.pathname + url.search, {
       context: {
         cf: request.cf,
-        waitUntil: context.waitUntil,
+        waitUntil: (promise) => context.waitUntil(promise),
         cloudflare: {
           request,
           env,

--- a/src/runtime/entries/cloudflare.ts
+++ b/src/runtime/entries/cloudflare.ts
@@ -34,7 +34,7 @@ async function handleEvent(event: FetchEvent) {
     context: {
       // https://developers.cloudflare.com/workers//runtime-apis/request#incomingrequestcfproperties
       cf: (event.request as any).cf,
-      waitUntil: event.waitUntil,
+      waitUntil: (promise) => event.waitUntil(promise),
     },
     url: url.pathname + url.search,
     host: url.hostname,

--- a/src/runtime/entries/cloudflare.ts
+++ b/src/runtime/entries/cloudflare.ts
@@ -34,6 +34,7 @@ async function handleEvent(event: FetchEvent) {
     context: {
       // https://developers.cloudflare.com/workers//runtime-apis/request#incomingrequestcfproperties
       cf: (event.request as any).cf,
+      waitUntil: event.waitUntil,
     },
     url: url.pathname + url.search,
     host: url.hostname,

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -13,6 +13,13 @@ declare module "h3" {
     fetch: H3EventFetch;
     /** @experimental Calls fetch with same context and request headers */
     $fetch: H3Event$Fetch;
+    /** @experimental See https://github.com/unjs/nitro/issues/1420 */
+    waitUntil: (promise: Promise<unknown>) => void;
+  }
+  interface H3Context {
+    nitro: {
+      _waitUntilPromises?: Promise<unknown>[];
+    };
   }
 }
 

--- a/test/fixture/routes/wait-until.ts
+++ b/test/fixture/routes/wait-until.ts
@@ -1,0 +1,11 @@
+const timeTakingOperation = async () => {
+  // console.log("wait-until.ts: timeTakingOperation() start");
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  // console.log("wait-until.ts: timeTakingOperation() done");
+};
+
+export default eventHandler((event) => {
+  event.waitUntil(timeTakingOperation());
+
+  return "done";
+});

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -390,7 +390,7 @@ export function testNitro(
   });
 
   it("event.waitUntil", async () => {
-    const res = await callHandler({ url: "/api/wait-until" });
+    const res = await callHandler({ url: "/wait-until" });
     expect(res.data).toBe("done");
   });
 }

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -388,4 +388,9 @@ export function testNitro(
       "versions?.nitro": [expect.any(String), expect.any(String)],
     });
   });
+
+  it("event.waitUntil", async () => {
+    const res = await callHandler({ url: "/api/wait-until" });
+    expect(res.data).toBe("done");
+  });
 }


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

#1420

This PR supports platform-agnostic `event.waitUntil` that keeps promises under `event.context.nitro._waitUntilPromises` (private - unused) and also adds integration with all clodflare presets (https://developers.cloudflare.com/workers/runtime-apis/fetch-event/#waituntil) 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
