### PR TITLE
fix(externals): increase score for npm package name patterns to avoid breaking changes

### DIFF
--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -536,6 +536,13 @@ export function normalizeMatcher(input: string | RegExp | Matcher): Matcher {
       return id.startsWith(pattern) || idWithoutNodeModules.startsWith(pattern);
     }) as Matcher;
     matcher.score = input.length;
+
+    // Increase score for npm package names to avoid breaking changes
+    // TODO: Remove in next major version
+    if (!isAbsolute(input) && input[0] !== ".") {
+      matcher.score += 1000;
+    }
+
     Object.defineProperty(matcher, "name", { value: `match(${pattern})` });
     return matcher;
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

#1429, https://github.com/nuxt/nuxt/pull/22515

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR improves the scoring system for include/exclude patterns introduce in #1429 by giving a higher score to package names (nonabsolute paths without).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
