### PR TITLE
feat(vercel): enable streaming support out of the box

### DIFF
--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -5,7 +5,10 @@ import { withoutLeadingSlash } from "ufo";
 import { writeFile } from "../utils";
 import { defineNitroPreset } from "../preset";
 import type { Nitro } from "../types";
-import type { VercelBuildConfigV3, VercelServerlessFunctionConfig } from "../types/presets";
+import type {
+  VercelBuildConfigV3,
+  VercelServerlessFunctionConfig,
+} from "../types/presets";
 
 // https://vercel.com/docs/build-output-api/v3
 

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -5,7 +5,7 @@ import { withoutLeadingSlash } from "ufo";
 import { writeFile } from "../utils";
 import { defineNitroPreset } from "../preset";
 import type { Nitro } from "../types";
-import type { VercelBuildConfigV3 } from "../types/presets";
+import type { VercelBuildConfigV3, VercelServerlessFunctionConfig } from "../types/presets";
 
 // https://vercel.com/docs/build-output-api/v3
 
@@ -36,11 +36,12 @@ export const vercel = defineNitroPreset({
         nitro.options.output.serverDir,
         ".vc-config.json"
       );
-      const functionConfig = {
+      const functionConfig: VercelServerlessFunctionConfig = {
         runtime: runtimeVersion,
         handler: "index.mjs",
         launcherType: "Nodejs",
         shouldAddHelpers: false,
+        supportsResponseStreaming: true,
         ...nitro.options.vercel?.functions,
       };
       await writeFile(

--- a/src/types/presets.ts
+++ b/src/types/presets.ts
@@ -6,19 +6,19 @@ export interface VercelBuildConfigV3 {
   version: 3;
   routes?: (
     | {
-      src: string;
-      headers: {
-        "cache-control": string;
-      };
-      continue: boolean;
-    }
+        src: string;
+        headers: {
+          "cache-control": string;
+        };
+        continue: boolean;
+      }
     | {
-      handle: string;
-    }
+        handle: string;
+      }
     | {
-      src: string;
-      dest: string;
-    }
+        src: string;
+        dest: string;
+      }
   )[];
   images?: {
     sizes: number[];

--- a/src/types/presets.ts
+++ b/src/types/presets.ts
@@ -6,19 +6,19 @@ export interface VercelBuildConfigV3 {
   version: 3;
   routes?: (
     | {
-        src: string;
-        headers: {
-          "cache-control": string;
-        };
-        continue: boolean;
-      }
+      src: string;
+      headers: {
+        "cache-control": string;
+      };
+      continue: boolean;
+    }
     | {
-        handle: string;
-      }
+      handle: string;
+    }
     | {
-        src: string;
-        dest: string;
-      }
+      src: string;
+      dest: string;
+    }
   )[];
   images?: {
     sizes: number[];
@@ -52,18 +52,43 @@ export interface VercelBuildConfigV3 {
   }[];
 }
 
+/**
+ * https://vercel.com/docs/build-output-api/v3/primitives#serverless-function-configuration
+ */
+export interface VercelServerlessFunctionConfig {
+  /**
+   * Amount of memory (RAM in MB) that will be allocated to the Serverless Function.
+   */
+  memory?: number;
+
+  /**
+   * Maximum execution duration (in seconds) that will be allowed for the Serverless Function.
+   */
+  maxDuration?: number;
+
+  /**
+   * True if a custom runtime has support for Lambda runtime wrappers.
+   */
+  supportsWrapper?: boolean;
+
+  /**
+   * When true, the Serverless Function will stream the response to the client.
+   */
+  supportsResponseStreaming?: boolean;
+
+  [key: string]: unknown;
+}
+
 export interface PresetOptions {
   vercel: {
     config: VercelBuildConfigV3;
+
     /**
      * If you are using `vercel-edge`, you can specify the region(s) for your edge function.
      * @see https://vercel.com/docs/concepts/functions/edge-functions#edge-function-regions
      */
     regions?: string[];
-    functions?: {
-      memory: number;
-      maxDuration: number;
-      [key: string]: unknown;
-    };
+
+    functions?: VercelServerlessFunctionConfig;
   };
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves #1505

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR improve js docs for vercel sls config and also enables `supportsResponseStreaming` flag by default (can be disabled by user).

Now that we are using a h3 version that is compatible with streaming, we can safely enable streaming. I have requested vercel team to verify this.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
