### PR TITLE
feat(prerender): support `retry` and `retryDelay`

### DIFF
--- a/docs/content/3.config.md
+++ b/docs/content/3.config.md
@@ -374,7 +374,7 @@ Set `autoSubfolderIndex` lets you control how to generate the files in the `.out
 
 This option is useful when your hosting provider does not give you an option regarding the trailing slash.
 
-The prerenderer will attempt to render pages 3 times with a delay of 500ms. Use `tries` and `retryDelay` to change this behavior.
+The prerenderer will attempt to render pages 3 times with a delay of 500ms. Use `retry` and `retryDelay` to change this behavior.
 
 ## Directories
 

--- a/docs/content/3.config.md
+++ b/docs/content/3.config.md
@@ -347,7 +347,9 @@ Default:
   failOnError: false,
   crawlLinks: false,
   ignore: [],
-  routes: []
+  routes: [],
+  tries: 3,
+  retryDelay: 500
 }
 ```
 
@@ -371,6 +373,8 @@ Set `autoSubfolderIndex` lets you control how to generate the files in the `.out
 ```
 
 This option is useful when your hosting provider does not give you an option regarding the trailing slash.
+
+The prerenderer will attempt to render pages 3 times with a delay of 500ms. Use `tries` and `retryDelay` to change this behavior.
 
 ## Directories
 

--- a/docs/content/3.config.md
+++ b/docs/content/3.config.md
@@ -348,7 +348,7 @@ Default:
   crawlLinks: false,
   ignore: [],
   routes: [],
-  tries: 3,
+  retries: 3,
   retryDelay: 500
 }
 ```
@@ -374,7 +374,7 @@ Set `autoSubfolderIndex` lets you control how to generate the files in the `.out
 
 This option is useful when your hosting provider does not give you an option regarding the trailing slash.
 
-The prerenderer will attempt to render pages 3 times with a delay of 500ms. Use `retry` and `retryDelay` to change this behavior.
+The prerenderer will attempt to render pages 3 times with a delay of 500ms. Use `retries` and `retryDelay` to change this behavior.
 
 ## Directories
 

