### PR TITLE
fix(prerender): only match `href` attribute after whitespace

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -300,7 +300,7 @@ async function runParallel<T>(
   await refillQueue();
 }
 
-const LINK_REGEX = /href=["']?([^"'>]+)/g;
+const LINK_REGEX = /(?<=\s)href=["']?([^"'>]+)/g;
 
 function extractLinks(
   html: string,

--- a/test/fixture/routes/500.ts
+++ b/test/fixture/routes/500.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler((event) => {
+  throw createError({ statusCode: 500, statusMessage: "Test Error" });
+});

--- a/test/fixture/routes/prerender.ts
+++ b/test/fixture/routes/prerender.ts
@@ -31,6 +31,9 @@ export default defineEventHandler((event) => {
 ${links.map((link) => `    <li><a href="${link}">${link}</a></li>`).join("\n")}
   </ul>
   <!-- Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ac fermentum tortor, vitae semper nisl. Morbi eu ex sed lacus mollis mollis vel nec mi. Aenean tincidunt pretium ligula, at dapibus libero vestibulum vel. Nunc in lorem vitae tortor lacinia cursus. Morbi malesuada nunc vel mi ornare, a iaculis magna molestie. In dictum, ex quis euismod semper, augue diam convallis nisi, vitae ullamcorper urna augue vel metus. Cras risus elit, tempus ac pretium quis, gravida id odio. Curabitur posuere diam vel leo imperdiet porttitor. Cras posuere hendrerit porta. In tellus velit, sagittis et scelerisque ultrices, iaculis ut leo. Proin id nibh blandit, pharetra lorem et, feugiat dui. Morbi hendrerit massa nec mauris aliquet ultrices. -->
+
+  /* Bad Link Examples */
+  <a x-href="/500?x-href">x-href attr</a>
 </body>
 </html>`;
 });


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves https://github.com/unjs/nitro/issues/1527

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This restricts `href` regexp to match only ` href` and not `x-link:href` (for example).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
