### PR TITLE
perf: reduce _prerenderRoutes memory footprint

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -24,6 +24,7 @@ export async function prerender(nitro: Nitro) {
 
   // Initial list of routes to prerender
   const routes = new Set(nitro.options.prerender.routes);
+
   // Extend with static prerender route rules
   const prerenderRulePaths = Object.entries(nitro.options.routeRules)
     .filter(([path, options]) => options.prerender && !path.includes("*"))

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -229,17 +229,3 @@ export function provideFallbackValues(obj: Record<string, any>) {
     }
   }
 }
-
-export function RouteSet(routes: string[]) {
-  let set = new Set(routes);
-  return {
-    size: set.size,
-    add: (s: string) => set.add(s),
-    prepend: (s: string) => {
-      set = new Set([s, ...set.values()]);
-      return set;
-    },
-    values: set.values,
-    getSet: () => set,
-  };
-}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -229,3 +229,17 @@ export function provideFallbackValues(obj: Record<string, any>) {
     }
   }
 }
+
+export function RouteSet(routes: string[]) {
+  let set = new Set(routes);
+  return {
+    size: set.size,
+    add: (s: string) => set.add(s),
+    prepend: (s: string) => {
+      set = new Set([s, ...set.values()]);
+      return set;
+    },
+    values: set.values,
+    getSet: () => set,
+  };
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Related https://github.com/unjs/nitro/issues/1535
Related https://github.com/unjs/nitro/issues/1480
Related https://github.com/nuxt/nuxt/issues/22449

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Based on @simkuns patch. Internal `_prerenderedRoutes` now only contains route and fileName to reduce the memory footprint

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
