### PR TITLE
refactor: reduce usage of `event.node.res`

### DIFF
--- a/src/dev/error.ts
+++ b/src/dev/error.ts
@@ -1,14 +1,21 @@
-import { H3Event, setResponseStatus } from "h3";
+import {
+  H3Event,
+  setResponseHeader,
+  setResponseStatus,
+  getResponseStatus,
+  getResponseStatusText,
+  send,
+} from "h3";
 import { NitroErrorHandler } from "../types";
 
 function errorHandler(error: any, event: H3Event) {
-  event.node.res.setHeader("Content-Type", "text/html; charset=UTF-8");
+  setResponseHeader(event, "Content-Type", "text/html; charset=UTF-8");
   setResponseStatus(event, 503, "Server Unavailable");
 
   let body;
   let title;
   if (error) {
-    title = `${event.node.res.statusCode} ${event.node.res.statusMessage}`;
+    title = `${getResponseStatus(event)} ${getResponseStatusText(event)}`;
     body = `<code><pre>${error.stack}</pre></code>`;
   } else {
     title = "Reloading server...";
@@ -16,11 +23,9 @@ function errorHandler(error: any, event: H3Event) {
       "<progress></progress><script>document.querySelector('progress').indeterminate=true</script>";
   }
 
-  if (event.handled) {
-    return;
-  }
-
-  event.node.res.end(`<!DOCTYPE html>
+  send(
+    event,
+    `<!DOCTYPE html>
   <html lang="en">
   <head>
     <meta charset="utf-8">
@@ -43,7 +48,8 @@ function errorHandler(error: any, event: H3Event) {
   </main>
   </body>
 </html>
-`);
+`
+  );
 }
 
 export default errorHandler as NitroErrorHandler;

--- a/src/runtime/error.ts
+++ b/src/runtime/error.ts
@@ -1,5 +1,5 @@
 // import ansiHTML from 'ansi-html'
-import { setResponseStatus } from "h3";
+import { setResponseHeader, setResponseStatus, send } from "h3";
 import type { NitroErrorHandler } from "../types";
 import { normalizeError, isJsonRequest } from "./utils";
 
@@ -44,14 +44,12 @@ export default <NitroErrorHandler>function (error, event) {
 
   setResponseStatus(event, statusCode, statusMessage);
 
-  if (!event.handled) {
-    if (isJsonRequest(event)) {
-      event.node.res.setHeader("Content-Type", "application/json");
-      event.node.res.end(JSON.stringify(errorObject));
-    } else {
-      event.node.res.setHeader("Content-Type", "text/html");
-      event.node.res.end(renderHTMLError(errorObject));
-    }
+  if (isJsonRequest(event)) {
+    setResponseHeader(event, "Content-Type", "application/json");
+    send(event, JSON.stringify(errorObject));
+  } else {
+    setResponseHeader(event, "Content-Type", "text/html");
+    send(event, renderHTMLError(errorObject));
   }
 };
 

--- a/src/runtime/renderer.ts
+++ b/src/runtime/renderer.ts
@@ -1,4 +1,12 @@
-import { H3Event, eventHandler, setResponseStatus } from "h3";
+import {
+  H3Event,
+  eventHandler,
+  getResponseStatus,
+  send,
+  setResponseHeader,
+  setResponseHeaders,
+  setResponseStatus,
+} from "h3";
 import { useNitroApp } from "./app";
 
 export interface RenderResponse {
@@ -16,25 +24,22 @@ export function defineRenderHandler(handler: RenderHandler) {
   return eventHandler(async (event) => {
     // TODO: Use serve-placeholder
     if (event.path.endsWith("/favicon.ico")) {
-      if (!event.handled) {
-        event.node.res.setHeader("Content-Type", "image/x-icon");
-        event.node.res.end(
-          "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-        );
-      }
+      setResponseHeader(event, "Content-Type", "image/x-icon");
+      send(
+        event,
+        "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+      );
       return;
     }
 
     const response = await handler(event);
     if (!response) {
-      if (!event.handled) {
-        event.node.res.statusCode =
-          event.node.res.statusCode === 200 ? 500 : event.node.res.statusCode;
-        event.node.res.end(
-          "No response returned from render handler: " + event.path
-        );
-      }
-      return;
+      const _currentStatus = getResponseStatus(event);
+      setResponseStatus(event, _currentStatus === 200 ? 500 : _currentStatus);
+      return send(
+        event,
+        "No response returned from render handler: " + event.path
+      );
     }
 
     // Allow hooking and modifying response
@@ -46,10 +51,10 @@ export function defineRenderHandler(handler: RenderHandler) {
     // TODO: Caching support
 
     // Send headers
-    if (!event.node.res.headersSent && response.headers) {
-      for (const header in response.headers) {
-        event.node.res.setHeader(header, response.headers[header]);
-      }
+    if (response.headers) {
+      setResponseHeaders(event, response.headers);
+    }
+    if (response.statusCode || response.statusMessage) {
       setResponseStatus(event, response.statusCode, response.statusMessage);
     }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Following up #1511, this reduces dependency on `event.node.res` across nitro codebase. `event.handled` checks are now removed too since send utility is expected to take care of it (in rare cases there might be regressions since `send` is async but we might investigate anything related in h3 `send` util if happens). Main part remaining are `timing` and `cachedEventHandler` to fully decouple from node.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
