### PR TITLE
fix(cache): try to call `event.waitUntil`

### DIFF
--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -4,6 +4,7 @@ import {
   defineEventHandler,
   createEvent,
   EventHandler,
+  isEvent,
 } from "h3";
 import type { H3Event } from "h3";
 import { parseURL } from "ufo";
@@ -55,7 +56,8 @@ export function defineCachedFunction<T = any>(
   async function get(
     key: string,
     resolver: () => T | Promise<T>,
-    shouldInvalidateCache?: boolean
+    shouldInvalidateCache?: boolean,
+    waitUntil?: (promise: Promise<void>) => void
   ): Promise<CacheEntry<T>> {
     // Use extension for key to avoid conflicting with parent namespace (foo/bar and foo/bar/baz)
     const cacheKey = [opts.base, group, name, key + ".json"]
@@ -110,9 +112,12 @@ export function defineCachedFunction<T = any>(
         entry.integrity = integrity;
         delete pending[key];
         if (validate(entry)) {
-          useStorage()
+          const promise = useStorage()
             .setItem(cacheKey, entry)
             .catch((error) => console.error("[nitro] [cache]", error));
+          if (waitUntil) {
+            waitUntil(promise);
+          }
         }
       }
     };
@@ -136,7 +141,14 @@ export function defineCachedFunction<T = any>(
     }
     const key = await (opts.getKey || getKey)(...args);
     const shouldInvalidateCache = opts.shouldInvalidateCache?.(...args);
-    const entry = await get(key, () => fn(...args), shouldInvalidateCache);
+    const waitUntil =
+      args[0] && isEvent(args[0]) ? args[0].waitUntil : undefined;
+    const entry = await get(
+      key,
+      () => fn(...args),
+      shouldInvalidateCache,
+      waitUntil
+    );
     let value = entry.value;
     if (opts.transform) {
       value = (await opts.transform(entry, ...args)) || value;


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/unjs/nitro/issues/1420

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Based on #1421, try to call `event.waitUntil` for the cache update operation if the first parameter in `defineCachedFunction` is an event and always for `defineCachedEventHandler`.

Previously we were using a dangling background promise which was not being ended on Cloudflare workers. 

(this is an experimental fix without introducing new API)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
