### PR TITLE
chore(vercel): make experimental `supportsResponseStreaming` opt-in

### DIFF
--- a/docs/content/2.deploy/providers/vercel.md
+++ b/docs/content/2.deploy/providers/vercel.md
@@ -21,6 +21,33 @@ After your project has been imported and deployed, all subsequent pushes to bran
 
 Learn more about Vercel’s [Git Integration](https://vercel.com/docs/concepts/git).
 
+## Experimental Streaming Support
+
+In order to leverage Streaming support in vercel functions, you have to enable `supportsResponseStreaming` flag:
+
+::code-group
+```ts [nitro.config.ts]
+export default defineNitroConfig({
+  vercel: {
+    functions: {
+      supportsResponseStreaming: true
+    }
+  }
+})
+```
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  nitro: {
+    vercel: {
+      functions: {
+        supportsResponseStreaming: true
+      }
+    }
+  }
+})
+```
+::
+
 ## Vercel Edge Functions
 
 **Preset:** `vercel_edge` ([switch to this preset](/deploy/#changing-the-deployment-preset))

--- a/playground/nitro.config.ts
+++ b/playground/nitro.config.ts
@@ -1,1 +1,7 @@
-export default defineNitroConfig({});
+export default defineNitroConfig({
+  vercel: {
+    functions: {
+      supportsResponseStreaming: true,
+    },
+  },
+});

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -44,7 +44,8 @@ export const vercel = defineNitroPreset({
         handler: "index.mjs",
         launcherType: "Nodejs",
         shouldAddHelpers: false,
-        supportsResponseStreaming: true,
+        // TODO: Enable as soon as we have a green light from Vercel team!
+        supportsResponseStreaming: false,
         ...nitro.options.vercel?.functions,
       };
       await writeFile(


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

#1505, #1514

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR makes the change in #1514 (unreleased) opt-in as per requested by the Vercel team that they might make some platform changes

> the team have reasons for not enabling supportsResponseStreaming by default for now (ongoing infra work) but there’s no problem encouraging users to enable it themselves.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
