### PR TITLE
feat: implement on:response hook

### DIFF
--- a/src/runtime/entries/aws-lambda.ts
+++ b/src/runtime/entries/aws-lambda.ts
@@ -9,6 +9,7 @@ import type {
 import "#internal/nitro/virtual/polyfill";
 import { withQuery } from "ufo";
 import { nitroApp } from "../app";
+import { defineNitroResponse } from "../utils";
 
 export async function handler(
   event: APIGatewayProxyEvent,
@@ -40,7 +41,7 @@ export async function handler(
     event.headers.cookie = event.cookies.join(";");
   }
 
-  const r = await nitroApp.localCall({
+  const response = await nitroApp.localCall({
     event,
     url,
     context,
@@ -49,6 +50,7 @@ export async function handler(
     query,
     body: event.body, // TODO: handle event.isBase64Encoded
   });
+  const r = await defineNitroResponse(nitroApp, response);
 
   if ("cookies" in event || "rawPath" in event) {
     const outgoingCookies = r.headers["set-cookie"];

--- a/src/runtime/entries/azure-functions.ts
+++ b/src/runtime/entries/azure-functions.ts
@@ -1,17 +1,21 @@
 import "#internal/nitro/virtual/polyfill";
 import { nitroApp } from "../app";
+import { defineNitroResponse } from "../utils";
 
 export async function handle(context, req) {
   const url = "/" + (req.params.url || "");
 
-  const { body, status, statusText, headers } = await nitroApp.localCall({
+  const response = await nitroApp.localCall({
     url,
     headers: req.headers,
     method: req.method,
     // https://github.com/Azure/azure-functions-host/issues/293
     body: req.rawBody,
   });
-
+  const { body, status, statusText, headers } = await defineNitroResponse(
+    nitroApp,
+    response
+  );
   context.res = {
     status,
     headers,

--- a/src/runtime/entries/azure.ts
+++ b/src/runtime/entries/azure.ts
@@ -1,6 +1,7 @@
 import "#internal/nitro/virtual/polyfill";
 import { parseURL } from "ufo";
 import { nitroApp } from "../app";
+import { defineNitroResponse } from "../utils";
 
 export async function handle(context, req) {
   let url: string;
@@ -14,14 +15,17 @@ export async function handle(context, req) {
     url = "/api/" + (req.params.url || "");
   }
 
-  const { body, status, statusText, headers } = await nitroApp.localCall({
+  const response = await nitroApp.localCall({
     url,
     headers: req.headers,
     method: req.method,
     // https://github.com/Azure/azure-functions-host/issues/293
     body: req.rawBody,
   });
-
+  const { body, status, statusText, headers } = await defineNitroResponse(
+    nitroApp,
+    response
+  );
   context.res = {
     status,
     headers,

--- a/src/runtime/entries/bun.ts
+++ b/src/runtime/entries/bun.ts
@@ -1,5 +1,6 @@
 import "#internal/nitro/virtual/polyfill";
 import { nitroApp } from "../app";
+import { defineNitroResponse } from "../utils";
 
 // @ts-expect-error: Bun global
 const server = Bun.serve({
@@ -21,8 +22,7 @@ const server = Bun.serve({
       redirect: request.redirect,
       body,
     });
-
-    return response;
+    return defineNitroResponse(nitroApp, response);
   },
 });
 

--- a/src/runtime/entries/cli.ts
+++ b/src/runtime/entries/cli.ts
@@ -1,11 +1,12 @@
 import "#internal/nitro/virtual/polyfill";
 import { nitroApp } from "../app";
+import { defineNitroResponse } from "../utils";
 
 async function cli() {
   const url = process.argv[2] || "/";
   const debug = (label, ...args) => console.debug(`> ${label}:`, ...args);
-  const r = await nitroApp.localCall({ url });
-
+  const response = await nitroApp.localCall({ url });
+  const r = await defineNitroResponse(nitroApp, response);
   debug("URL", url);
   debug("StatusCode", r.status);
   debug("StatusMessage", r.statusText);

--- a/src/runtime/entries/cloudflare-module.ts
+++ b/src/runtime/entries/cloudflare-module.ts
@@ -8,7 +8,7 @@ import {
 // @ts-ignore Bundled by Wrangler
 // See https://github.com/cloudflare/kv-asset-handler#asset_manifest-required-for-es-modules
 import manifest from "__STATIC_CONTENT_MANIFEST";
-import { requestHasBody } from "../utils";
+import { defineNitroResponse, requestHasBody } from "../utils";
 import { nitroApp } from "#internal/nitro/app";
 import { useRuntimeConfig } from "#internal/nitro";
 import { getPublicAssetMeta } from "#internal/nitro/virtual/public-assets";
@@ -52,22 +52,25 @@ export default {
     // Expose latest env to the global context
     globalThis.__env__ = env;
 
-    return nitroApp.localFetch(url.pathname + url.search, {
-      context: {
-        cf: (request as any).cf,
-        waitUntil: (promise) => context.waitUntil(promise),
-        cloudflare: {
-          request,
-          env,
-          context,
+    return defineNitroResponse(
+      nitroApp,
+      await nitroApp.localFetch(url.pathname + url.search, {
+        context: {
+          cf: (request as any).cf,
+          waitUntil: (promise) => context.waitUntil(promise),
+          cloudflare: {
+            request,
+            env,
+            context,
+          },
         },
-      },
-      host: url.hostname,
-      protocol: url.protocol,
-      method: request.method,
-      headers: request.headers,
-      body,
-    });
+        host: url.hostname,
+        protocol: url.protocol,
+        method: request.method,
+        headers: request.headers,
+        body,
+      })
+    );
   },
 };
 

--- a/src/runtime/entries/cloudflare-pages.ts
+++ b/src/runtime/entries/cloudflare-pages.ts
@@ -3,7 +3,7 @@ import type {
   Request as CFRequest,
   EventContext,
 } from "@cloudflare/workers-types";
-import { requestHasBody } from "#internal/nitro/utils";
+import { defineNitroResponse, requestHasBody } from "#internal/nitro/utils";
 import { nitroApp } from "#internal/nitro/app";
 import { isPublicAssetURL } from "#internal/nitro/virtual/public-assets";
 
@@ -39,21 +39,24 @@ export default {
     // Expose latest env to the global context
     globalThis.__env__ = env;
 
-    return nitroApp.localFetch(url.pathname + url.search, {
-      context: {
-        cf: request.cf,
-        waitUntil: (promise) => context.waitUntil(promise),
-        cloudflare: {
-          request,
-          env,
-          context,
+    return defineNitroResponse(
+      nitroApp,
+      await nitroApp.localFetch(url.pathname + url.search, {
+        context: {
+          cf: request.cf,
+          waitUntil: (promise) => context.waitUntil(promise),
+          cloudflare: {
+            request,
+            env,
+            context,
+          },
         },
-      },
-      host: url.hostname,
-      protocol: url.protocol,
-      method: request.method,
-      headers: request.headers,
-      body,
-    });
+        host: url.hostname,
+        protocol: url.protocol,
+        method: request.method,
+        headers: request.headers,
+        body,
+      })
+    );
   },
 };

--- a/src/runtime/entries/cloudflare.ts
+++ b/src/runtime/entries/cloudflare.ts
@@ -4,7 +4,7 @@ import {
   mapRequestToAsset,
 } from "@cloudflare/kv-asset-handler";
 import { withoutBase } from "ufo";
-import { requestHasBody } from "../utils";
+import { defineNitroResponse, requestHasBody } from "../utils";
 import { nitroApp } from "#internal/nitro/app";
 import { useRuntimeConfig } from "#internal/nitro";
 import { getPublicAssetMeta } from "#internal/nitro/virtual/public-assets";
@@ -29,7 +29,7 @@ async function handleEvent(event: FetchEvent) {
     body = Buffer.from(await event.request.arrayBuffer());
   }
 
-  const r = await nitroApp.localCall({
+  const response = await nitroApp.localCall({
     event,
     context: {
       // https://developers.cloudflare.com/workers//runtime-apis/request#incomingrequestcfproperties
@@ -44,6 +44,7 @@ async function handleEvent(event: FetchEvent) {
     redirect: event.request.redirect,
     body,
   });
+  const r = await defineNitroResponse(nitroApp, response);
 
   return new Response(r.body, {
     // @ts-ignore TODO: Should be HeadersInit instead of string[][]

--- a/src/runtime/entries/deno-deploy.ts
+++ b/src/runtime/entries/deno-deploy.ts
@@ -2,6 +2,7 @@ import "#internal/nitro/virtual/polyfill";
 // @ts-ignore
 import { serve } from "https://deno.land/std/http/server.ts";
 import { nitroApp } from "../app";
+import { defineNitroResponse } from "../utils";
 
 serve((request: Request) => {
   return handleRequest(request);
@@ -16,7 +17,7 @@ async function handleRequest(request: Request) {
     body = await request.arrayBuffer();
   }
 
-  const r = await nitroApp.localCall({
+  const response = await nitroApp.localCall({
     url: url.pathname + url.search,
     host: url.hostname,
     protocol: url.protocol,
@@ -25,6 +26,7 @@ async function handleRequest(request: Request) {
     redirect: request.redirect,
     body,
   });
+  const r = await defineNitroResponse(nitroApp, response);
 
   return new Response(r.body || undefined, {
     // @ts-ignore TODO: Should be HeadersInit instead of string[][]

--- a/src/runtime/entries/deno-server.ts
+++ b/src/runtime/entries/deno-server.ts
@@ -1,6 +1,7 @@
 import "#internal/nitro/virtual/polyfill";
 import destr from "destr";
 import { nitroApp } from "../app";
+import { defineNitroResponse } from "../utils";
 import { useRuntimeConfig } from "#internal/nitro";
 
 // @ts-expect-error unknown global Deno
@@ -50,7 +51,7 @@ async function handler(request: Request) {
     body = await request.arrayBuffer();
   }
 
-  const r = await nitroApp.localCall({
+  const response = await nitroApp.localCall({
     url: url.pathname + url.search,
     host: url.hostname,
     protocol: url.protocol,
@@ -59,6 +60,7 @@ async function handler(request: Request) {
     redirect: request.redirect,
     body,
   });
+  const r = await defineNitroResponse(nitroApp, response);
 
   // TODO: fix in runtime/static
   const responseBody = r.status === 304 ? null : r.body;

--- a/src/runtime/entries/firebase.ts
+++ b/src/runtime/entries/firebase.ts
@@ -4,4 +4,5 @@ import functions from "firebase-functions";
 import { toNodeListener } from "h3";
 import { nitroApp } from "../app";
 
+// @todo apply defineNitroResponse
 export const server = functions.https.onRequest(toNodeListener(nitroApp.h3App));

--- a/src/runtime/entries/lagon.ts
+++ b/src/runtime/entries/lagon.ts
@@ -1,4 +1,5 @@
 import "#internal/nitro/virtual/polyfill";
+import { defineNitroResponse } from "../utils";
 import { nitroApp } from "#internal/nitro/app";
 
 export async function handler(request: Request): Promise<Response> {
@@ -9,7 +10,7 @@ export async function handler(request: Request): Promise<Response> {
     body = await request.arrayBuffer();
   }
 
-  const r = await nitroApp.localCall({
+  const response = await nitroApp.localCall({
     url: url.pathname + url.search,
     host: url.hostname,
     protocol: url.protocol,
@@ -18,6 +19,7 @@ export async function handler(request: Request): Promise<Response> {
     redirect: request.redirect,
     body,
   });
+  const r = await defineNitroResponse(nitroApp, response);
 
   return new Response(r.body, {
     // @ts-ignore TODO: Should be HeadersInit instead of string[][]

--- a/src/runtime/entries/netlify-edge.ts
+++ b/src/runtime/entries/netlify-edge.ts
@@ -1,5 +1,6 @@
 import "#internal/nitro/virtual/polyfill";
 import { nitroApp } from "../app";
+import { defineNitroResponse } from "../utils";
 import { isPublicAssetURL } from "#internal/nitro/virtual/public-assets";
 
 // https://docs.netlify.com/edge-functions/api/
@@ -19,7 +20,7 @@ export default async function (request: Request, _context) {
     body = await request.arrayBuffer();
   }
 
-  const r = await nitroApp.localCall({
+  const response = await nitroApp.localCall({
     url: url.pathname + url.search,
     host: url.hostname,
     protocol: url.protocol,
@@ -29,6 +30,7 @@ export default async function (request: Request, _context) {
     redirect: request.redirect,
     body,
   });
+  const r = await defineNitroResponse(nitroApp, response);
 
   return new Response(r.body, {
     headers: r.headers as HeadersInit,

--- a/src/runtime/entries/netlify-lambda.ts
+++ b/src/runtime/entries/netlify-lambda.ts
@@ -8,6 +8,7 @@ import type {
 import type { APIGatewayProxyEventHeaders } from "aws-lambda";
 import { withQuery } from "ufo";
 import { nitroApp } from "../app";
+import { defineNitroResponse } from "../utils";
 
 export async function lambda(
   event: HandlerEvent,
@@ -20,7 +21,7 @@ export async function lambda(
   const url = withQuery(event.path, query);
   const method = event.httpMethod || "get";
 
-  const r = await nitroApp.localCall({
+  const response = await nitroApp.localCall({
     event,
     url,
     context,
@@ -29,6 +30,7 @@ export async function lambda(
     query,
     body: event.body, // TODO: handle event.isBase64Encoded
   });
+  const r = await defineNitroResponse(nitroApp, response);
 
   return {
     statusCode: r.status,

--- a/src/runtime/entries/nitro-dev.ts
+++ b/src/runtime/entries/nitro-dev.ts
@@ -9,6 +9,7 @@ import { toNodeListener } from "h3";
 import { nitroApp } from "../app";
 import { trapUnhandledNodeErrors } from "../utils";
 
+// @todo apply define nitro response
 const server = new Server(toNodeListener(nitroApp.h3App));
 
 function getAddress() {

--- a/src/runtime/entries/nitro-prerenderer.ts
+++ b/src/runtime/entries/nitro-prerenderer.ts
@@ -2,6 +2,7 @@ import "#internal/nitro/virtual/polyfill";
 import { nitroApp } from "../app";
 import { trapUnhandledNodeErrors } from "../utils";
 
+// @todo apply defineNitroResponse
 export const localFetch = nitroApp.localFetch;
 
 // Trap unhandled errors

--- a/src/runtime/entries/node-server.ts
+++ b/src/runtime/entries/node-server.ts
@@ -12,6 +12,7 @@ import { useRuntimeConfig } from "#internal/nitro";
 const cert = process.env.NITRO_SSL_CERT;
 const key = process.env.NITRO_SSL_KEY;
 
+// @todo apply defineNitroResponse
 const server =
   cert && key
     ? new HttpsServer({ key, cert }, toNodeListener(nitroApp.h3App))

--- a/src/runtime/entries/node.ts
+++ b/src/runtime/entries/node.ts
@@ -3,6 +3,7 @@ import { toNodeListener } from "h3";
 import { nitroApp } from "../app";
 import { trapUnhandledNodeErrors } from "../utils";
 
+// @todo apply defineNitroResponse
 export const listener = toNodeListener(nitroApp.h3App);
 
 /** @deprecated use new `listener` export instead */

--- a/src/runtime/entries/service-worker.ts
+++ b/src/runtime/entries/service-worker.ts
@@ -1,5 +1,6 @@
 import "#internal/nitro/virtual/polyfill";
 import { nitroApp } from "../app";
+import { defineNitroResponse } from "../utils";
 import { isPublicAssetURL } from "#internal/nitro/virtual/public-assets";
 
 addEventListener("fetch", (event: any) => {
@@ -17,7 +18,7 @@ async function handleEvent(url, event) {
     body = await event.request.arrayBuffer();
   }
 
-  const r = await nitroApp.localCall({
+  const response = await nitroApp.localCall({
     event,
     url: url.pathname + url.search,
     host: url.hostname,
@@ -27,6 +28,7 @@ async function handleEvent(url, event) {
     redirect: event.request.redirect,
     body,
   });
+  const r = await defineNitroResponse(nitroApp, response);
 
   return new Response(r.body, {
     headers: r.headers as HeadersInit,

--- a/src/runtime/entries/stormkit.ts
+++ b/src/runtime/entries/stormkit.ts
@@ -1,6 +1,7 @@
 import type { Handler } from "aws-lambda";
 import "#internal/nitro/virtual/polyfill";
 import { nitroApp } from "../app";
+import { defineNitroResponse } from "../utils";
 
 interface StormkitEvent {
   url: string; // e.g. /my/path, /my/path?with=query
@@ -24,7 +25,7 @@ export const handler: Handler<StormkitEvent, StormkitResult> = async function (
 ) {
   const method = event.method || "get";
 
-  const r = await nitroApp.localCall({
+  const response = await nitroApp.localCall({
     event,
     url: event.url,
     context,
@@ -33,6 +34,7 @@ export const handler: Handler<StormkitEvent, StormkitResult> = async function (
     query: event.query,
     body: event.body,
   });
+  const r = await defineNitroResponse(nitroApp, response);
 
   return {
     statusCode: r.status,

--- a/src/runtime/entries/vercel-edge.ts
+++ b/src/runtime/entries/vercel-edge.ts
@@ -1,4 +1,5 @@
 import "#internal/nitro/virtual/polyfill";
+import { defineNitroResponse } from "../utils";
 import { nitroApp } from "#internal/nitro/app";
 
 export default async function handleEvent(request, event) {
@@ -9,7 +10,7 @@ export default async function handleEvent(request, event) {
     body = await request.arrayBuffer();
   }
 
-  const r = await nitroApp.localCall({
+  const response = await nitroApp.localCall({
     event,
     url: url.pathname + url.search,
     host: url.hostname,
@@ -18,6 +19,7 @@ export default async function handleEvent(request, event) {
     method: request.method,
     body,
   });
+  const r = await defineNitroResponse(nitroApp, response);
 
   return new Response(r.body, {
     // @ts-ignore TODO: Should be HeadersInit instead of string[][]

--- a/src/runtime/entries/vercel.ts
+++ b/src/runtime/entries/vercel.ts
@@ -3,6 +3,7 @@ import { toNodeListener, NodeListener } from "h3";
 import { parseQuery } from "ufo";
 import { nitroApp } from "../app";
 
+// @todo apply defineNitroResponse
 const handler = toNodeListener(nitroApp.h3App);
 
 export default <NodeListener>function (req, res) {

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,6 +1,6 @@
 import type { H3Event } from "h3";
 import type { RenderResponse } from "./renderer";
-
+import type { NitroApp } from "./app";
 export type { NitroApp } from "./app";
 export type {
   CacheEntry,
@@ -12,6 +12,11 @@ export type { NitroAppPlugin } from "./plugin";
 export type { RenderResponse, RenderHandler } from "./renderer";
 
 export interface NitroRuntimeHooks {
+  "on:response": (callback: {
+    modifyResponse: (
+      response: Response | Awaited<ReturnType<NitroApp["localCall"]>>
+    ) => typeof response;
+  }) => void;
   "render:response": (
     response: Partial<RenderResponse>,
     context: { event: H3Event }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,5 +1,7 @@
 import type { H3Event } from "h3";
 import { getRequestHeader } from "h3";
+import type { NitroApp } from "./app";
+
 const METHOD_WITH_BODY_RE = /post|put|patch/i;
 const TEXT_MIME_RE = /application\/text|text\/html/;
 const JSON_MIME_RE = /application\/json/;
@@ -100,3 +102,25 @@ export function trapUnhandledNodeErrors() {
     );
   }
 }
+
+/**
+ * Hook usage :
+ *
+ * ```ts
+ * nitroApp.hooks.hook("on:response", (callback) => {
+ *  callback.modifyResponse = (response) => new Response("hello")
+ * });
+ * ```
+ */
+export const defineNitroResponse = async <
+  ResponseType extends Response | Awaited<ReturnType<NitroApp["localCall"]>>
+>(
+  nitroApp: NitroApp,
+  response: ResponseType
+) => {
+  const callback = {
+    modifyResponse: (response: ResponseType) => response,
+  };
+  await nitroApp.hooks.callHook("on:response", callback);
+  return callback.modifyResponse(response);
+};


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

Resolves https://github.com/unjs/nitro/issues/1396
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

WIP 

There's a one issue with this implementation : 

`toNodeListener` isn't compatible with `defineNitroResponse`, so the presets would need to be refactored to use `localCall`, or h3s `toNodeListener` would need to be updated to accept a callback function that can modify the response.

For the hook API name we could use `extendResponse` instead of `modifyResponse`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
