### PR TITLE
fix: use relative paths in `tsconfig.json`

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -233,24 +233,24 @@ declare module 'nitropack' {
         jsxFactory: "h",
         jsxFragmentFactory: "Fragment",
         paths: {
-          "#imports": [join(typesDir, "nitro-imports")],
+          "#imports": [relativeWithDot(tsconfigDir, join(typesDir, "nitro-imports"))],
           ...(nitro.options.typescript.internalPaths
             ? {
-                "#internal/nitro": [join(runtimeDir, "index")],
-                "#internal/nitro/*": [join(runtimeDir, "*")],
+                "#internal/nitro": [relativeWithDot(tsconfigDir, join(runtimeDir, "index"))],
+                "#internal/nitro/*": [relativeWithDot(tsconfigDir, join(runtimeDir, "*"))],
               }
             : {}),
         },
       },
       include: [
-        relative(tsconfigDir, join(typesDir, "nitro.d.ts")).replace(
+        relativeWithDot(tsconfigDir, join(typesDir, "nitro.d.ts")).replace(
           /^(?=[^.])/,
           "./"
         ),
-        join(relative(tsconfigDir, nitro.options.rootDir), "**/*"),
+        join(relativeWithDot(tsconfigDir, nitro.options.rootDir), "**/*"),
         ...(nitro.options.srcDir === nitro.options.rootDir
           ? []
-          : [join(relative(tsconfigDir, nitro.options.srcDir), "**/*")]),
+          : [join(relativeWithDot(tsconfigDir, nitro.options.srcDir), "**/*")]),
       ],
     });
     buildFiles.push({
@@ -462,4 +462,9 @@ function formatRollupError(_error: RollupError | OnResolveResult) {
   } catch {
     return _error?.toString();
   }
+}
+
+function relativeWithDot (from: string, to: string) {
+  const rel = relative(from, to)
+  return rel.startsWith('.') ? rel : './' + rel
 }

--- a/src/build.ts
+++ b/src/build.ts
@@ -233,11 +233,17 @@ declare module 'nitropack' {
         jsxFactory: "h",
         jsxFragmentFactory: "Fragment",
         paths: {
-          "#imports": [relativeWithDot(tsconfigDir, join(typesDir, "nitro-imports"))],
+          "#imports": [
+            relativeWithDot(tsconfigDir, join(typesDir, "nitro-imports")),
+          ],
           ...(nitro.options.typescript.internalPaths
             ? {
-                "#internal/nitro": [relativeWithDot(tsconfigDir, join(runtimeDir, "index"))],
-                "#internal/nitro/*": [relativeWithDot(tsconfigDir, join(runtimeDir, "*"))],
+                "#internal/nitro": [
+                  relativeWithDot(tsconfigDir, join(runtimeDir, "index")),
+                ],
+                "#internal/nitro/*": [
+                  relativeWithDot(tsconfigDir, join(runtimeDir, "*")),
+                ],
               }
             : {}),
         },
@@ -465,7 +471,7 @@ function formatRollupError(_error: RollupError | OnResolveResult) {
 }
 
 const RELATIVE_RE = /^\.{1,2}\//;
-function relativeWithDot (from: string, to: string) {
-  const rel = relative(from, to)
-  return RELATIVE_RE.test(rel) ? rel : './' + rel
+function relativeWithDot(from: string, to: string) {
+  const rel = relative(from, to);
+  return RELATIVE_RE.test(rel) ? rel : "./" + rel;
 }

--- a/src/build.ts
+++ b/src/build.ts
@@ -464,7 +464,8 @@ function formatRollupError(_error: RollupError | OnResolveResult) {
   }
 }
 
+const RELATIVE_RE = /^\.{1,2}\//;
 function relativeWithDot (from: string, to: string) {
   const rel = relative(from, to)
-  return rel.startsWith('.') ? rel : './' + rel
+  return RELATIVE_RE.test(rel) ? rel : './' + rel
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Without a `baseUrl` we cannot pass in absolute paths in nitro aliases. This ensures that our aliases + includes are relative to the tsconfig file itself.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
