### PR TITLE
docs: fixed typo of the word 'discussions'

### DIFF
--- a/docs/content/1.guide/community/9.contributing.md
+++ b/docs/content/1.guide/community/9.contributing.md
@@ -2,7 +2,7 @@
 
 Thank you for wanting to contribute to Nitro 💛
 
-Before everything, please make sure to check the [open issues](https://github.com/unjs/nitro/issues) or the [dicussions](https://github.com/unjs/nitro/discussions).
+Before everything, please make sure to check the [open issues](https://github.com/unjs/nitro/issues) or the [discussions](https://github.com/unjs/nitro/discussions).
 
 To contribute locally:
 - Fork and clone [unjs/nitro](https://github.com/unjs/nitro)


### PR DESCRIPTION
The contributing page had a small mistake which misspelled the word discussions.

<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
The Contributing page on the website had a typo where the word 'discussions' was spelled as 'dicussions'. I corrected this small typo.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
