### PR TITLE
docs: prefer snake_case for preset names

### DIFF
--- a/docs/content/2.deploy/0.index.md
+++ b/docs/content/2.deploy/0.index.md
@@ -20,7 +20,7 @@ When running Nitro in development mode, Nitro will always use a special preset c
 When deploying to the production using CI/CD, Nitro tries to automatically detect the provider environment and set the right one without any additional configuration. Currently, providers below can be auto-detected with zero config.
 
 - [azure](/deploy/providers/azure)
-- [cloudflare_pages](/deploy/providers/cloudflare#cloudflare_pages)
+- [cloudflare pages](/deploy/providers/cloudflare#cloudflare-pages)
 - [netlify](/deploy/providers/netlify)
 - [stormkit](/deploy/providers/stormkit)
 - [vercel](/deploy/providers/vercel)

--- a/docs/content/2.deploy/0.index.md
+++ b/docs/content/2.deploy/0.index.md
@@ -20,7 +20,7 @@ When running Nitro in development mode, Nitro will always use a special preset c
 When deploying to the production using CI/CD, Nitro tries to automatically detect the provider environment and set the right one without any additional configuration. Currently, providers below can be auto-detected with zero config.
 
 - [azure](/deploy/providers/azure)
-- [cloudflare_pages](/deploy/providers/cloudflare#cloudflare-pages)
+- [cloudflare_pages](/deploy/providers/cloudflare#cloudflare_pages)
 - [netlify](/deploy/providers/netlify)
 - [stormkit](/deploy/providers/stormkit)
 - [vercel](/deploy/providers/vercel)
@@ -32,7 +32,7 @@ If you need to build Nitro against a specific provider, you can override it usin
 
 **Example:** Using `NITRO_PRESET`
 ```bash
-NITRO_PRESET=aws-lambda nitro build
+NITRO_PRESET=aws_lambda nitro build
 ```
 
 **Example:** Using [nitro.config.ts](/guide/configuration)

--- a/docs/content/2.deploy/2.workers.md
+++ b/docs/content/2.deploy/2.workers.md
@@ -12,7 +12,7 @@ Nitro provides out of the box support for deploying any Nitro app to different E
 
 - [Cloudflare](/deploy/providers/cloudflare)
 - [Deno](/deploy/providers/deno)
-- [Vercel](/deploy/providers/vercel#vercel_edge-functions)
+- [Vercel](/deploy/providers/vercel#vercel-edge-functions)
 - [Netlify](/deploy/providers/netlify#netlify-edge-functions)
 - [Lagon](/deploy/providers/lagon)
 - [Browser Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) (via experimental preset `service-worker`)

--- a/docs/content/2.deploy/2.workers.md
+++ b/docs/content/2.deploy/2.workers.md
@@ -13,7 +13,7 @@ Nitro provides out of the box support for deploying any Nitro app to different E
 - [Cloudflare](/deploy/providers/cloudflare)
 - [Deno](/deploy/providers/deno)
 - [Vercel](/deploy/providers/vercel#vercel_edge-functions)
-- [Netlify](/deploy/providers/netlify#netlify_edge-functions)
+- [Netlify](/deploy/providers/netlify#netlify-edge-functions)
 - [Lagon](/deploy/providers/lagon)
 - [Browser Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) (via experimental preset `service-worker`)
 

--- a/docs/content/2.deploy/2.workers.md
+++ b/docs/content/2.deploy/2.workers.md
@@ -12,8 +12,8 @@ Nitro provides out of the box support for deploying any Nitro app to different E
 
 - [Cloudflare](/deploy/providers/cloudflare)
 - [Deno](/deploy/providers/deno)
-- [Vercel](/deploy/providers/vercel#vercel-edge-functions)
-- [Netlify](/deploy/providers/netlify#netlify-edge-functions)
+- [Vercel](/deploy/providers/vercel#vercel_edge-functions)
+- [Netlify](/deploy/providers/netlify#netlify_edge-functions)
 - [Lagon](/deploy/providers/lagon)
 - [Browser Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) (via experimental preset `service-worker`)
 

--- a/docs/content/2.deploy/providers/aws.md
+++ b/docs/content/2.deploy/providers/aws.md
@@ -2,7 +2,7 @@
 
 Deploy Nitro apps to AWS Lambda.
 
-**Preset:** `aws-lambda` ([switch to this preset](/deploy/#changing-the-deployment-preset))
+**Preset:** `aws_lambda` ([switch to this preset](/deploy/#changing-the-deployment-preset))
 
 Nitro provides a built-in preset to generate output format compatible with [AWS Lambda](https://aws.amazon.com/lambda/).
 

--- a/docs/content/2.deploy/providers/azure.md
+++ b/docs/content/2.deploy/providers/azure.md
@@ -16,7 +16,7 @@ Azure Static Web Apps are designed to be deployed continuously in a [GitHub Acti
 
 ### Local preview
 
-Install [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure_functions/functions-run-local) if you want to test locally.
+Install [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local) if you want to test locally.
 
 You can invoke a development environment to preview before deploying.
 
@@ -57,11 +57,11 @@ If you are using runtimeConfig, you will likely want to configure the correspond
 
 **Preset:** `azure_functions`
 
-**Note:** If you encounter any issues, please ensure you're using a Node.js 14+ runtime. You can find more information about [how to set the Node version in the Azure docs](https://docs.microsoft.com/en-us/azure/azure_functions/functions-reference-node?tabs=v2#setting-the-node-version).
+**Note:** If you encounter any issues, please ensure you're using a Node.js 14+ runtime. You can find more information about [how to set the Node version in the Azure docs](https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=v2#setting-the-node-version).
 
 ### Local preview
 
-Install [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure_functions/functions-run-local) if you want to test locally.
+Install [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local) if you want to test locally.
 
 You can invoke a development environment from the serverless directory.
 

--- a/docs/content/2.deploy/providers/azure.md
+++ b/docs/content/2.deploy/providers/azure.md
@@ -16,7 +16,7 @@ Azure Static Web Apps are designed to be deployed continuously in a [GitHub Acti
 
 ### Local preview
 
-Install [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local) if you want to test locally.
+Install [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure_functions/functions-run-local) if you want to test locally.
 
 You can invoke a development environment to preview before deploying.
 
@@ -55,18 +55,18 @@ If you are using runtimeConfig, you will likely want to configure the correspond
 
 ## Azure Functions
 
-**Preset:** `azure-functions`
+**Preset:** `azure_functions`
 
-**Note:** If you encounter any issues, please ensure you're using a Node.js 14+ runtime. You can find more information about [how to set the Node version in the Azure docs](https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=v2#setting-the-node-version).
+**Note:** If you encounter any issues, please ensure you're using a Node.js 14+ runtime. You can find more information about [how to set the Node version in the Azure docs](https://docs.microsoft.com/en-us/azure/azure_functions/functions-reference-node?tabs=v2#setting-the-node-version).
 
 ### Local preview
 
-Install [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local) if you want to test locally.
+Install [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure_functions/functions-run-local) if you want to test locally.
 
 You can invoke a development environment from the serverless directory.
 
 ```bash
-NITRO_PRESET=azure-functions yarn build
+NITRO_PRESET=azure_functions yarn build
 cd .output
 func start
 ```
@@ -134,7 +134,7 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          NITRO_PRESET: azure-functions
+          NITRO_PRESET: azure_functions
 
       - name: 'Deploy to Azure Functions'
         uses: Azure/functions-action@v1

--- a/docs/content/2.deploy/providers/cloudflare.md
+++ b/docs/content/2.deploy/providers/cloudflare.md
@@ -132,7 +132,7 @@ jobs:
 
 ## Cloudflare Pages
 
-**Preset:** `cloudflare-pages` ([switch to this preset](/deploy/#changing-the-deployment-preset))
+**Preset:** `cloudflare_pages` ([switch to this preset](/deploy/#changing-the-deployment-preset))
 
 ::alert{type="warning"}
 **Note:** This is an experimental preset.

--- a/docs/content/2.deploy/providers/cloudflare.md
+++ b/docs/content/2.deploy/providers/cloudflare.md
@@ -175,7 +175,7 @@ wrangler pages deploy
 
 ## Cloudflare Module Workers
 
-**Preset:** `cloudflare-module` ([switch to this preset](/deploy/#changing-the-deployment-preset))
+**Preset:** `cloudflare_module` ([switch to this preset](/deploy/#changing-the-deployment-preset))
 
 ::alert{type="warning"}
 **Note:** This is an experimental preset.

--- a/docs/content/2.deploy/providers/deno.md
+++ b/docs/content/2.deploy/providers/deno.md
@@ -34,7 +34,7 @@ You do not need to set up any secrets for this to work. You do need to link your
 Create `.github/workflows/deno_deploy.yml`:
 
 ```yaml
-name: deno_deploy
+name: deno-deploy
 
 on:
   push:

--- a/docs/content/2.deploy/providers/deno.md
+++ b/docs/content/2.deploy/providers/deno.md
@@ -4,7 +4,7 @@ Deploy Nitro apps to [Deno Deploy](https://deno.com/deploy).
 
 ## Deno Deploy
 
-**Preset:** `deno-deploy` ([switch to this preset](/deploy/#changing-the-deployment-preset))
+**Preset:** `deno_deploy` ([switch to this preset](/deploy/#changing-the-deployment-preset))
 
 ::alert{type="warning"}
 Deno deploy preset is experimental.
@@ -17,8 +17,8 @@ You can use [deployctl](https://deno.com/deploy/docs/deployctl) to deploy your a
 Login to [Deno Deploy](https://dash.deno.com/account#access-tokens) to obtain a `DENO_DEPLOY_TOKEN` access token, and set it as an environment variable.
 
 ```bash
-# Build with the deno-deploy NITRO preset
-NITRO_PRESET=deno-deploy npm run build
+# Build with the deno_deploy NITRO preset
+NITRO_PRESET=deno_deploy npm run build
 
 # Make sure to run the deployctl command from the output directory
 cd .output
@@ -31,10 +31,10 @@ You just need to include the deployctl GitHub Action as a step in your workflow.
 
 You do not need to set up any secrets for this to work. You do need to link your GitHub repository to your Deno Deploy project and choose the "GitHub Actions" deployment mode. You can do this in your project settings on https://dash.deno.com.
 
-Create `.github/workflows/deno-deploy.yml`:
+Create `.github/workflows/deno_deploy.yml`:
 
 ```yaml
-name: deno-deploy
+name: deno_deploy
 
 on:
   push:
@@ -56,7 +56,7 @@ jobs:
       - run: pnpm install
       - run: pnpm build
         env:
-          NITRO_PRESET: deno-deploy
+          NITRO_PRESET: deno_deploy
       - name: Deploy to Deno Deploy
         uses: denoland/deployctl@v1
         with:

--- a/docs/content/2.deploy/providers/github-pages.md
+++ b/docs/content/2.deploy/providers/github-pages.md
@@ -8,7 +8,7 @@ Nitro supports deploying on [GitHub Pages](https://pages.github.com/) with minim
 
 ## Setup
 
-Follow the steps to [create a GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github_pages/creating-a-github_pages-site).
+Follow the steps to [create a GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-github-pages-site).
 
 ## Deployment
 

--- a/docs/content/2.deploy/providers/github-pages.md
+++ b/docs/content/2.deploy/providers/github-pages.md
@@ -2,17 +2,17 @@
 
 Deploy Nitro apps to GitHub Pages.
 
-**Preset:** `github-pages` ([switch to this preset](/deploy/#changing-the-deployment-preset))
+**Preset:** `github_pages` ([switch to this preset](/deploy/#changing-the-deployment-preset))
 
 Nitro supports deploying on [GitHub Pages](https://pages.github.com/) with minimal configuration.
 
 ## Setup
 
-Follow the steps to [create a GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-github-pages-site).
+Follow the steps to [create a GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github_pages/creating-a-github_pages-site).
 
 ## Deployment
 
-Here is an example GitHub Actions workflow to deploy your site to GitHub Pages using the `github-pages` preset:
+Here is an example GitHub Actions workflow to deploy your site to GitHub Pages using the `github_pages` preset:
 
 ```yaml
 # https://github.com/actions/deploy-pages#usage
@@ -38,7 +38,7 @@ jobs:
       - run: npm install
       - run: npm run build
         env:
-          NITRO_PRESET: github-pages
+          NITRO_PRESET: github_pages
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
@@ -55,9 +55,9 @@ jobs:
       pages: write      # to deploy to Pages
       id-token: write   # to verify the deployment originates from an appropriate source
 
-    # Deploy to the github-pages environment
+    # Deploy to the github_pages environment
     environment:
-      name: github-pages
+      name: github_pages
       url: ${{ steps.deployment.outputs.page_url }}
 
     # Specify runner + deployment step

--- a/docs/content/2.deploy/providers/iis.md
+++ b/docs/content/2.deploy/providers/iis.md
@@ -8,7 +8,7 @@ This is an experimental preset.
 
 ## Using [IISnode](https://github.com/Azure/iisnode) (recommended)
 
-**Preset:** `iis-node` ([switch to this preset](/deploy/#changing-the-deployment-preset))
+**Preset:** `iis_node` ([switch to this preset](/deploy/#changing-the-deployment-preset))
 
 1. Install [IISnode](https://github.com/azure/iisnode/releases), and the [IIS URL Rewrite Module](https://www.iis.net/downloads/microsoft/url-rewrite).
 2. In IIS, add `.mjs` as a new mime type and set its content type to `application/javascript`.

--- a/docs/content/2.deploy/providers/netlify.md
+++ b/docs/content/2.deploy/providers/netlify.md
@@ -23,7 +23,7 @@ For deployment, just push to your git repository [as you would normally do for N
 
 ## Netlify Edge Functions
 
-**Preset:** `netlify-edge` ([switch to this preset](/deploy/#changing-the-deployment-preset))
+**Preset:** `netlify_edge` ([switch to this preset](/deploy/#changing-the-deployment-preset))
 
 Netlify Edge Functions use Deno and the powerful V8 JavaScript runtime to let you run globally distributed functions for the fastest possible response times. ([Read More](https://www.netlify.com/blog/announcing-serverless-compute-with-edge-functions))
 
@@ -31,7 +31,7 @@ Nitro output can directly run the server at the edge. Closer to your users.
 
 ## On-demand Builders
 
-**Preset:** `netlify-builder` ([switch to this preset](/deploy/#changing-the-deployment-preset))
+**Preset:** `netlify_builder` ([switch to this preset](/deploy/#changing-the-deployment-preset))
 
 On-demand Builders are serverless functions used to generate web content as needed that’s automatically cached on Netlify’s Edge CDN. They enable you to build pages for your site when a user visits them for the first time and then cache them at the edge for subsequent visits.  ([Read More](https://docs.netlify.com/configure-builds/on-demand-builders/))
 

--- a/docs/content/2.deploy/providers/render.md
+++ b/docs/content/2.deploy/providers/render.md
@@ -2,7 +2,7 @@
 
 Deploy Nitro apps to Render.
 
-**Preset:** `render-com` ([switch to this preset](/deploy/#changing-the-deployment-preset))
+**Preset:** `render_com` ([switch to this preset](/deploy/#changing-the-deployment-preset))
 
 Nitro supports deploying on [Render](https://render.com/) with minimal configuration.
 
@@ -16,7 +16,7 @@ Nitro supports deploying on [Render](https://render.com/) with minimal configura
 
 1. Update the start command to `node .output/server/index.mjs`
 
-1. Click 'Advanced' and add an environment variable with `NITRO_PRESET` set to `render-com`.
+1. Click 'Advanced' and add an environment variable with `NITRO_PRESET` set to `render_com`.
 
 1. Click 'Create Web Service'.
 
@@ -35,7 +35,7 @@ services:
     buildCommand: npm install && npm run build
     envVars:
     - key: NITRO_PRESET
-      value: render-com
+      value: render_com
 ```
 2. [Create a new Blueprint Instance](https://dashboard.render.com/select-repo?type=blueprint) and select the repository containing your `render.yaml` file.
 

--- a/docs/content/2.deploy/providers/vercel.md
+++ b/docs/content/2.deploy/providers/vercel.md
@@ -23,7 +23,7 @@ Learn more about Vercel’s [Git Integration](https://vercel.com/docs/concepts/g
 
 ## Vercel Edge Functions
 
-**Preset:** `vercel-edge` ([switch to this preset](/deploy/#changing-the-deployment-preset))
+**Preset:** `vercel_edge` ([switch to this preset](/deploy/#changing-the-deployment-preset))
 
 It is possible to deploy your nitro applications directly on [Vercel Edge Functions](https://vercel.com/docs/concepts/functions/edge-functions).
 
@@ -33,7 +33,7 @@ It is possible to deploy your nitro applications directly on [Vercel Edge Functi
 > By taking advantage of this small runtime, Edge Functions can have faster cold boots and higher scalability than Serverless Functions.
 > Edge Functions run after the cache, and can both cache and return responses. [Read More](https://vercel.com/docs/concepts/functions/edge-functions)
 
-In order to enable this target, please set `NITRO_PRESET` environment variable to `vercel-edge`.
+In order to enable this target, please set `NITRO_PRESET` environment variable to `vercel_edge`.
 
 ## Vercel KV Storage
 


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This updates the preset for Cloudflare Pages to be named `cloudflare_pages` instead of `cloudflare-pages`.  This brings the name inline with the one on the https://nitro.unjs.io/deploy page and actually works when deploying to Cloudflare Pages.

I have to set `cloudflare_pages` in my `nuxt.config.ts` in order for this preset to work.  I assume that means that the preset should be underscored and not dashed like `cloudflare-pages`.  If I use `cloudflare-pages` instead of `cloudflare_pages`, the `dist` directory does not get created.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
