### PR TITLE
test: add `~` alias to fixture

### DIFF
--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -1,6 +1,6 @@
+import { fileURLToPath } from "node:url"
 import { dirname } from "pathe"
 import { defineNitroConfig } from "../../src/config";
-import { fileURLToPath } from "node:url"
 
 export default defineNitroConfig({
   compressPublicAssets: true,

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -1,4 +1,6 @@
+import { dirname } from "pathe"
 import { defineNitroConfig } from "../../src/config";
+import { fileURLToPath } from "node:url"
 
 export default defineNitroConfig({
   compressPublicAssets: true,
@@ -10,6 +12,9 @@ export default defineNitroConfig({
         imports: ["camelCase", "pascalCase", "kebabCase"],
       },
     ],
+  },
+  alias: {
+    '~': dirname(fileURLToPath(import.meta.url))
   },
   handlers: [
     {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In working on https://github.com/unjs/nitro/pull/1532, I noticed we have an api route that uses an alias that doesn't exist.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
