### PR TITLE
fix: split cookie headers 

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "unstorage": "^1.8.0"
   },
   "devDependencies": {
+    "@azure/functions": "^3.5.1",
     "@cloudflare/workers-types": "^4.20230710.1",
     "@types/aws-lambda": "^8.10.119",
     "@types/etag": "^1.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
         specifier: ^1.8.0
         version: 1.8.0
     devDependencies:
+      '@azure/functions':
+        specifier: ^3.5.1
+        version: 3.5.1
       '@cloudflare/workers-types':
         specifier: ^4.20230710.1
         version: 4.20230710.1
@@ -339,6 +342,14 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
+    dev: true
+
+  /@azure/functions@3.5.1:
+    resolution: {integrity: sha512-6UltvJiuVpvHSwLcK/Zc6NfUwlkDLOFFx97BHCJzlWNsfiWwzwmTsxJXg4kE/LemKTHxPpfoPE+kOJ8hAdiKFQ==}
+    dependencies:
+      iconv-lite: 0.6.3
+      long: 4.0.0
+      uuid: 8.3.2
     dev: true
 
   /@babel/code-frame@7.22.5:
@@ -3546,6 +3557,13 @@ packages:
     engines: {node: '>=14.18.0'}
     dev: true
 
+  /iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: true
+
   /ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
     dev: false
@@ -4003,6 +4021,10 @@ packages:
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
+
+  /long@4.0.0:
+    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
     dev: true
 
   /loupe@2.3.6:
@@ -4849,6 +4871,10 @@ packages:
       regexp-tree: 0.1.27
     dev: true
 
+  /safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    dev: true
+
   /scule@1.0.0:
     resolution: {integrity: sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==}
 
@@ -5529,6 +5555,11 @@ packages:
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: false
+
+  /uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+    dev: true
 
   /v8-to-istanbul@9.1.0:
     resolution: {integrity: sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==}

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -18,6 +18,7 @@ import { createHooks, Hookable } from "hookable";
 import type { NitroRuntimeHooks } from "./types";
 import { useRuntimeConfig } from "./config";
 import { cachedEventHandler } from "./cache";
+import { withNormalizedHeaders } from "./utils";
 import { createRouteRulesHandler, getRouteRulesForPath } from "./route-rules";
 import type { $Fetch, NitroFetchRequest } from "nitropack";
 import { plugins } from "#internal/nitro/virtual/plugins";
@@ -30,6 +31,7 @@ export interface NitroApp {
   hooks: Hookable<NitroRuntimeHooks>;
   localCall: ReturnType<typeof createCall>;
   localFetch: ReturnType<typeof createLocalFetch>;
+  localFetchWithNormalizedHeaders: ReturnType<typeof createLocalFetch>;
 }
 
 function createNitroApp(): NitroApp {
@@ -49,6 +51,9 @@ function createNitroApp(): NitroApp {
   // Create local fetch callers
   const localCall = createCall(toNodeListener(h3App) as any);
   const localFetch = createLocalFetch(localCall, globalThis.fetch);
+  const localFetchWithNormalizedHeaders = withNormalizedHeaders(
+    createLocalFetch(localCall, globalThis.fetch)
+  );
   const $fetch = createFetch({
     fetch: localFetch,
     Headers,
@@ -120,6 +125,7 @@ function createNitroApp(): NitroApp {
     router,
     localCall,
     localFetch,
+    localFetchWithNormalizedHeaders,
   };
 
   for (const plugin of plugins) {

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -31,7 +31,6 @@ export interface NitroApp {
   hooks: Hookable<NitroRuntimeHooks>;
   localCall: ReturnType<typeof createCall>;
   localFetch: ReturnType<typeof createLocalFetch>;
-  localFetchWithNormalizedHeaders: ReturnType<typeof createLocalFetch>;
 }
 
 function createNitroApp(): NitroApp {
@@ -50,8 +49,7 @@ function createNitroApp(): NitroApp {
 
   // Create local fetch callers
   const localCall = createCall(toNodeListener(h3App) as any);
-  const localFetch = createLocalFetch(localCall, globalThis.fetch);
-  const localFetchWithNormalizedHeaders = withNormalizedHeaders(
+  const localFetch = withNormalizedHeaders(
     createLocalFetch(localCall, globalThis.fetch)
   );
   const $fetch = createFetch({
@@ -125,7 +123,6 @@ function createNitroApp(): NitroApp {
     router,
     localCall,
     localFetch,
-    localFetchWithNormalizedHeaders,
   };
 
   for (const plugin of plugins) {

--- a/src/runtime/entries/aws-lambda.ts
+++ b/src/runtime/entries/aws-lambda.ts
@@ -53,6 +53,7 @@ export async function handler(
     body: event.body, // TODO: handle event.isBase64Encoded
   });
 
+  // Lambda v2 https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.v2
   if ("cookies" in event || "rawPath" in event) {
     const outgoingCookies = r.headers["set-cookie"];
     const cookies = Array.isArray(outgoingCookies)
@@ -60,7 +61,7 @@ export async function handler(
       : outgoingCookies?.split(",") || [];
 
     return {
-      cookies, // lambda v2 https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.v2
+      cookies,
       statusCode: r.status,
       headers: normalizeLambdaOutgoingHeaders(r.headers, true),
       body: r.body.toString(),

--- a/src/runtime/entries/aws-lambda.ts
+++ b/src/runtime/entries/aws-lambda.ts
@@ -1,6 +1,5 @@
 import type {
   APIGatewayProxyEvent,
-  APIGatewayProxyEventHeaders,
   APIGatewayProxyEventV2,
   APIGatewayProxyResult,
   APIGatewayProxyResultV2,
@@ -10,9 +9,9 @@ import "#internal/nitro/virtual/polyfill";
 import { withQuery } from "ufo";
 import { nitroApp } from "../app";
 import {
-  normalizeIncomingHeadersLambda,
-  normalizeOutgoingHeadersLambda,
-} from "../utils";
+  normalizeLambdaIncomingHeaders,
+  normalizeLambdaOutgoingHeaders,
+} from "../utils.lambda";
 
 export async function handler(
   event: APIGatewayProxyEvent,
@@ -48,7 +47,7 @@ export async function handler(
     event,
     url,
     context,
-    headers: normalizeIncomingHeadersLambda(event.headers),
+    headers: normalizeLambdaIncomingHeaders(event.headers),
     method,
     query,
     body: event.body, // TODO: handle event.isBase64Encoded
@@ -63,14 +62,14 @@ export async function handler(
     return {
       cookies, // lambda v2 https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.v2
       statusCode: r.status,
-      headers: normalizeOutgoingHeadersLambda(r.headers, true),
+      headers: normalizeLambdaOutgoingHeaders(r.headers, true),
       body: r.body.toString(),
     };
   }
 
   return {
     statusCode: r.status,
-    headers: normalizeOutgoingHeadersLambda(r.headers),
+    headers: normalizeLambdaOutgoingHeaders(r.headers),
     body: r.body.toString(),
   };
 }

--- a/src/runtime/entries/aws-lambda.ts
+++ b/src/runtime/entries/aws-lambda.ts
@@ -58,7 +58,7 @@ export async function handler(
     const outgoingCookies = r.headers["set-cookie"];
     const cookies = Array.isArray(outgoingCookies)
       ? outgoingCookies
-      : outgoingCookies?.split(",") || [];
+      : outgoingCookies?.split(/,\s?/) || [];
 
     return {
       cookies,

--- a/src/runtime/entries/azure-functions.ts
+++ b/src/runtime/entries/azure-functions.ts
@@ -1,10 +1,8 @@
 import "#internal/nitro/virtual/polyfill";
 import type { HttpRequest, HttpResponse } from "@azure/functions";
 import { nitroApp } from "../app";
-import {
-  getParsedCookiesFromHeaders,
-  normalizeOutgoingHeadersLambda,
-} from "../utils";
+import { getAzureParsedCookiesFromHeaders } from "../utils.azure";
+import { normalizeLambdaOutgoingHeaders } from "../utils.lambda";
 
 export async function handle(context: { res: HttpResponse }, req: HttpRequest) {
   const url = "/" + (req.params.url || "");
@@ -20,8 +18,8 @@ export async function handle(context: { res: HttpResponse }, req: HttpRequest) {
   context.res = {
     status,
     // cookies https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#http-response
-    cookies: getParsedCookiesFromHeaders(headers),
-    headers: normalizeOutgoingHeadersLambda(headers, true),
+    cookies: getAzureParsedCookiesFromHeaders(headers),
+    headers: normalizeLambdaOutgoingHeaders(headers, true),
     body: body ? body.toString() : statusText,
   };
 }

--- a/src/runtime/entries/azure-functions.ts
+++ b/src/runtime/entries/azure-functions.ts
@@ -17,9 +17,9 @@ export async function handle(context: { res: HttpResponse }, req: HttpRequest) {
     body: req.rawBody,
   });
 
-  // @todo cookies https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#http-response
   context.res = {
     status,
+    // cookies https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#http-response
     cookies: getParsedCookiesFromHeaders(headers),
     headers: normalizeOutgoingHeadersLambda(headers, true),
     body: body ? body.toString() : statusText,

--- a/src/runtime/entries/azure-functions.ts
+++ b/src/runtime/entries/azure-functions.ts
@@ -12,6 +12,7 @@ export async function handle(context, req) {
     body: req.rawBody,
   });
 
+  // @todo cookies https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#http-response
   context.res = {
     status,
     headers,

--- a/src/runtime/entries/azure-functions.ts
+++ b/src/runtime/entries/azure-functions.ts
@@ -1,7 +1,12 @@
 import "#internal/nitro/virtual/polyfill";
+import type { HttpRequest, HttpResponse } from "@azure/functions";
 import { nitroApp } from "../app";
+import {
+  getParsedCookiesFromHeaders,
+  normalizeOutgoingHeadersLambda,
+} from "../utils";
 
-export async function handle(context, req) {
+export async function handle(context: { res: HttpResponse }, req: HttpRequest) {
   const url = "/" + (req.params.url || "");
 
   const { body, status, statusText, headers } = await nitroApp.localCall({
@@ -15,7 +20,8 @@ export async function handle(context, req) {
   // @todo cookies https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#http-response
   context.res = {
     status,
-    headers,
+    cookies: getParsedCookiesFromHeaders(headers),
+    headers: normalizeOutgoingHeadersLambda(headers, true),
     body: body ? body.toString() : statusText,
   };
 }

--- a/src/runtime/entries/azure.ts
+++ b/src/runtime/entries/azure.ts
@@ -22,6 +22,7 @@ export async function handle(context, req) {
     body: req.rawBody,
   });
 
+  // @todo cookies https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#http-response
   context.res = {
     status,
     headers,

--- a/src/runtime/entries/azure.ts
+++ b/src/runtime/entries/azure.ts
@@ -2,10 +2,8 @@ import "#internal/nitro/virtual/polyfill";
 import type { HttpResponse, HttpRequest } from "@azure/functions";
 import { parseURL } from "ufo";
 import { nitroApp } from "../app";
-import {
-  getParsedCookiesFromHeaders,
-  normalizeOutgoingHeadersLambda,
-} from "../utils";
+import { getAzureParsedCookiesFromHeaders } from "../utils.azure";
+import { normalizeLambdaOutgoingHeaders } from "../utils.lambda";
 
 export async function handle(context: { res: HttpResponse }, req: HttpRequest) {
   let url: string;
@@ -30,8 +28,8 @@ export async function handle(context: { res: HttpResponse }, req: HttpRequest) {
   context.res = {
     status,
     // cookies https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#http-response
-    cookies: getParsedCookiesFromHeaders(headers),
-    headers: normalizeOutgoingHeadersLambda(headers, true),
+    cookies: getAzureParsedCookiesFromHeaders(headers),
+    headers: normalizeLambdaOutgoingHeaders(headers, true),
     body: body ? body.toString() : statusText,
   };
 }

--- a/src/runtime/entries/azure.ts
+++ b/src/runtime/entries/azure.ts
@@ -1,8 +1,13 @@
 import "#internal/nitro/virtual/polyfill";
+import type { HttpResponse, HttpRequest } from "@azure/functions";
 import { parseURL } from "ufo";
 import { nitroApp } from "../app";
+import {
+  getParsedCookiesFromHeaders,
+  normalizeOutgoingHeadersLambda,
+} from "../utils";
 
-export async function handle(context, req) {
+export async function handle(context: { res: HttpResponse }, req: HttpRequest) {
   let url: string;
   if (req.headers["x-ms-original-url"]) {
     // This URL has been proxied as there was no static file matching it.
@@ -25,7 +30,8 @@ export async function handle(context, req) {
   // @todo cookies https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#http-response
   context.res = {
     status,
-    headers,
+    cookies: getParsedCookiesFromHeaders(headers),
+    headers: normalizeOutgoingHeadersLambda(headers, true),
     body: body ? body.toString() : statusText,
   };
 }

--- a/src/runtime/entries/azure.ts
+++ b/src/runtime/entries/azure.ts
@@ -27,9 +27,9 @@ export async function handle(context: { res: HttpResponse }, req: HttpRequest) {
     body: req.rawBody,
   });
 
-  // @todo cookies https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#http-response
   context.res = {
     status,
+    // cookies https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#http-response
     cookies: getParsedCookiesFromHeaders(headers),
     headers: normalizeOutgoingHeadersLambda(headers, true),
     body: body ? body.toString() : statusText,

--- a/src/runtime/entries/bun.ts
+++ b/src/runtime/entries/bun.ts
@@ -1,6 +1,5 @@
 import "#internal/nitro/virtual/polyfill";
 import { nitroApp } from "../app";
-import { normalizeOutgoingHeaders } from "../utils";
 
 // @ts-expect-error: Bun global
 const server = Bun.serve({
@@ -13,7 +12,7 @@ const server = Bun.serve({
       body = await request.arrayBuffer();
     }
 
-    const r = await nitroApp.localFetch(url.pathname + url.search, {
+    return nitroApp.localFetchWithNormalizedHeaders(url.pathname + url.search, {
       url: url.pathname + url.search,
       host: url.hostname,
       protocol: url.protocol,
@@ -21,11 +20,6 @@ const server = Bun.serve({
       method: request.method,
       redirect: request.redirect,
       body,
-    });
-    return new Response(r.body, {
-      headers: normalizeOutgoingHeaders(r.headers),
-      status: r.status,
-      statusText: r.statusText,
     });
   },
 });

--- a/src/runtime/entries/bun.ts
+++ b/src/runtime/entries/bun.ts
@@ -13,7 +13,6 @@ const server = Bun.serve({
     }
 
     return nitroApp.localFetchWithNormalizedHeaders(url.pathname + url.search, {
-      url: url.pathname + url.search,
       host: url.hostname,
       protocol: url.protocol,
       headers: request.headers,

--- a/src/runtime/entries/bun.ts
+++ b/src/runtime/entries/bun.ts
@@ -12,7 +12,7 @@ const server = Bun.serve({
       body = await request.arrayBuffer();
     }
 
-    return nitroApp.localFetchWithNormalizedHeaders(url.pathname + url.search, {
+    return nitroApp.localFetch(url.pathname + url.search, {
       host: url.hostname,
       protocol: url.protocol,
       headers: request.headers,

--- a/src/runtime/entries/bun.ts
+++ b/src/runtime/entries/bun.ts
@@ -1,5 +1,6 @@
 import "#internal/nitro/virtual/polyfill";
 import { nitroApp } from "../app";
+import { normalizeOutgoingHeaders } from "../utils";
 
 // @ts-expect-error: Bun global
 const server = Bun.serve({
@@ -12,7 +13,7 @@ const server = Bun.serve({
       body = await request.arrayBuffer();
     }
 
-    const response = await nitroApp.localFetch(url.pathname + url.search, {
+    const r = await nitroApp.localFetch(url.pathname + url.search, {
       url: url.pathname + url.search,
       host: url.hostname,
       protocol: url.protocol,
@@ -21,8 +22,11 @@ const server = Bun.serve({
       redirect: request.redirect,
       body,
     });
-
-    return response;
+    return new Response(r.body, {
+      headers: normalizeOutgoingHeaders(r.headers),
+      status: r.status,
+      statusText: r.statusText,
+    });
   },
 });
 

--- a/src/runtime/entries/cloudflare-module.ts
+++ b/src/runtime/entries/cloudflare-module.ts
@@ -8,7 +8,7 @@ import {
 // @ts-ignore Bundled by Wrangler
 // See https://github.com/cloudflare/kv-asset-handler#asset_manifest-required-for-es-modules
 import manifest from "__STATIC_CONTENT_MANIFEST";
-import { requestHasBody } from "../utils";
+import { normalizeOutgoingHeaders, requestHasBody } from "../utils";
 import { nitroApp } from "#internal/nitro/app";
 import { useRuntimeConfig } from "#internal/nitro";
 import { getPublicAssetMeta } from "#internal/nitro/virtual/public-assets";
@@ -52,7 +52,7 @@ export default {
     // Expose latest env to the global context
     globalThis.__env__ = env;
 
-    return nitroApp.localFetch(url.pathname + url.search, {
+    const r = await nitroApp.localFetch(url.pathname + url.search, {
       context: {
         cf: (request as any).cf,
         waitUntil: (promise) => context.waitUntil(promise),
@@ -67,6 +67,11 @@ export default {
       method: request.method,
       headers: request.headers,
       body,
+    });
+    return new Response(r.body, {
+      headers: normalizeOutgoingHeaders(r.headers),
+      status: r.status,
+      statusText: r.statusText,
     });
   },
 };

--- a/src/runtime/entries/cloudflare-module.ts
+++ b/src/runtime/entries/cloudflare-module.ts
@@ -52,7 +52,7 @@ export default {
     // Expose latest env to the global context
     globalThis.__env__ = env;
 
-    return nitroApp.localFetchWithNormalizedHeaders(url.pathname + url.search, {
+    return nitroApp.localFetch(url.pathname + url.search, {
       context: {
         cf: (request as any).cf,
         waitUntil: (promise) => context.waitUntil(promise),

--- a/src/runtime/entries/cloudflare-module.ts
+++ b/src/runtime/entries/cloudflare-module.ts
@@ -8,7 +8,7 @@ import {
 // @ts-ignore Bundled by Wrangler
 // See https://github.com/cloudflare/kv-asset-handler#asset_manifest-required-for-es-modules
 import manifest from "__STATIC_CONTENT_MANIFEST";
-import { normalizeOutgoingHeaders, requestHasBody } from "../utils";
+import { requestHasBody } from "../utils";
 import { nitroApp } from "#internal/nitro/app";
 import { useRuntimeConfig } from "#internal/nitro";
 import { getPublicAssetMeta } from "#internal/nitro/virtual/public-assets";
@@ -52,7 +52,7 @@ export default {
     // Expose latest env to the global context
     globalThis.__env__ = env;
 
-    const r = await nitroApp.localFetch(url.pathname + url.search, {
+    return nitroApp.localFetchWithNormalizedHeaders(url.pathname + url.search, {
       context: {
         cf: (request as any).cf,
         waitUntil: (promise) => context.waitUntil(promise),
@@ -67,11 +67,6 @@ export default {
       method: request.method,
       headers: request.headers,
       body,
-    });
-    return new Response(r.body, {
-      headers: normalizeOutgoingHeaders(r.headers),
-      status: r.status,
-      statusText: r.statusText,
     });
   },
 };

--- a/src/runtime/entries/cloudflare-pages.ts
+++ b/src/runtime/entries/cloudflare-pages.ts
@@ -39,7 +39,7 @@ export default {
     // Expose latest env to the global context
     globalThis.__env__ = env;
 
-    return nitroApp.localFetchWithNormalizedHeaders(url.pathname + url.search, {
+    return nitroApp.localFetch(url.pathname + url.search, {
       context: {
         cf: request.cf,
         waitUntil: (promise) => context.waitUntil(promise),

--- a/src/runtime/entries/cloudflare-pages.ts
+++ b/src/runtime/entries/cloudflare-pages.ts
@@ -3,10 +3,7 @@ import type {
   Request as CFRequest,
   EventContext,
 } from "@cloudflare/workers-types";
-import {
-  normalizeOutgoingHeaders,
-  requestHasBody,
-} from "#internal/nitro/utils";
+import { requestHasBody } from "#internal/nitro/utils";
 import { nitroApp } from "#internal/nitro/app";
 import { isPublicAssetURL } from "#internal/nitro/virtual/public-assets";
 
@@ -42,7 +39,7 @@ export default {
     // Expose latest env to the global context
     globalThis.__env__ = env;
 
-    const r = await nitroApp.localFetch(url.pathname + url.search, {
+    return nitroApp.localFetchWithNormalizedHeaders(url.pathname + url.search, {
       context: {
         cf: request.cf,
         waitUntil: (promise) => context.waitUntil(promise),
@@ -57,11 +54,6 @@ export default {
       method: request.method,
       headers: request.headers,
       body,
-    });
-    return new Response(r.body, {
-      headers: normalizeOutgoingHeaders(r.headers),
-      status: r.status,
-      statusText: r.statusText,
     });
   },
 };

--- a/src/runtime/entries/cloudflare.ts
+++ b/src/runtime/entries/cloudflare.ts
@@ -4,7 +4,7 @@ import {
   mapRequestToAsset,
 } from "@cloudflare/kv-asset-handler";
 import { withoutBase } from "ufo";
-import { requestHasBody } from "../utils";
+import { normalizeOutgoingHeaders, requestHasBody } from "../utils";
 import { nitroApp } from "#internal/nitro/app";
 import { useRuntimeConfig } from "#internal/nitro";
 import { getPublicAssetMeta } from "#internal/nitro/virtual/public-assets";
@@ -46,7 +46,6 @@ async function handleEvent(event: FetchEvent) {
   });
 
   return new Response(r.body, {
-    // @ts-ignore TODO: Should be HeadersInit instead of string[][]
     headers: normalizeOutgoingHeaders(r.headers),
     status: r.status,
     statusText: r.statusText,
@@ -69,12 +68,3 @@ const baseURLModifier = (request: Request) => {
   const url = withoutBase(request.url, useRuntimeConfig().app.baseURL);
   return mapRequestToAsset(new Request(url, request));
 };
-
-function normalizeOutgoingHeaders(
-  headers: Record<string, string | string[] | undefined>
-) {
-  return Object.entries(headers).map(([k, v]) => [
-    k,
-    Array.isArray(v) ? v.join(",") : v,
-  ]);
-}

--- a/src/runtime/entries/cloudflare.ts
+++ b/src/runtime/entries/cloudflare.ts
@@ -40,7 +40,7 @@ async function handleEvent(event: FetchEvent) {
     },
     host: url.hostname,
     protocol: url.protocol,
-    headers: Object.fromEntries(event.request.headers.entries()),
+    headers: event.request.headers,
     method: event.request.method,
     redirect: event.request.redirect,
     body,

--- a/src/runtime/entries/cloudflare.ts
+++ b/src/runtime/entries/cloudflare.ts
@@ -29,7 +29,7 @@ async function handleEvent(event: FetchEvent) {
     body = Buffer.from(await event.request.arrayBuffer());
   }
 
-  return nitroApp.localFetchWithNormalizedHeaders(url.pathname + url.search, {
+  return nitroApp.localFetch(url.pathname + url.search, {
     context: {
       // https://developers.cloudflare.com/workers//runtime-apis/request#incomingrequestcfproperties
       cf: (event.request as any).cf,

--- a/src/runtime/entries/deno-deploy.ts
+++ b/src/runtime/entries/deno-deploy.ts
@@ -16,7 +16,7 @@ async function handleRequest(request: Request) {
     body = await request.arrayBuffer();
   }
 
-  return nitroApp.localFetchWithNormalizedHeaders(url.pathname + url.search, {
+  return nitroApp.localFetch(url.pathname + url.search, {
     host: url.hostname,
     protocol: url.protocol,
     headers: request.headers,

--- a/src/runtime/entries/deno-deploy.ts
+++ b/src/runtime/entries/deno-deploy.ts
@@ -2,6 +2,7 @@ import "#internal/nitro/virtual/polyfill";
 // @ts-ignore
 import { serve } from "https://deno.land/std/http/server.ts";
 import { nitroApp } from "../app";
+import { normalizeOutgoingHeaders } from "../utils";
 
 serve((request: Request) => {
   return handleRequest(request);
@@ -27,18 +28,8 @@ async function handleRequest(request: Request) {
   });
 
   return new Response(r.body || undefined, {
-    // @ts-ignore TODO: Should be HeadersInit instead of string[][]
     headers: normalizeOutgoingHeaders(r.headers),
     status: r.status,
     statusText: r.statusText,
   });
-}
-
-function normalizeOutgoingHeaders(
-  headers: Record<string, string | string[] | undefined>
-) {
-  return Object.entries(headers).map(([k, v]) => [
-    k,
-    Array.isArray(v) ? v.join(",") : v,
-  ]);
 }

--- a/src/runtime/entries/deno-deploy.ts
+++ b/src/runtime/entries/deno-deploy.ts
@@ -2,7 +2,6 @@ import "#internal/nitro/virtual/polyfill";
 // @ts-ignore
 import { serve } from "https://deno.land/std/http/server.ts";
 import { nitroApp } from "../app";
-import { normalizeOutgoingHeaders } from "../utils";
 
 serve((request: Request) => {
   return handleRequest(request);
@@ -17,19 +16,12 @@ async function handleRequest(request: Request) {
     body = await request.arrayBuffer();
   }
 
-  const r = await nitroApp.localCall({
-    url: url.pathname + url.search,
+  return nitroApp.localFetchWithNormalizedHeaders(url.pathname + url.search, {
     host: url.hostname,
     protocol: url.protocol,
-    headers: Object.fromEntries(request.headers.entries()),
+    headers: request.headers,
     method: request.method,
     redirect: request.redirect,
     body,
-  });
-
-  return new Response(r.body || undefined, {
-    headers: normalizeOutgoingHeaders(r.headers),
-    status: r.status,
-    statusText: r.statusText,
   });
 }

--- a/src/runtime/entries/deno-server.ts
+++ b/src/runtime/entries/deno-server.ts
@@ -50,17 +50,14 @@ async function handler(request: Request) {
     body = await request.arrayBuffer();
   }
 
-  const r = await nitroApp.localFetchWithNormalizedHeaders(
-    url.pathname + url.search,
-    {
-      host: url.hostname,
-      protocol: url.protocol,
-      headers: request.headers,
-      method: request.method,
-      redirect: request.redirect,
-      body,
-    }
-  );
+  const r = await nitroApp.localFetch(url.pathname + url.search, {
+    host: url.hostname,
+    protocol: url.protocol,
+    headers: request.headers,
+    method: request.method,
+    redirect: request.redirect,
+    body,
+  });
 
   // TODO: fix in runtime/static
   const responseBody = r.status === 304 ? null : r.body;

--- a/src/runtime/entries/deno-server.ts
+++ b/src/runtime/entries/deno-server.ts
@@ -50,7 +50,7 @@ async function handler(request: Request) {
     body = await request.arrayBuffer();
   }
 
-  const r = await nitroApp.localFetch(url.pathname + url.search, {
+  return nitroApp.localFetch(url.pathname + url.search, {
     host: url.hostname,
     protocol: url.protocol,
     headers: request.headers,
@@ -58,9 +58,6 @@ async function handler(request: Request) {
     redirect: request.redirect,
     body,
   });
-
-  // TODO: fix in runtime/static
-  const responseBody = r.status === 304 ? null : r.body;
-  return new Response(responseBody, r);
 }
+
 export default {};

--- a/src/runtime/entries/deno-server.ts
+++ b/src/runtime/entries/deno-server.ts
@@ -1,6 +1,7 @@
 import "#internal/nitro/virtual/polyfill";
 import destr from "destr";
 import { nitroApp } from "../app";
+import { normalizeOutgoingHeaders } from "../utils";
 import { useRuntimeConfig } from "#internal/nitro";
 
 // @ts-expect-error unknown global Deno
@@ -63,20 +64,9 @@ async function handler(request: Request) {
   // TODO: fix in runtime/static
   const responseBody = r.status === 304 ? null : r.body;
   return new Response(responseBody, {
-    // @ts-ignore TODO: Should be HeadersInit instead of string[][]
     headers: normalizeOutgoingHeaders(r.headers),
     status: r.status,
     statusText: r.statusText,
   });
 }
-
-function normalizeOutgoingHeaders(
-  headers: Record<string, string | string[] | undefined>
-) {
-  return Object.entries(headers).map(([k, v]) => [
-    k,
-    Array.isArray(v) ? v.join(",") : v,
-  ]);
-}
-
 export default {};

--- a/src/runtime/entries/lagon.ts
+++ b/src/runtime/entries/lagon.ts
@@ -9,7 +9,7 @@ export async function handler(request: Request) {
     body = await request.arrayBuffer();
   }
 
-  return nitroApp.localFetchWithNormalizedHeaders(url.pathname + url.search, {
+  return nitroApp.localFetch(url.pathname + url.search, {
     host: url.hostname,
     protocol: url.protocol,
     headers: request.headers,

--- a/src/runtime/entries/lagon.ts
+++ b/src/runtime/entries/lagon.ts
@@ -1,4 +1,5 @@
 import "#internal/nitro/virtual/polyfill";
+import { normalizeOutgoingHeaders } from "../utils";
 import { nitroApp } from "#internal/nitro/app";
 
 export async function handler(request: Request): Promise<Response> {
@@ -20,18 +21,8 @@ export async function handler(request: Request): Promise<Response> {
   });
 
   return new Response(r.body, {
-    // @ts-ignore TODO: Should be HeadersInit instead of string[][]
     headers: normalizeOutgoingHeaders(r.headers),
     status: r.status,
     statusText: r.statusText,
   });
-}
-
-function normalizeOutgoingHeaders(
-  headers: Record<string, string | string[] | undefined>
-) {
-  return Object.entries(headers).map(([k, v]) => [
-    k,
-    Array.isArray(v) ? v.join(",") : v,
-  ]);
 }

--- a/src/runtime/entries/lagon.ts
+++ b/src/runtime/entries/lagon.ts
@@ -1,8 +1,7 @@
 import "#internal/nitro/virtual/polyfill";
-import { normalizeOutgoingHeaders } from "../utils";
 import { nitroApp } from "#internal/nitro/app";
 
-export async function handler(request: Request): Promise<Response> {
+export async function handler(request: Request) {
   const url = new URL(request.url);
 
   let body;
@@ -10,19 +9,12 @@ export async function handler(request: Request): Promise<Response> {
     body = await request.arrayBuffer();
   }
 
-  const r = await nitroApp.localCall({
-    url: url.pathname + url.search,
+  return nitroApp.localFetchWithNormalizedHeaders(url.pathname + url.search, {
     host: url.hostname,
     protocol: url.protocol,
-    headers: Object.fromEntries(request.headers.entries()),
+    headers: request.headers,
     method: request.method,
     redirect: request.redirect,
     body,
-  });
-
-  return new Response(r.body, {
-    headers: normalizeOutgoingHeaders(r.headers),
-    status: r.status,
-    statusText: r.statusText,
   });
 }

--- a/src/runtime/entries/netlify-edge.ts
+++ b/src/runtime/entries/netlify-edge.ts
@@ -19,7 +19,7 @@ export default async function (request: Request, _context) {
     body = await request.arrayBuffer();
   }
 
-  return nitroApp.localFetchWithNormalizedHeaders(url.pathname + url.search, {
+  return nitroApp.localFetch(url.pathname + url.search, {
     host: url.hostname,
     protocol: url.protocol,
     headers: request.headers,

--- a/src/runtime/entries/netlify-edge.ts
+++ b/src/runtime/entries/netlify-edge.ts
@@ -1,5 +1,6 @@
 import "#internal/nitro/virtual/polyfill";
 import { nitroApp } from "../app";
+import { normalizeOutgoingHeaders } from "../utils";
 import { isPublicAssetURL } from "#internal/nitro/virtual/public-assets";
 
 // https://docs.netlify.com/edge-functions/api/
@@ -31,7 +32,7 @@ export default async function (request: Request, _context) {
   });
 
   return new Response(r.body, {
-    headers: r.headers as HeadersInit,
+    headers: normalizeOutgoingHeaders(r.headers),
     status: r.status,
     statusText: r.statusText,
   });

--- a/src/runtime/entries/netlify-edge.ts
+++ b/src/runtime/entries/netlify-edge.ts
@@ -1,6 +1,5 @@
 import "#internal/nitro/virtual/polyfill";
 import { nitroApp } from "../app";
-import { normalizeOutgoingHeaders } from "../utils";
 import { isPublicAssetURL } from "#internal/nitro/virtual/public-assets";
 
 // https://docs.netlify.com/edge-functions/api/
@@ -20,20 +19,12 @@ export default async function (request: Request, _context) {
     body = await request.arrayBuffer();
   }
 
-  const r = await nitroApp.localCall({
-    url: url.pathname + url.search,
+  return nitroApp.localFetchWithNormalizedHeaders(url.pathname + url.search, {
     host: url.hostname,
     protocol: url.protocol,
-    // @ts-ignore TODO
     headers: request.headers,
     method: request.method,
     redirect: request.redirect,
     body,
-  });
-
-  return new Response(r.body, {
-    headers: normalizeOutgoingHeaders(r.headers),
-    status: r.status,
-    statusText: r.statusText,
   });
 }

--- a/src/runtime/entries/netlify-lambda.ts
+++ b/src/runtime/entries/netlify-lambda.ts
@@ -1,6 +1,5 @@
 import "#internal/nitro/virtual/polyfill";
 import type {
-  Handler,
   HandlerResponse,
   HandlerContext,
   HandlerEvent,

--- a/src/runtime/entries/netlify-lambda.ts
+++ b/src/runtime/entries/netlify-lambda.ts
@@ -7,9 +7,9 @@ import type {
 import { withQuery } from "ufo";
 import { nitroApp } from "../app";
 import {
-  normalizeIncomingHeadersLambda,
-  normalizeOutgoingHeadersLambda,
-} from "../utils";
+  normalizeLambdaIncomingHeaders,
+  normalizeLambdaOutgoingHeaders,
+} from "../utils.lambda";
 
 // Netlify functions uses lambda v1 https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.v2
 export async function lambda(
@@ -27,7 +27,7 @@ export async function lambda(
     event,
     url,
     context,
-    headers: normalizeIncomingHeadersLambda(event.headers),
+    headers: normalizeLambdaIncomingHeaders(event.headers),
     method,
     query,
     body: event.body, // TODO: handle event.isBase64Encoded
@@ -36,7 +36,7 @@ export async function lambda(
   const cookies = r.headers["set-cookie"];
   return {
     statusCode: r.status,
-    headers: normalizeOutgoingHeadersLambda(r.headers, true),
+    headers: normalizeLambdaOutgoingHeaders(r.headers, true),
     body: r.body.toString(),
     ...(cookies &&
       cookies.length > 0 && {

--- a/src/runtime/entries/netlify-lambda.ts
+++ b/src/runtime/entries/netlify-lambda.ts
@@ -30,6 +30,7 @@ export async function lambda(
     body: event.body, // TODO: handle event.isBase64Encoded
   });
 
+  // @todo Handle cookies
   return {
     statusCode: r.status,
     headers: normalizeOutgoingHeaders(r.headers),

--- a/src/runtime/entries/netlify-lambda.ts
+++ b/src/runtime/entries/netlify-lambda.ts
@@ -11,6 +11,7 @@ import {
   normalizeOutgoingHeadersLambda,
 } from "../utils";
 
+// Netlify functions uses lambda v1 https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.v2
 export async function lambda(
   event: HandlerEvent,
   context: HandlerContext
@@ -32,16 +33,16 @@ export async function lambda(
     body: event.body, // TODO: handle event.isBase64Encoded
   });
 
-  // Netlify functions uses lambda v1 https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.v2
   const cookies = r.headers["set-cookie"];
   return {
     statusCode: r.status,
     headers: normalizeOutgoingHeadersLambda(r.headers, true),
     body: r.body.toString(),
-    ...(cookies.length > 0 && {
-      multiValueHeaders: {
-        "set-cookie": Array.isArray(cookies) ? cookies : [cookies],
-      },
-    }),
+    ...(cookies &&
+      cookies.length > 0 && {
+        multiValueHeaders: {
+          "set-cookie": Array.isArray(cookies) ? cookies : [cookies],
+        },
+      }),
   };
 }

--- a/src/runtime/entries/service-worker.ts
+++ b/src/runtime/entries/service-worker.ts
@@ -1,5 +1,6 @@
 import "#internal/nitro/virtual/polyfill";
 import { nitroApp } from "../app";
+import { normalizeOutgoingHeaders } from "../utils";
 import { isPublicAssetURL } from "#internal/nitro/virtual/public-assets";
 
 addEventListener("fetch", (event: any) => {
@@ -29,7 +30,7 @@ async function handleEvent(url, event) {
   });
 
   return new Response(r.body, {
-    headers: r.headers as HeadersInit,
+    headers: normalizeOutgoingHeaders(r.headers),
     status: r.status,
     statusText: r.statusText,
   });

--- a/src/runtime/entries/service-worker.ts
+++ b/src/runtime/entries/service-worker.ts
@@ -1,9 +1,8 @@
 import "#internal/nitro/virtual/polyfill";
 import { nitroApp } from "../app";
-import { normalizeOutgoingHeaders } from "../utils";
 import { isPublicAssetURL } from "#internal/nitro/virtual/public-assets";
 
-addEventListener("fetch", (event: any) => {
+addEventListener("fetch", (event: FetchEvent) => {
   const url = new URL(event.request.url);
   if (isPublicAssetURL(url.pathname) || url.pathname.includes("/_server/")) {
     return;
@@ -18,21 +17,13 @@ async function handleEvent(url, event) {
     body = await event.request.arrayBuffer();
   }
 
-  const r = await nitroApp.localCall({
-    event,
-    url: url.pathname + url.search,
+  return nitroApp.localFetchWithNormalizedHeaders(url.pathname + url.search, {
     host: url.hostname,
     protocol: url.protocol,
     headers: event.request.headers,
     method: event.request.method,
     redirect: event.request.redirect,
     body,
-  });
-
-  return new Response(r.body, {
-    headers: normalizeOutgoingHeaders(r.headers),
-    status: r.status,
-    statusText: r.statusText,
   });
 }
 

--- a/src/runtime/entries/service-worker.ts
+++ b/src/runtime/entries/service-worker.ts
@@ -17,7 +17,7 @@ async function handleEvent(url, event) {
     body = await event.request.arrayBuffer();
   }
 
-  return nitroApp.localFetchWithNormalizedHeaders(url.pathname + url.search, {
+  return nitroApp.localFetch(url.pathname + url.search, {
     host: url.hostname,
     protocol: url.protocol,
     headers: event.request.headers,

--- a/src/runtime/entries/stormkit.ts
+++ b/src/runtime/entries/stormkit.ts
@@ -34,6 +34,7 @@ export const handler: Handler<StormkitEvent, StormkitResult> = async function (
     body: event.body,
   });
 
+  // @todo handle cookies
   return {
     statusCode: r.status,
     headers: normalizeOutgoingHeaders(r.headers),

--- a/src/runtime/entries/stormkit.ts
+++ b/src/runtime/entries/stormkit.ts
@@ -28,13 +28,13 @@ export const handler: Handler<StormkitEvent, StormkitResult> = async function (
     event,
     url: event.url,
     context,
-    headers: event.headers, // @todo normalize headers ?
+    headers: event.headers, // TODO: Normalize headers
     method,
     query: event.query,
     body: event.body,
   });
 
-  // @todo handle cookies with lambda v1 or v2 ?
+  // TODO: Handle cookies with lambda v1 or v2 ?
   return {
     statusCode: r.status,
     headers: normalizeOutgoingHeaders(r.headers),

--- a/src/runtime/entries/stormkit.ts
+++ b/src/runtime/entries/stormkit.ts
@@ -28,13 +28,13 @@ export const handler: Handler<StormkitEvent, StormkitResult> = async function (
     event,
     url: event.url,
     context,
-    headers: event.headers,
+    headers: event.headers, // @todo normalize headers ?
     method,
     query: event.query,
     body: event.body,
   });
 
-  // @todo handle cookies
+  // @todo handle cookies with lambda v1 or v2 ?
   return {
     statusCode: r.status,
     headers: normalizeOutgoingHeaders(r.headers),

--- a/src/runtime/entries/vercel-edge.ts
+++ b/src/runtime/entries/vercel-edge.ts
@@ -1,8 +1,7 @@
 import "#internal/nitro/virtual/polyfill";
-import { normalizeOutgoingHeaders } from "../utils";
 import { nitroApp } from "#internal/nitro/app";
 
-export default async function handleEvent(request, event) {
+export default async function handleEvent(request: Request) {
   const url = new URL(request.url);
 
   let body;
@@ -10,19 +9,11 @@ export default async function handleEvent(request, event) {
     body = await request.arrayBuffer();
   }
 
-  const r = await nitroApp.localCall({
-    event,
-    url: url.pathname + url.search,
+  return nitroApp.localFetchWithNormalizedHeaders(url.pathname + url.search, {
     host: url.hostname,
     protocol: url.protocol,
-    headers: Object.fromEntries(request.headers.entries()),
+    headers: request.headers,
     method: request.method,
     body,
-  });
-
-  return new Response(r.body, {
-    headers: normalizeOutgoingHeaders(r.headers),
-    status: r.status,
-    statusText: r.statusText,
   });
 }

--- a/src/runtime/entries/vercel-edge.ts
+++ b/src/runtime/entries/vercel-edge.ts
@@ -1,7 +1,7 @@
 import "#internal/nitro/virtual/polyfill";
 import { nitroApp } from "#internal/nitro/app";
 
-export default async function handleEvent(request: Request) {
+export default async function handleEvent(request: Request, event: any) {
   const url = new URL(request.url);
 
   let body;
@@ -15,5 +15,10 @@ export default async function handleEvent(request: Request) {
     headers: request.headers,
     method: request.method,
     body,
+    context: {
+      vercel: {
+        event,
+      },
+    },
   });
 }

--- a/src/runtime/entries/vercel-edge.ts
+++ b/src/runtime/entries/vercel-edge.ts
@@ -9,7 +9,7 @@ export default async function handleEvent(request: Request) {
     body = await request.arrayBuffer();
   }
 
-  return nitroApp.localFetchWithNormalizedHeaders(url.pathname + url.search, {
+  return nitroApp.localFetch(url.pathname + url.search, {
     host: url.hostname,
     protocol: url.protocol,
     headers: request.headers,

--- a/src/runtime/entries/vercel-edge.ts
+++ b/src/runtime/entries/vercel-edge.ts
@@ -1,4 +1,5 @@
 import "#internal/nitro/virtual/polyfill";
+import { normalizeOutgoingHeaders } from "../utils";
 import { nitroApp } from "#internal/nitro/app";
 
 export default async function handleEvent(request, event) {
@@ -20,18 +21,8 @@ export default async function handleEvent(request, event) {
   });
 
   return new Response(r.body, {
-    // @ts-ignore TODO: Should be HeadersInit instead of string[][]
     headers: normalizeOutgoingHeaders(r.headers),
     status: r.status,
     statusText: r.statusText,
   });
-}
-
-function normalizeOutgoingHeaders(
-  headers: Record<string, string | string[] | undefined>
-) {
-  return Object.entries(headers).map(([k, v]) => [
-    k,
-    Array.isArray(v) ? v.join(",") : v,
-  ]);
 }

--- a/src/runtime/utils.azure.ts
+++ b/src/runtime/utils.azure.ts
@@ -1,0 +1,16 @@
+import type { Cookie } from "@azure/functions";
+import type { HeadersObject } from "unenv/runtime/_internal/types";
+import { parse } from "cookie-es";
+import { splitCookiesString } from "h3";
+import { joinHeaders } from "./utils";
+
+export function getAzureParsedCookiesFromHeaders(headers: HeadersObject) {
+  const c = headers["set-cookie"];
+  if (!c || c.length === 0) {
+    return [];
+  }
+  const cookies = splitCookiesString(joinHeaders(c)).map((cookie) =>
+    parse(cookie)
+  );
+  return cookies as unknown as Cookie[];
+}

--- a/src/runtime/utils.lambda.ts
+++ b/src/runtime/utils.lambda.ts
@@ -1,0 +1,26 @@
+import type { APIGatewayProxyEventHeaders } from "aws-lambda";
+import type { HeadersObject } from "unenv/runtime/_internal/types";
+
+export function normalizeLambdaIncomingHeaders(
+  headers?: APIGatewayProxyEventHeaders
+) {
+  return Object.fromEntries(
+    Object.entries(headers || {}).map(([key, value]) => [
+      key.toLowerCase(),
+      value,
+    ])
+  );
+}
+
+export function normalizeLambdaOutgoingHeaders(
+  headers: HeadersObject,
+  stripCookies = false
+) {
+  const entries = stripCookies
+    ? Object.entries(headers).filter(([key]) => !["set-cookie"].includes(key))
+    : Object.entries(headers);
+
+  return Object.fromEntries(
+    entries.map(([k, v]) => [k, Array.isArray(v) ? v.join(",") : v])
+  );
+}

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -132,7 +132,7 @@ export function normalizeIncomingHeadersLambda(
 }
 
 export function normalizeOutgoingHeadersLambda(
-  headers: Record<string, string | string[] | undefined>,
+  headers: HeadersObject,
   stripCookies = false
 ) {
   const entries = stripCookies

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -117,11 +117,15 @@ export function normalizeFetchResponse(response: Response) {
   });
 }
 
+export function normalizeCookieHeader(header: string | string[] = "") {
+  return splitCookiesString(joinHeaders(header));
+}
+
 export function normalizeCookieHeaders(headers: Headers) {
   const outgoingHeaders = new Headers();
   for (const [name, header] of headers) {
     if (name === "set-cookie") {
-      for (const cookie of splitCookiesString(joinHeaders(header))) {
+      for (const cookie of normalizeCookieHeader(header)) {
         outgoingHeaders.append("set-cookie", cookie);
       }
     } else {

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -103,7 +103,7 @@ export function trapUnhandledNodeErrors() {
 }
 
 export function joinHeaders(value: string | string[]) {
-  return Array.isArray(value) ? value.join(",") : value;
+  return Array.isArray(value) ? value.join(", ") : value;
 }
 
 export function normalizeFetchResponse(response: Response) {

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -106,13 +106,9 @@ export function trapUnhandledNodeErrors() {
 const joinIfArray = (value: string | string[]) =>
   Array.isArray(value) ? value.join(",") : value;
 
-export function normalizeOutgoingHeaders(
-  headers: Awaited<ReturnType<NitroApp["localCall"]>>["headers"] | Headers
-) {
+const normalizeOutgoingHeaders = (headers: Headers) => {
   const outgoingHeaders = new Headers();
-  const iterableHeaders =
-    headers instanceof Headers ? headers : Object.entries(headers);
-  for (const [name, header] of iterableHeaders) {
+  for (const [name, header] of headers) {
     if (name === "set-cookie") {
       for (const cookie of splitCookiesString(joinIfArray(header))) {
         outgoingHeaders.append("set-cookie", cookie);
@@ -122,7 +118,7 @@ export function normalizeOutgoingHeaders(
     }
   }
   return outgoingHeaders;
-}
+};
 
 export function withNormalizedHeaders(fetch: typeof globalThis.fetch) {
   return async (...args: Parameters<typeof fetch>) => {

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -106,40 +106,15 @@ export function trapUnhandledNodeErrors() {
   }
 }
 
-const joinIfArray = (value: string | string[]) =>
+export const stringifyHeaders = (value: string | string[]) =>
   Array.isArray(value) ? value.join(",") : value;
-
-const normalizeOutgoingFetchHeaders = (headers: Headers) => {
-  const outgoingHeaders = new Headers();
-  for (const [name, header] of headers) {
-    if (name === "set-cookie") {
-      for (const cookie of splitCookiesString(joinIfArray(header))) {
-        outgoingHeaders.append("set-cookie", cookie);
-      }
-    } else {
-      outgoingHeaders.set(name, joinIfArray(header));
-    }
-  }
-  return outgoingHeaders;
-};
-
-export function withNormalizedHeaders(fetch: typeof globalThis.fetch) {
-  return async (...args: Parameters<typeof fetch>) => {
-    const r = await fetch(...args);
-    return new Response(r.body, {
-      headers: normalizeOutgoingFetchHeaders(r.headers),
-      status: r.status,
-      statusText: r.statusText,
-    });
-  };
-}
 
 export function getParsedCookiesFromHeaders(headers: HeadersObject) {
   const c = headers["set-cookie"];
   if (!c || c.length === 0) {
     return [];
   }
-  const cookies = splitCookiesString(joinIfArray(c)).map((cookie) =>
+  const cookies = splitCookiesString(stringifyHeaders(c)).map((cookie) =>
     parse(cookie)
   );
   return cookies as unknown as Cookie[];

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -123,3 +123,14 @@ export function normalizeOutgoingHeaders(
   }
   return outgoingHeaders;
 }
+
+export function withNormalizedHeaders(fetch: typeof globalThis.fetch) {
+  return async (...args: Parameters<typeof fetch>) => {
+    const r = await fetch(...args);
+    return new Response(r.body, {
+      headers: normalizeOutgoingHeaders(r.headers),
+      status: r.status,
+      statusText: r.statusText,
+    });
+  };
+}

--- a/test/fixture/api/headers.ts
+++ b/test/fixture/api/headers.ts
@@ -1,0 +1,10 @@
+export default defineEventHandler((event) => {
+  setHeader(event, "x-foo", "bar");
+  setHeader(event, "x-array", ["foo", "bar"]);
+
+  setHeader(event, "Set-Cookie", "foo=bar, bar=baz");
+  setCookie(event, "test", "value");
+  setCookie(event, "test2", "value");
+
+  return "headers sent";
+});

--- a/test/presets/netlify.test.ts
+++ b/test/presets/netlify.test.ts
@@ -26,10 +26,11 @@ describe("nitro:preset:netlify", async () => {
         body: body || "",
       };
       const res = await handler(event, {} as any, () => {});
+      const resHeaders = { ...res.headers, ...res.multiValueHeaders };
       return {
         data: destr(res.body),
         status: res.statusCode,
-        headers: res.headers,
+        headers: resHeaders,
       };
     };
   });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -452,11 +452,14 @@ export function testNitro(
       // (vercel uses node only for tests only)
       const notSplitingPresets = ["node", "nitro-dev", "vercel"];
       if (notSplitingPresets.includes(ctx.preset)) {
-        expectedCookies = [
-          "foo=bar, bar=baz",
-          "test=value; Path=/",
-          "test2=value; Path=/",
-        ];
+        // Refactor: https://github.com/unjs/std-env/issues/60
+        const nodeVersion = Number.parseInt(
+          process.versions.node.match(/^v?(\d+)/)[0]
+        );
+        expectedCookies =
+          nodeVersion < 18
+            ? "foo=bar, bar=baz, test=value; Path=/, test2=value; Path=/"
+            : ["foo=bar, bar=baz", "test=value; Path=/", "test2=value; Path=/"];
       }
 
       // TODO: verce-ledge joins all cookies for some reason!
@@ -474,7 +477,7 @@ export function testNitro(
       // TODO: Bun does not handles set-cookie at all
       // https://github.com/unjs/nitro/issues/1461
       if (["bun"].includes(ctx.preset)) {
-        return [];
+        return;
       }
 
       expect(headers["set-cookie"]).toMatchObject(expectedCookies);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -8,6 +8,9 @@ import { joinURL } from "ufo";
 import * as _nitro from "../src";
 import type { Nitro } from "../src";
 
+// Refactor: https://github.com/unjs/std-env/issues/60
+const nodeVersion = Number.parseInt(process.versions.node.match(/^v?(\d+)/)[0]);
+
 const { createNitro, build, prepare, copyPublicAssets, prerender } =
   (_nitro as any as { default: typeof _nitro }).default || _nitro;
 
@@ -452,10 +455,6 @@ export function testNitro(
       // (vercel and deno-server uses node only for tests only)
       const notSplitingPresets = ["node", "nitro-dev", "vercel", "deno-server"];
       if (notSplitingPresets.includes(ctx.preset)) {
-        // Refactor: https://github.com/unjs/std-env/issues/60
-        const nodeVersion = Number.parseInt(
-          process.versions.node.match(/^v?(\d+)/)[0]
-        );
         expectedCookies =
           nodeVersion < 18
             ? "foo=bar, bar=baz, test=value; Path=/, test2=value; Path=/"

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -448,6 +448,7 @@ export function testNitro(
       ];
 
       // TODO: Node presets do not split cookies
+      // https://github.com/unjs/nitro/issues/1462
       // (vercel uses node only for tests only)
       const notSplitingPresets = ["node", "nitro-dev", "vercel"];
       if (notSplitingPresets.includes(ctx.preset)) {
@@ -471,6 +472,7 @@ export function testNitro(
       }
 
       // TODO: Bun does not handles set-cookie at all
+      // https://github.com/unjs/nitro/issues/1461
       if (["bun"].includes(ctx.preset)) {
         return [];
       }

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -449,8 +449,8 @@ export function testNitro(
 
       // TODO: Node presets do not split cookies
       // https://github.com/unjs/nitro/issues/1462
-      // (vercel uses node only for tests only)
-      const notSplitingPresets = ["node", "nitro-dev", "vercel"];
+      // (vercel and deno-server uses node only for tests only)
+      const notSplitingPresets = ["node", "nitro-dev", "vercel", "deno-server"];
       if (notSplitingPresets.includes(ctx.preset)) {
         // Refactor: https://github.com/unjs/std-env/issues/60
         const nodeVersion = Number.parseInt(


### PR DESCRIPTION
- feat: handler cookie headers for Response
- chore: flag unhandled cookies

<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

Closes https://github.com/unjs/nitro/pull/989
Fix #988 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Continuing the work done by @oleghalin and applying it more generally to every presets that needs it.
Note that the culprit for this would be `unenv`, but fixing this in Nitro allows us to not add any dependency to `unenv`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
