### PR TITLE
docs: remove auto-imported `defineNitroConfig`

### DIFF
--- a/docs/content/1.guide/1.configuration.md
+++ b/docs/content/1.guide/1.configuration.md
@@ -12,8 +12,6 @@ If you are using [Nuxt](https://nuxt.com), use the `nitro` option in your Nuxt c
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from 'nitropack/config'
-
 export default defineNitroConfig({
   // Nitro options
 })

--- a/docs/content/1.guide/3.routing.md
+++ b/docs/content/1.guide/3.routing.md
@@ -118,8 +118,6 @@ When `cache` option is set, handlers matching pattern will be automatically wrap
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from 'nitropack/config'
-
 export default defineNitroConfig({
   routeRules: {
     '/blog/**': { swr: true },

--- a/docs/content/1.guide/4.storage.md
+++ b/docs/content/1.guide/4.storage.md
@@ -27,8 +27,6 @@ You can mount storage drivers using the `storage` option:
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from 'nitropack/config'
-
 export default defineNitroConfig({
   storage: {
     'redis': {

--- a/docs/content/1.guide/5.cache.md
+++ b/docs/content/1.guide/5.cache.md
@@ -14,8 +14,6 @@ To overwrite the production storage, set the `cache` mountpoint using the `stora
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitropack/config";
-
 export default defineNitroConfig({
   storage: {
     cache: {
@@ -123,8 +121,6 @@ Cache all the blog routes for 1 hour with `stale-while-revalidate` behavior:
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitropack/config";
-
 export default defineNitroConfig({
   routeRules: {
     "/blog/**": {
@@ -156,8 +152,6 @@ If we want to use a custom storage mountpoint, we can use the `base` option. Let
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitropack/config";
-
 export default defineNitroConfig({
   storage: {
     redis: {

--- a/docs/content/1.guide/6.assets.md
+++ b/docs/content/1.guide/6.assets.md
@@ -63,8 +63,6 @@ In order to add assets from a custom directory, path will need to be defined in 
 
 ::code-group
 ```js [nitro.config.ts]
-import { defineNitroConfig } from 'nitropack/config'
-
 export default defineNitroConfig({
   serverAssets: [{
     baseName: 'my_directory',
@@ -101,8 +99,6 @@ export default defineEventHandler(async () => {
 
 ::code-group
 ```js [nitro.config.ts]
-import { defineNitroConfig } from 'nitropack/config'
-
 export default defineNitroConfig({
   serverAssets: [{
     baseName: 'templates',

--- a/docs/content/1.guide/7.plugins.md
+++ b/docs/content/1.guide/7.plugins.md
@@ -31,8 +31,6 @@ If you have plugins in another directory, you can use the `plugins` option:
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from 'nitropack/config'
-
 export default defineNitroConfig({
   plugins: ['my-plugins/hello.ts']
 })
@@ -81,4 +79,3 @@ export default defineNitroPlugin((nitro) => {
   })
 })
 ```
-

--- a/docs/content/2.deploy/0.index.md
+++ b/docs/content/2.deploy/0.index.md
@@ -38,8 +38,6 @@ NITRO_PRESET=aws-lambda nitro build
 **Example:** Using [nitro.config.ts](/guide/configuration)
 
 ```ts
-import { defineNitroConfig } from "nitropack/config";
-
 export default defineNitroConfig({
   preset: 'node-server'
 })

--- a/docs/content/2.deploy/3.custom-presets.md
+++ b/docs/content/2.deploy/3.custom-presets.md
@@ -82,8 +82,6 @@ Then in your nitro config file, you can use your custom preset.
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitropack/config";
-
 export default defineNitroConfig({
   preset: "./preset",
 });

--- a/docs/content/2.deploy/providers/aws.md
+++ b/docs/content/2.deploy/providers/aws.md
@@ -23,8 +23,6 @@ Nitro output, by default uses dynamic chunks for lazy loading code only when nee
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitropack/config";
-
 export default defineNitroConfig({
   inlineDynamicImports: true
 });

--- a/docs/content/2.deploy/providers/vercel.md
+++ b/docs/content/2.deploy/providers/vercel.md
@@ -57,8 +57,6 @@ Update your configuration:
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from 'nitropack/config'
-
 export default defineNitroConfig({
   storage: {
     data: { driver: 'vercelKV' }

--- a/docs/content/3.config.md
+++ b/docs/content/3.config.md
@@ -11,8 +11,6 @@ In order to customize Nitro's behavior, we create a file named `nitro.config.ts`
 
 ::code-group
 ```ts [nitro.config.ts]
-import { defineNitroConfig } from "nitropack/config";
-
 export default defineNitroConfig({
   // options
 });
@@ -252,7 +250,6 @@ We can use `devHandlers` but note that they are **only available in development 
 For example:
 
 ```ts
-import { defineNitroConfig } from 'nitropack/config'
 import { eventHandler } from 'h3'
 
 export default defineNitroConfig({
@@ -295,8 +292,6 @@ Path to a custom runtime error handler. Replacing nitro's built-in error page.
 **Example:**
 
 ```js [nitro.config]
-import { defineNitroConfig } from "nitropack/config";
-
 export default defineNitroConfig({
   errorHandler: "~/error",
 });


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Since the `defineNitroConfig` is auto-imported, I think that we could safely remove import from examples.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