--- a/docs/content/3.config.md
+++ b/docs/content/3.config.md
@@ -374,7 +374,7 @@ Set `autoSubfolderIndex` lets you control how to generate the files in the `.out
 
 This option is useful when your hosting provider does not give you an option regarding the trailing slash.
 
-The prerenderer will attempt to render pages 3 times with a delay of 500ms. Use `retries` and `retryDelay` to change this behavior.
+The prerenderer will attempt to render pages 3 times with a delay of 500ms. Use `retry` and `retryDelay` to change this behavior.
 
 ## Directories
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -79,6 +79,8 @@ const NitroDefaults: NitroConfig = {
     autoSubfolderIndex: true,
     concurrency: 1,
     interval: 0,
+    retry: 3,
+    retryDelay: 500,
     failOnError: false,
     crawlLinks: false,
     ignore: [],

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -179,7 +179,6 @@ export async function prerender(nitro: Nitro) {
     // Data will be removed as soon as written to the disk
     let dataBuff: Buffer | undefined = Buffer.from(await res.arrayBuffer());
 
-    _route.data = await res.arrayBuffer();
     Object.defineProperty(_route, "contents", {
       get: () => {
         return dataBuff ? dataBuff.toString("utf8") : undefined;

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -172,8 +172,8 @@ export async function prerender(nitro: Nitro) {
       withBase(encodedRoute, nitro.options.baseURL),
       {
         headers: { "x-nitro-prerender": encodedRoute },
-        retry: nitro.options.prerender.retries ?? 2, // By default we retry 2 times
-        retryDelay: nitro.options.prerender.retryDelay ?? 250,
+        retry: nitro.options.prerender.retries ?? 2, // default is 2 retries
+        retryDelay: nitro.options.prerender.retryDelay ?? 250, // default is 250ms
       }
     );
     // Data will be removed as soon as written to the disk

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -171,7 +171,7 @@ export async function prerender(nitro: Nitro) {
         headers: { "x-nitro-prerender": encodedRoute },
       },
       fetcher: localFetch,
-      tries: nitro.options.prerender.tries ?? 3, // By default we try 3 times
+      retries: nitro.options.prerender.retries ?? 2, // By default we retry 2 times
       delay: nitro.options.prerender.retryDelay ?? 500,
     })) as Awaited<ReturnType<typeof fetch>>;
 

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -8,7 +8,7 @@ import mime from "mime";
 import { createNitro } from "./nitro";
 import { build } from "./build";
 import type { Nitro, NitroRouteRules, PrerenderRoute } from "./types";
-import { localFetchWithRetries, writeFile } from "./utils";
+import { fetchWithRetries, writeFile } from "./utils";
 import { compressPublicAssets } from "./compress";
 
 const allowedExtensions = new Set(["", ".json"]);
@@ -165,7 +165,7 @@ export async function prerender(nitro: Nitro) {
     // Fetch the route
     const encodedRoute = encodeURI(route);
 
-    const res = (await localFetchWithRetries({
+    const res = (await fetchWithRetries({
       url: withBase(encodedRoute, nitro.options.baseURL),
       options: {
         headers: { "x-nitro-prerender": encodedRoute },

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -172,8 +172,8 @@ export async function prerender(nitro: Nitro) {
       withBase(encodedRoute, nitro.options.baseURL),
       {
         headers: { "x-nitro-prerender": encodedRoute },
-        retry: nitro.options.prerender.retry ?? 3, // default is 3 retries
-        retryDelay: nitro.options.prerender.retryDelay ?? 500, // default is 500ms
+        retry: nitro.options.prerender.retry,
+        retryDelay: nitro.options.prerender.retryDelay,
       }
     );
     // Data will be removed as soon as written to the disk

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -172,7 +172,7 @@ export async function prerender(nitro: Nitro) {
       withBase(encodedRoute, nitro.options.baseURL),
       {
         headers: { "x-nitro-prerender": encodedRoute },
-        retry: nitro.options.prerender.retries ?? 3, // default is 3 retries
+        retry: nitro.options.prerender.retry ?? 3, // default is 3 retries
         retryDelay: nitro.options.prerender.retryDelay ?? 500, // default is 500ms
       }
     );

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -172,8 +172,8 @@ export async function prerender(nitro: Nitro) {
       withBase(encodedRoute, nitro.options.baseURL),
       {
         headers: { "x-nitro-prerender": encodedRoute },
-        retry: nitro.options.prerender.retries ?? 2, // default is 2 retries
-        retryDelay: nitro.options.prerender.retryDelay ?? 250, // default is 250ms
+        retry: nitro.options.prerender.retries ?? 3, // default is 3 retries
+        retryDelay: nitro.options.prerender.retryDelay ?? 500, // default is 500ms
       }
     );
     // Data will be removed as soon as written to the disk

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -298,7 +298,7 @@ export interface NitroOptions extends PresetOptions {
     ignore: string[];
     routes: string[];
     /** Amount of tries. Pass Infinity to retry indefinitely. */
-    tries: number;
+    retries: number;
     /** Delay between each retry in ms. */
     retryDelay: number;
   };

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -297,6 +297,10 @@ export interface NitroOptions extends PresetOptions {
     failOnError: boolean;
     ignore: string[];
     routes: string[];
+    /** Amount of tries. Pass Infinity to retry indefinitely. */
+    tries: number;
+    /** Delay between each retry in ms. */
+    retryDelay: number;
   };
 
   // Rollup

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -298,7 +298,7 @@ export interface NitroOptions extends PresetOptions {
     ignore: string[];
     routes: string[];
     /** Amount of retries. Pass Infinity to retry indefinitely. */
-    retries: number;
+    retry: number;
     /** Delay between each retry in ms. */
     retryDelay: number;
   };

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -297,7 +297,7 @@ export interface NitroOptions extends PresetOptions {
     failOnError: boolean;
     ignore: string[];
     routes: string[];
-    /** Amount of tries. Pass Infinity to retry indefinitely. */
+    /** Amount of retries. Pass Infinity to retry indefinitely. */
     retries: number;
     /** Delay between each retry in ms. */
     retryDelay: number;

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -297,9 +297,15 @@ export interface NitroOptions extends PresetOptions {
     failOnError: boolean;
     ignore: string[];
     routes: string[];
-    /** Amount of retries. Pass Infinity to retry indefinitely. */
+    /**
+     * Amount of retries. Pass Infinity to retry indefinitely.
+     * @default 3
+     */
     retry: number;
-    /** Delay between each retry in ms. */
+    /**
+     * Delay between each retry in ms.
+     * @default 500
+     */
     retryDelay: number;
   };
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -230,14 +230,3 @@ export function provideFallbackValues(obj: Record<string, any>) {
     }
   }
 }
-
-type FetchWithRetries = {
-  url: string;
-  options: RequestInit;
-  /** Will use globalThis.fetch by default. */
-  fetcher?: typeof fetch;
-  /** Amount of retries. Pass Infinity to retry indefinitely. */
-  retries?: number;
-  /** Delay between each retry in ms. */
-  delay?: number;
-};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -230,3 +230,41 @@ export function provideFallbackValues(obj: Record<string, any>) {
     }
   }
 }
+
+type FetchWithRetries = {
+  url: string;
+  options: RequestInit;
+  /** Will use globalThis.fetch by default. */
+  fetcher?: typeof fetch;
+  /** Amount of tries. Pass Infinity to retry indefinitely. */
+  tries?: number;
+  /** Delay between each retry in ms. */
+  delay?: number;
+};
+export async function localFetchWithRetries({
+  url,
+  options,
+  fetcher = fetch,
+  tries = 3,
+  delay = 1000,
+}: FetchWithRetries): Promise<Response> {
+  try {
+    const res = await fetcher(url, options);
+    if (!res.ok) {
+      throw new Error(res.statusText);
+    }
+    return res;
+  } catch (error) {
+    if (tries > 1) {
+      // wait 1s before retrying
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      return localFetchWithRetries({
+        url,
+        options,
+        fetcher,
+        tries: tries - 1,
+      });
+    }
+    throw error;
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -241,30 +241,3 @@ type FetchWithRetries = {
   /** Delay between each retry in ms. */
   delay?: number;
 };
-export async function fetchWithRetries({
-  url,
-  options,
-  fetcher = fetch,
-  retries = 3,
-  delay = 1000,
-}: FetchWithRetries): Promise<Response> {
-  try {
-    const res = await fetcher(url, options);
-    if (!res.ok) {
-      throw new Error(res.statusText);
-    }
-    return res;
-  } catch (error) {
-    if (retries > 0) {
-      // wait 1s before retrying
-      await new Promise((resolve) => setTimeout(resolve, delay));
-      return fetchWithRetries({
-        url,
-        options,
-        fetcher,
-        retries: retries - 1,
-      });
-    }
-    throw error;
-  }
-}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -231,7 +231,7 @@ export function provideFallbackValues(obj: Record<string, any>) {
   }
 }
 
-type FetchWithRetries = {
+type FetchWithNTries = {
   url: string;
   options: RequestInit;
   /** Will use globalThis.fetch by default. */
@@ -241,13 +241,13 @@ type FetchWithRetries = {
   /** Delay between each retry in ms. */
   delay?: number;
 };
-export async function localFetchWithRetries({
+export async function fetchWithNTries({
   url,
   options,
   fetcher = fetch,
   tries = 3,
   delay = 1000,
-}: FetchWithRetries): Promise<Response> {
+}: FetchWithNTries): Promise<Response> {
   try {
     const res = await fetcher(url, options);
     if (!res.ok) {
@@ -258,7 +258,7 @@ export async function localFetchWithRetries({
     if (tries > 1) {
       // wait 1s before retrying
       await new Promise((resolve) => setTimeout(resolve, delay));
-      return localFetchWithRetries({
+      return fetchWithNTries({
         url,
         options,
         fetcher,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -231,23 +231,23 @@ export function provideFallbackValues(obj: Record<string, any>) {
   }
 }
 
-type FetchWithNTries = {
+type FetchWithRetries = {
   url: string;
   options: RequestInit;
   /** Will use globalThis.fetch by default. */
   fetcher?: typeof fetch;
   /** Amount of tries. Pass Infinity to retry indefinitely. */
-  tries?: number;
+  retries?: number;
   /** Delay between each retry in ms. */
   delay?: number;
 };
-export async function fetchWithNTries({
+export async function fetchWithRetries({
   url,
   options,
   fetcher = fetch,
-  tries = 3,
+  retries = 3,
   delay = 1000,
-}: FetchWithNTries): Promise<Response> {
+}: FetchWithRetries): Promise<Response> {
   try {
     const res = await fetcher(url, options);
     if (!res.ok) {
@@ -255,14 +255,14 @@ export async function fetchWithNTries({
     }
     return res;
   } catch (error) {
-    if (tries > 1) {
+    if (retries > 0) {
       // wait 1s before retrying
       await new Promise((resolve) => setTimeout(resolve, delay));
-      return fetchWithNTries({
+      return fetchWithRetries({
         url,
         options,
         fetcher,
-        tries: tries - 1,
+        retries: retries - 1,
       });
     }
     throw error;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -236,7 +236,7 @@ type FetchWithRetries = {
   options: RequestInit;
   /** Will use globalThis.fetch by default. */
   fetcher?: typeof fetch;
-  /** Amount of tries. Pass Infinity to retry indefinitely. */
+  /** Amount of retries. Pass Infinity to retry indefinitely. */
   retries?: number;
   /** Delay between each retry in ms. */
   delay?: number;


### PR DESCRIPTION


### 🔗 Linked issue

Resolves https://github.com/unjs/nitro/issues/1469

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The prerender by default will fail if a page fails to render. This PR changes the default behaviour to 3 attempts before failure. 
This also adds 2 configuration options `nitro.options.prerender.tries` and `nitro.options.prerender.retryDelay` to change the behaviour. `tries` can be set to`Inifinity`if someones wants the pre-render to try endlessly.

For the default values, I've arbitrarily chose 2 retries and a 250ms retry delay.
### Additional thoughts

We could nest the options: `nitro.options.prerender.retry.attempts` and `nitro.options.prerender.retry.delay`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
