### PR TITLE
feat: support `ignore` to ignore scanned files

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -63,6 +63,7 @@ const NitroDefaults: NitroConfig = {
   },
   virtual: {},
   compressPublicAssets: false,
+  ignore: [],
 
   // Dev
   dev: false,

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -76,7 +76,7 @@ export async function scanServerRoutes(
 
 export async function scanPlugins(nitro: Nitro) {
   const files = await scanFiles(nitro, "plugins");
-  return files;
+  return files.map((f) => f.fullPath);
 }
 
 async function scanFiles(nitro: Nitro, name: string): Promise<FileInfo[]> {

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -1,45 +1,53 @@
-import { resolve, join } from "pathe";
+import { relative, join } from "pathe";
 import { globby } from "globby";
-
 import { withBase, withLeadingSlash, withoutTrailingSlash } from "ufo";
-import type { Nitro, NitroEventHandler } from "./types";
+import type { Nitro } from "./types";
 
 export const GLOB_SCAN_PATTERN = "**/*.{js,mjs,cjs,ts,mts,cts,tsx,jsx}";
-type FileInfo = { dir: string; path: string; fullPath: string };
+type FileInfo = { path: string; fullPath: string };
 
 const httpMethodRegex =
   /\.(connect|delete|get|head|options|patch|post|put|trace)/;
 
 export async function scanHandlers(nitro: Nitro) {
+  const middleware = await scanMiddleware(nitro);
+
   const handlers = await Promise.all([
-    scanMiddleware(nitro),
-    scanRoutes(nitro, "api", "/api"),
-    scanRoutes(nitro, "routes", "/"),
+    scanServerRoutes(nitro, "api", "/api"),
+    scanServerRoutes(nitro, "routes", "/"),
   ]).then((r) => r.flat());
 
-  nitro.scannedHandlers = handlers
-    .flatMap((h) => h.handlers)
-    .filter((h, index, array) => {
+  nitro.scannedHandlers = [
+    ...middleware,
+    ...handlers.filter((h, index, array) => {
       return (
-        h.middleware ||
         array.findIndex(
           (h2) => h.route === h2.route && h.method === h2.method
         ) === index
       );
-    });
+    }),
+  ];
 
   return handlers;
 }
 
-export function scanMiddleware(nitro: Nitro) {
-  return scanServerDir(nitro, "middleware", (file) => ({
-    middleware: true,
-    handler: file.fullPath,
-  }));
+export async function scanMiddleware(nitro: Nitro) {
+  const files = await scanFiles(nitro, "middleware");
+  return files.map((file) => {
+    return {
+      middleware: true,
+      handler: file.fullPath,
+    };
+  });
 }
 
-export function scanRoutes(nitro: Nitro, dir: string, prefix = "/") {
-  return scanServerDir(nitro, dir, (file) => {
+export async function scanServerRoutes(
+  nitro: Nitro,
+  dir: "routes" | "api",
+  prefix = "/"
+) {
+  const files = await scanFiles(nitro, dir);
+  return files.map((file) => {
     let route = file.path
       .replace(/\.[A-Za-z]+$/, "")
       .replace(/\[\.{3}]/g, "**")
@@ -59,52 +67,42 @@ export function scanRoutes(nitro: Nitro, dir: string, prefix = "/") {
     return {
       handler: file.fullPath,
       lazy: true,
+      middlweware: false,
       route,
       method,
     };
   });
 }
 
-async function scanServerDir(
-  nitro: Nitro,
-  name: string,
-  mapper: (file: FileInfo) => NitroEventHandler
-) {
-  const dirs = nitro.options.scanDirs.map((dir) => join(dir, name));
-  const files = await scanDirs(dirs);
-  const handlers: NitroEventHandler[] = files.map((f) => mapper(f));
-  return { dirs, files, handlers };
-}
-
 export async function scanPlugins(nitro: Nitro) {
-  const plugins = [];
-  for (const dir of nitro.options.scanDirs) {
-    const pluginDir = join(dir, "plugins");
-    const pluginFiles = await globby(GLOB_SCAN_PATTERN, {
-      cwd: pluginDir,
-      absolute: true,
-    });
-    plugins.push(...pluginFiles.sort());
-  }
-  return plugins;
+  const files = await scanFiles(nitro, "plugins");
+  return files;
 }
 
-function scanDirs(dirs: string[]): Promise<FileInfo[]> {
-  return Promise.all(
-    dirs.map(async (dir) => {
-      const fileNames = await globby(GLOB_SCAN_PATTERN, {
-        cwd: dir,
-        dot: true,
-      });
-      return fileNames
-        .map((fileName) => {
-          return {
-            dir,
-            path: fileName,
-            fullPath: resolve(dir, fileName),
-          };
-        })
-        .sort((a, b) => a.path.localeCompare(b.path));
-    })
+async function scanFiles(nitro: Nitro, name: string): Promise<FileInfo[]> {
+  const files = await Promise.all(
+    nitro.options.scanDirs.map((dir) => scanDir(nitro, dir, name))
   ).then((r) => r.flat());
+  return files;
+}
+
+async function scanDir(
+  nitro: Nitro,
+  dir: string,
+  name: string
+): Promise<FileInfo[]> {
+  const fileNames = await globby(join(name, GLOB_SCAN_PATTERN), {
+    cwd: dir,
+    dot: true,
+    ignore: nitro.options.ignore,
+    absolute: true,
+  });
+  return fileNames
+    .map((fullPath) => {
+      return {
+        fullPath,
+        path: relative(join(dir, name), fullPath),
+      };
+    })
+    .sort((a, b) => a.path.localeCompare(b.path));
 }

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -230,6 +230,7 @@ export interface NitroOptions extends PresetOptions {
   plugins: string[];
   virtual: Record<string, string | (() => string | Promise<string>)>;
   compressPublicAssets: boolean | CompressOptions;
+  ignore: string[];
 
   // Dev
   dev: boolean;

--- a/test/fixture/api/_ignored.ts
+++ b/test/fixture/api/_ignored.ts
@@ -1,0 +1,3 @@
+export default eventHandler((event) => {
+  throw createError("This file should be ignored!");
+});

--- a/test/fixture/middleware/_ignored.ts
+++ b/test/fixture/middleware/_ignored.ts
@@ -1,0 +1,3 @@
+export default eventHandler((event) => {
+  throw createError("This file should be ignored!");
+});

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -26,6 +26,7 @@ export default defineNitroConfig({
       dir: "files",
     },
   ],
+  ignore: ["api/**/_*", "middleware/_ignored.ts", "routes/_*.ts"],
   appConfig: {
     "nitro-config": true,
     dynamic: "initial",

--- a/test/fixture/routes/_ignored.ts
+++ b/test/fixture/routes/_ignored.ts
@@ -1,0 +1,3 @@
+export default eventHandler((event) => {
+  throw createError("This file should be ignored!");
+});

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -394,4 +394,11 @@ export function testNitro(
     const res = await callHandler({ url: "/wait-until" });
     expect(res.data).toBe("done");
   });
+
+  describe("ignore", () => {
+    it("server routes should be ignored", async () => {
+      expect((await callHandler({ url: "/api/_ignored" })).status).toBe(404);
+      expect((await callHandler({ url: "/_ignored" })).status).toBe(404);
+    });
+  });
 }


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

Resolves #843

Related: https://github.com/nuxt/nuxt/issues/13427, https://github.com/unjs/nitro/pull/945

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR supports `ignore: string[]` option in order to specify ignore patterns for scanning `/plugins`, `/middleware`, `/routes` and `/api` from all layers. The `scan.ts` has been almost rewritten to be prepared for this. Supporting public dir ignore in #945 after this. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
