### PR TITLE
fix: remove non-standard `module` export condition

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -498,7 +498,7 @@ function _resolveExportConditions(
   }
 
   // 4. Add default conditions
-  resolvedConditions.push("import", "module", "default");
+  resolvedConditions.push("import", "require", "default");
 
   // Dedup with preserving order
   return resolvedConditions.filter(

--- a/src/options.ts
+++ b/src/options.ts
@@ -498,7 +498,7 @@ function _resolveExportConditions(
   }
 
   // 4. Add default conditions
-  resolvedConditions.push("import", "require", "default");
+  resolvedConditions.push("import", "default");
 
   // Dedup with preserving order
   return resolvedConditions.filter(

--- a/src/presets/bun.ts
+++ b/src/presets/bun.ts
@@ -1,11 +1,10 @@
-import { resolvePathSync } from "mlly";
 import { defineNitroPreset } from "../preset";
 
 export const bun = defineNitroPreset({
   extends: "node-server",
   entry: "#internal/nitro/entries/bun",
   // https://bun.sh/docs/runtime/modules#resolution
-  exportConditions: ["bun", "worker", "node", "require", "import", "default"],
+  exportConditions: ["bun", "worker", "node", "import", "default"],
   commands: {
     preview: "bun run ./server/index.mjs",
   },

--- a/src/presets/bun.ts
+++ b/src/presets/bun.ts
@@ -5,7 +5,7 @@ export const bun = defineNitroPreset({
   extends: "node-server",
   entry: "#internal/nitro/entries/bun",
   // https://bun.sh/docs/runtime/modules#resolution
-  exportConditions: ["bun", "worker", "module", "node", "default", "browser"],
+  exportConditions: ["bun", "worker", "node", "require", "import", "default"],
   commands: {
     preview: "bun run ./server/index.mjs",
   },

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -356,9 +356,9 @@ export const plugins = [
             conditions: [
               "default",
               nitro.options.dev ? "development" : "production",
-              "module",
               "node",
               "import",
+              "require",
             ],
           }).catch(() => null);
           if (_resolved) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves #1558

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`module` is a non-standard export condition not supported by Node.js or any runtimes which was previously used as a top-level property in order to help bundlers pick the esm-like/browser builds. 

We disabled [top level `module` field long before](https://github.com/unjs/nitro/blob/7fa84084dc2531d8274d0bb035d4f4977428311c/src/rollup/config.ts#L425) because of this externals, new resolution conditions in #1401 added it back and makes issues with packages such as `ts-lib` and `@sanity/client` that are (wrongly!) using AND preferring this export condition over `import.

I also updated Bun conditions. Checking their docs, it seems they recently made same decition.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
