### PR TITLE
chore: $Fetch is not found in fixture/types.ts

### DIFF
--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf } from "expect-type";
 import { describe, it } from "vitest";
-import { $Fetch } from "../..";
+import { $Fetch } from "../../src";
 import { defineNitroConfig } from "../../src/config";
 
 interface TestResponse {


### PR DESCRIPTION
- fix(types import): error  $Fetch not found in '../..'

### 🔗 Linked issue

no issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

pnpm test and the error occur

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
