### PR TITLE
feat: add `transparent` option to proxy

### DIFF
--- a/src/runtime/route-rules.ts
+++ b/src/runtime/route-rules.ts
@@ -54,11 +54,14 @@ export function createRouteRulesHandler() {
         }
       }
 
-      return proxyRequest(event, target, {
-        fetch: $fetch.raw as any,
-        ...routeRules.proxy,
-        ...transparentOptions
-      });
+      const options = defu(
+        {},
+        transparentOptions,
+        routeRules.proxy,
+        { fetch: $fetch.raw as any },
+      )
+
+      return proxyRequest(event, target, options);
     }
   });
 }

--- a/src/runtime/route-rules.ts
+++ b/src/runtime/route-rules.ts
@@ -46,9 +46,18 @@ export function createRouteRulesHandler() {
         const query = getQuery(event.path);
         target = withQuery(target, query);
       }
+
+      const transparentOptions: any = {}
+      if (routeRules.proxy.transparent) {
+        transparentOptions.fetchOptions = {
+          ignoreResponseError: true
+        }
+      }
+
       return proxyRequest(event, target, {
         fetch: $fetch.raw as any,
         ...routeRules.proxy,
+        ...transparentOptions
       });
     }
   });

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -161,7 +161,7 @@ export interface NitroRouteConfig {
   headers?: Record<string, string>;
   redirect?: string | { to: string; statusCode?: HTTPStatusCode };
   prerender?: boolean;
-  proxy?: string | ({ to: string } & ProxyOptions);
+  proxy?: string | ({ to: string; transparent?: boolean } & ProxyOptions);
   isr?: number | boolean;
 
   // Shortcuts
@@ -173,7 +173,7 @@ export interface NitroRouteConfig {
 export interface NitroRouteRules
   extends Omit<NitroRouteConfig, "redirect" | "cors" | "swr" | "static"> {
   redirect?: { to: string; statusCode: HTTPStatusCode };
-  proxy?: { to: string } & ProxyOptions;
+  proxy?: { to: string; transparent?: boolean } & ProxyOptions;
 }
 
 export interface NitroOptions extends PresetOptions {


### PR DESCRIPTION
<!---
☝️ Please ensure title is following conventional commits (https://conventionalcommits.org)

Examples:
 - feat: add something
 - fix(rollup): change something
 - docs: fix typo
-->

### 🔗 Linked issue

https://github.com/unjs/h3/issues/464

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves unjs/nitro#1337" -->

Currently [ofetch](https://github.com/unjs/ofetch/blob/main/src/fetch.ts#L208-L217) is transforming responses with status code between 400 and 600 to errors. This may not be the desired outcome, as it masks plenty of useful information received from proxy target. Therefore as the user, I may want to opt-out of the masking and receive raw response as-is.

Test with:
```ts
// nitro.config.ts
export default defineNitroConfig({
  routeRules: {
    '/404': {
      proxy: {
        to: 'https://github.com/404',
        transparent: true,
      }
    },
  }
});
```

Resolves unjs/h3#464

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
