### PR TITLE
fix(openapi): merge handlers with same route and different method

### DIFF
--- a/src/runtime/routes/openapi.ts
+++ b/src/runtime/routes/openapi.ts
@@ -24,54 +24,72 @@ export default eventHandler((event) => {
       },
     ],
     schemes: ["http"],
-    // eslint-disable-next-line unicorn/no-array-reduce
-    paths: handlersMeta.reduce((paths: PathsObject, h) => {
-      const parameters: ParameterObject[] = [];
-
-      let anonymousCtr = 0;
-      const route = h.route
-        .replace(/:(\w+)/g, (_, name) => `{${name}}`)
-        .replace(/\/(\*)\//g, () => `/{param${++anonymousCtr}}/`)
-        .replace(/\*\*{/, "{")
-        .replace(/\/(\*\*)$/g, () => `/{*param${++anonymousCtr}}`);
-
-      const paramMatches = route.matchAll(/{(\*?\w+)}/g);
-      for (const match of paramMatches) {
-        const name = match[1];
-        if (!parameters.some((p) => p.name === name)) {
-          parameters.push({ name, in: "path", required: true });
-        }
-      }
-
-      const tags: string[] = [];
-      if (route.startsWith("/api/")) {
-        tags.push("API Routes");
-      } else if (route.startsWith("/_")) {
-        tags.push("Internal");
-      } else {
-        tags.push("App Routes");
-      }
-
-      const item: PathItemObject = {
-        [(h.method || "get").toLowerCase()]: <OperationObject>{
-          tags,
-          parameters,
-          responses: {
-            200: { description: "OK" },
-          },
-        },
-      };
-
-      // If we have not seen this route before
-      if (paths[`${route}`] === undefined) {
-        // Assign the PathItemObject with the route
-        paths[`${route}`] = item;
-      } else {
-        // Else, merge this new PathItemObject with the previous ones of this route
-        Object.assign(paths[`${route}`], item);
-      }
-
-      return paths;
-    }, {}),
+    paths: getPaths(),
   };
 });
+
+function getPaths(): PathsObject {
+  const paths: PathsObject = {};
+
+  for (const h of handlersMeta) {
+    const { route, parameters } = normalizeRoute(h.route);
+    const tags = defaultTags(h.route);
+    const method = (h.method || "get").toLowerCase();
+
+    const item: PathItemObject = {
+      [method]: <OperationObject>{
+        tags,
+        parameters,
+        responses: {
+          200: { description: "OK" },
+        },
+      },
+    };
+
+    if (paths[route] === undefined) {
+      paths[route] = item;
+    } else {
+      Object.assign(paths[route], item);
+    }
+  }
+
+  return paths;
+}
+
+function normalizeRoute(_route: string) {
+  const parameters: ParameterObject[] = [];
+
+  let anonymousCtr = 0;
+  const route = _route
+    .replace(/:(\w+)/g, (_, name) => `{${name}}`)
+    .replace(/\/(\*)\//g, () => `/{param${++anonymousCtr}}/`)
+    .replace(/\*\*{/, "{")
+    .replace(/\/(\*\*)$/g, () => `/{*param${++anonymousCtr}}`);
+
+  const paramMatches = route.matchAll(/{(\*?\w+)}/g);
+  for (const match of paramMatches) {
+    const name = match[1];
+    if (!parameters.some((p) => p.name === name)) {
+      parameters.push({ name, in: "path", required: true });
+    }
+  }
+
+  return {
+    route,
+    parameters,
+  };
+}
+
+function defaultTags(route: string) {
+  const tags: string[] = [];
+
+  if (route.startsWith("/api/")) {
+    tags.push("API Routes");
+  } else if (route.startsWith("/_")) {
+    tags.push("Internal");
+  } else {
+    tags.push("App Routes");
+  }
+
+  return tags;
+}

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -74,4 +74,7 @@ export default defineNitroConfig({
     ],
     routes: ["/prerender", "/icon.png", "/404"],
   },
+  experimental: {
+    openAPI: true,
+  },
 });


### PR DESCRIPTION
### 🔗 Linked issue
#1350
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In the openapi.ts file, the `paths` property is generated by using `Object.fromEntries` on the result of a map operation on `handlersMeta`. However, this causes unwanted behaviour : when there are sub-paths routes that only differ by their method, only the last path is present, as it has overridden the other paths information in the final `paths` property.

To fix this, I am now creating the paths object and merging the sub-paths using `Array.reduce` on `handlersMeta` instead. The operations inside this reduce are still the same as the ones inside the previous map implementation.
What has changed is that now instead of returning an array of the route and its path, I now check if the accumulated value, (the total paths object), has the current route as a property. If it does not, I add the route property and the corresponding route information. If it does, I merge the current route information with the information already present for this route.

Resolves #1350 
### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. - N/A
