### PR TITLE
fix(prerender): call `prerender:route` before freeing up memory

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -234,10 +234,8 @@ export async function prerender(nitro: Nitro) {
       }
     }
 
-    if (!_route.skip) {
-      await nitro.hooks.callHook("prerender:route", _route);
-      nitro.logger.log(formatPrerenderRoute(_route));
-    }
+    await nitro.hooks.callHook("prerender:route", _route);
+    nitro.logger.log(formatPrerenderRoute(_route));
 
     // Free memory
     dataBuff = undefined;

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -208,6 +208,8 @@ export async function prerender(nitro: Nitro) {
 
     // Check if route skipped or has errors
     if (_route.skip || _route.error) {
+      await nitro.hooks.callHook("prerender:route", _route);
+      nitro.logger.log(formatPrerenderRoute(_route));
       return _route;
     }
 

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -232,7 +232,13 @@ export async function prerender(nitro: Nitro) {
       }
     }
 
-    dataBuff = undefined; // Free memory
+    if (!_route.skip) {
+      await nitro.hooks.callHook("prerender:route", _route);
+      nitro.logger.log(formatPrerenderRoute(_route));
+    }
+
+    // Free memory
+    dataBuff = undefined;
 
     return _route;
   };
@@ -243,20 +249,7 @@ export async function prerender(nitro: Nitro) {
       : `Prerendering ${routes.size} routes`
   );
 
-  async function processRoute(route: string) {
-    const _route = await generateRoute(route).catch(
-      (error) => ({ route, error }) as PrerenderGenerateRoute
-    );
-
-    if (!_route || _route.skip) {
-      return;
-    }
-
-    await nitro.hooks.callHook("prerender:route", _route);
-    nitro.logger.log(formatPrerenderRoute(_route));
-  }
-
-  await runParallel(routes, processRoute, {
+  await runParallel(routes, generateRoute, {
     concurrency: nitro.options.prerender.concurrency,
     interval: nitro.options.prerender.interval,
   });
@@ -295,9 +288,11 @@ async function runParallel<T>(
     }
 
     inputs.delete(route);
-    const task = new Promise((resolve) =>
-      setTimeout(resolve, opts.interval)
-    ).then(() => cb(route));
+    const task = new Promise((resolve) => setTimeout(resolve, opts.interval))
+      .then(() => cb(route))
+      .catch((error) => {
+        console.error(error);
+      });
 
     tasks.add(task);
     return task.then(() => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

[<!-- Please ensure there is an open issue and mention its number as #123 -->](https://github.com/unjs/nitro/pull/1536)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With #1536, we are freeing up route contents from memory but this was causing `prender:route` to lose access to the route contents.

This PR fixes this by fixing the ordering and calling the hook directly inside `generateRoute` before freeing up memory and also simplifying the code. (previously we were wrongly catching _unhandled internal errors_ as route errors now it uses simple console log to only avoid hiding edge cases with internal nitro bugs)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
