### PR TITLE
fix(static): safe decode path

### DIFF
--- a/src/runtime/static.ts
+++ b/src/runtime/static.ts
@@ -1,5 +1,5 @@
 import { eventHandler, createError } from "h3";
-import { joinURL, withoutTrailingSlash, withLeadingSlash, parseURL } from "ufo";
+import { decodePath, joinURL, parseURL } from "ufo";
 import {
   getAsset,
   readAsset,
@@ -16,41 +16,34 @@ export default eventHandler((event) => {
     return;
   }
 
-  let id: string;
+  let id = decodePath(parseURL(event.node.req.url).pathname);
   let asset: PublicAsset;
-  try {
-    id = decodeURIComponent(
-      withLeadingSlash(
-        withoutTrailingSlash(parseURL(event.node.req.url).pathname)
-      )
-    );
 
-    const encodingHeader = String(
-      event.node.req.headers["accept-encoding"] || ""
-    );
-    const encodings = [
-      ...encodingHeader
-        .split(",")
-        .map((e) => EncodingMap[e.trim()])
-        .filter(Boolean)
-        .sort(),
-      "",
-    ];
-    if (encodings.length > 1) {
-      event.node.res.setHeader("Vary", "Accept-Encoding");
-    }
+  const encodingHeader = String(
+    event.node.req.headers["accept-encoding"] || ""
+  );
+  const encodings = [
+    ...encodingHeader
+      .split(",")
+      .map((e) => EncodingMap[e.trim()])
+      .filter(Boolean)
+      .sort(),
+    "",
+  ];
+  if (encodings.length > 1) {
+    event.node.res.setHeader("Vary", "Accept-Encoding");
+  }
 
-    for (const encoding of encodings) {
-      for (const _id of [id + encoding, joinURL(id, "index.html" + encoding)]) {
-        const _asset = getAsset(_id);
-        if (_asset) {
-          asset = _asset;
-          id = _id;
-          break;
-        }
+  for (const encoding of encodings) {
+    for (const _id of [id + encoding, joinURL(id, "index.html" + encoding)]) {
+      const _asset = getAsset(_id);
+      if (_asset) {
+        asset = _asset;
+        id = _id;
+        break;
       }
     }
-  } catch {}
+  }
 
   if (!asset) {
     if (isPublicAssetURL(id)) {

--- a/src/runtime/static.ts
+++ b/src/runtime/static.ts
@@ -15,38 +15,41 @@ export default eventHandler((event) => {
     return;
   }
 
-  let id = decodeURIComponent(
-    withLeadingSlash(
-      withoutTrailingSlash(parseURL(event.node.req.url).pathname)
-    )
-  );
+  let id: string;
   let asset;
+  try {
+    id = decodeURIComponent(
+      withLeadingSlash(
+        withoutTrailingSlash(parseURL(event.node.req.url).pathname)
+      )
+    );
 
-  const encodingHeader = String(
-    event.node.req.headers["accept-encoding"] || ""
-  );
-  const encodings = [
-    ...encodingHeader
-      .split(",")
-      .map((e) => EncodingMap[e.trim()])
-      .filter(Boolean)
-      .sort(),
-    "",
-  ];
-  if (encodings.length > 1) {
-    event.node.res.setHeader("Vary", "Accept-Encoding");
-  }
+    const encodingHeader = String(
+      event.node.req.headers["accept-encoding"] || ""
+    );
+    const encodings = [
+      ...encodingHeader
+        .split(",")
+        .map((e) => EncodingMap[e.trim()])
+        .filter(Boolean)
+        .sort(),
+      "",
+    ];
+    if (encodings.length > 1) {
+      event.node.res.setHeader("Vary", "Accept-Encoding");
+    }
 
-  for (const encoding of encodings) {
-    for (const _id of [id + encoding, joinURL(id, "index.html" + encoding)]) {
-      const _asset = getAsset(_id);
-      if (_asset) {
-        asset = _asset;
-        id = _id;
-        break;
+    for (const encoding of encodings) {
+      for (const _id of [id + encoding, joinURL(id, "index.html" + encoding)]) {
+        const _asset = getAsset(_id);
+        if (_asset) {
+          asset = _asset;
+          id = _id;
+          break;
+        }
       }
     }
-  }
+  } catch {}
 
   if (!asset) {
     if (isPublicAssetURL(id)) {

--- a/src/runtime/static.ts
+++ b/src/runtime/static.ts
@@ -1,5 +1,11 @@
 import { eventHandler, createError } from "h3";
-import { decodePath, joinURL, parseURL } from "ufo";
+import {
+  decodePath,
+  joinURL,
+  parseURL,
+  withLeadingSlash,
+  withoutTrailingSlash,
+} from "ufo";
 import {
   getAsset,
   readAsset,
@@ -16,7 +22,11 @@ export default eventHandler((event) => {
     return;
   }
 
-  let id = decodePath(parseURL(event.node.req.url).pathname);
+  let id = decodePath(
+    withLeadingSlash(
+      withoutTrailingSlash(parseURL(event.node.req.url).pathname)
+    )
+  );
   let asset: PublicAsset;
 
   const encodingHeader = String(


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/22071

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In some cases (such as a malformed URL) we might encounter an error when checking whether the URL is a static asset. However, we can be assured it is _not_ a static asset and either throw a 404 if it has the static prefix, or simply early return from the handler and directly progress to the next handler, which can allow the user to correct the URL or throw their own error.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
