### PR TITLE
docs: use `defineEventHandler` instead of `eventHandler`

### DIFF
--- a/docs/content/1.guide/3.routing.md
+++ b/docs/content/1.guide/3.routing.md
@@ -34,7 +34,7 @@ If you are using [Nuxt](https://nuxt.com), move the `api/` and `routes/` inside 
 
 ```ts
 // api/hello.ts
-export default eventHandler(() => {
+export default defineEventHandler(() => {
   return { hello: 'world' }
 })
 ```
@@ -45,7 +45,7 @@ You can now universally call this API using `await $fetch('/api/hello')`.
 
 ```js
 // routes/hello/[name].ts
-export default eventHandler(event => `Hello ${event.context.params.name}!`)
+export default defineEventHandler(event => `Hello ${event.context.params.name}!`)
 ```
 
 ::code-group
@@ -58,7 +58,7 @@ To include the `/`, use `[...name].ts`:
 
 ```js
 // routes/hello/[...name].ts
-export default eventHandler(event => `Hello ${event.context.params.name}!`)
+export default defineEventHandler(event => `Hello ${event.context.params.name}!`)
 ```
 
 ::code-group
@@ -74,7 +74,7 @@ API route with a specific HTTP request method (get, post, put, delete, options a
 ::code-group
 ```js [GET]
 // routes/users/[id].get.ts
-export default eventHandler(async (event) => {
+export default defineEventHandler(async (event) => {
   const { id } = event.context.params
   // TODO: fetch user by id
   return `User profile!`
@@ -83,7 +83,7 @@ export default eventHandler(async (event) => {
 
 ```js [POST]
 // routes/users.post.ts
-export default eventHandler(async event => {
+export default defineEventHandler(async event => {
   const body = await readBody(event)
   // TODO: Handle body and add user
   return { updated: true }
@@ -97,7 +97,7 @@ Check out [h3 JSDocs](https://www.jsdocs.io/package/h3#package-index-functions) 
 
 ```js
 // routes/[...].ts
-export default eventHandler(event => `Default page`)
+export default defineEventHandler(event => `Default page`)
 ```
 
 ## Route Rules

--- a/docs/content/1.guide/5.cache.md
+++ b/docs/content/1.guide/5.cache.md
@@ -94,7 +94,7 @@ export const cachedGHStars = cachedFunction(async (repo: string) => {
 })
 ```
 ```ts [api/stars/[...repo].ts]
-export default eventHandler(async (event) => {
+export default defineEventHandler(async (event) => {
   const repo = event.context.params.repo
   const stars = await cachedGHStars(repo).catch(() => 0)
 

--- a/docs/content/2.deploy/providers/vercel.md
+++ b/docs/content/2.deploy/providers/vercel.md
@@ -83,7 +83,7 @@ You need to either set `KV_REST_API_URL` and `KV_REST_API_TOKEN` environment var
 You can now access data store in any event handler:
 
 ```ts
-export default eventHandler(async (event) => {
+export default defineEventHandler(async (event) => {
   const dataStorage = useStorage("data");
   await dataStorage.setItem("hello", "world");
   return {

--- a/docs/content/3.config.md
+++ b/docs/content/3.config.md
@@ -253,13 +253,13 @@ For example:
 
 ```ts
 import { defineNitroConfig } from 'nitropack/config'
-import { eventHandler } from 'h3'
+import { defineEventHandler } from 'h3'
 
 export default defineNitroConfig({
   devHandlers: [
     {
       route: '/',
-      handler: eventHandler((event) => {
+      handler: defineEventHandler((event) => {
        console.log(event)
       })
     }
@@ -268,7 +268,7 @@ export default defineNitroConfig({
 ```
 
 ::alert{type=info}
-Note that `eventHandler` is a helper function from [`h3`](https://github.com/unjs/h3) library.
+Note that `defineEventHandler` is a helper function from [`h3`](https://github.com/unjs/h3) library.
 ::
 
 ### `devProxy`


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Hello, since functions like `defineNitroConfig` and `defineNitroPlugin` start with `define` (and Nuxt use `defineEventHandler`), we could harmonize using `defineEventHandler` everywhere.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
