### PR TITLE
fix(externals): trace externals with their commonjs / esm status

### DIFF
--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -188,7 +188,6 @@ export function externals(opts: NodeExternalsOptions): Plugin {
 
       // Trace used files using nft
       const _fileTrace = await nodeFileTrace([...trackedExternals], {
-        conditions: opts.exportConditions,
         ...opts.traceOptions,
       });
 

--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -188,6 +188,10 @@ export function externals(opts: NodeExternalsOptions): Plugin {
 
       // Trace used files using nft
       const _fileTrace = await nodeFileTrace([...trackedExternals], {
+        // https://github.com/unjs/nitro/pull/1562
+        conditions: opts.exportConditions.filter(
+          (c) => !["require", "import", "default"].includes(c)
+        ),
         ...opts.traceOptions,
       });
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves https://github.com/unjs/nitro/issues/1558#issuecomment-1673919094

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Reproduction: https://stackblitz.com/edit/github-kkcfd3?file=package.json


vercel/nft smartly applies `import` OR `require` conditions based on the parent file. By overriding (giving both import and require conditions) we were allowing nft to resolve as ESM even for CommonJS modules.

<img width="631" alt="image" src="https://github.com/unjs/nitro/assets/5158436/951178a6-3207-4528-88f2-4780f3d3eeab">


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
