### PR TITLE
fix: add types for public assets data

### DIFF
--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -6,23 +6,14 @@ import { globby } from "globby";
 import type { Plugin } from "rollup";
 import type { Nitro } from "../../types";
 import { virtual } from "./virtual";
+import type { PublicAsset } from "#internal/nitro/virtual/public-assets";
 
 export function publicAssets(nitro: Nitro): Plugin {
   return virtual(
     {
       // #internal/nitro/virtual/public-assets-data
       "#internal/nitro/virtual/public-assets-data": async () => {
-        const assets: Record<
-          string,
-          {
-            type: string;
-            etag: string;
-            mtime: string;
-            path: string;
-            size: number;
-            encoding?: string;
-          }
-        > = {};
+        const assets: Record<string, PublicAsset> = {};
         const files = await globby("**", {
           cwd: nitro.options.output.publicDir,
           absolute: false,

--- a/src/runtime/static.ts
+++ b/src/runtime/static.ts
@@ -4,6 +4,7 @@ import {
   getAsset,
   readAsset,
   isPublicAssetURL,
+  PublicAsset,
 } from "#internal/nitro/virtual/public-assets";
 
 const METHODS = new Set(["HEAD", "GET"]);
@@ -20,7 +21,7 @@ export default eventHandler((event) => {
       withoutTrailingSlash(parseURL(event.node.req.url).pathname)
     )
   );
-  let asset;
+  let asset: PublicAsset;
 
   const encodingHeader = String(
     event.node.req.headers["accept-encoding"] || ""

--- a/src/runtime/virtual/public-assets.d.ts
+++ b/src/runtime/virtual/public-assets.d.ts
@@ -2,4 +2,13 @@ export const publicAssetBases: string[];
 export const isPublicAssetURL: (id: string) => boolean;
 export const getPublicAssetMeta: (id: string) => { maxAge?: number };
 export const readAsset: (id: string) => Promise<Buffer>;
-export const getAsset: (id: string) => any;
+export const getAsset: (id: string) => PublicAsset;
+
+export interface PublicAsset {
+  type: string;
+  etag: string;
+  mtime: string;
+  path: string;
+  size: number;
+  encoding?: string;
+}


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We had an untyped `asset` which can safely produce types for. This PR improves internal type safety but no bug or issue was encountered with the code.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
