### PR TITLE
fix: use relative paths in generated tsconfig

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -294,6 +294,21 @@ declare module 'nitropack' {
           : [join(relativeWithDot(tsconfigDir, nitro.options.srcDir), "**/*")]),
       ],
     });
+
+    for (const alias in tsConfig.compilerOptions!.paths) {
+      const paths = tsConfig.compilerOptions!.paths[alias]
+      tsConfig.compilerOptions!.paths[alias] = await Promise.all(paths.map(async (path: string) => {
+        if (!isAbsolute(path)) { return path }
+        const stats = await fsp.stat(path).catch(() => null /* file does not exist */)
+        return relativeWithDot(tsconfigDir, stats?.isFile() ? path.replace(/(?<=\w)\.\w+$/g, '') /* remove extension */ : path)
+      }))
+    }
+
+    tsConfig.include = [...new Set(tsConfig.include.map(p => isAbsolute(p) ? relativeWithDot(tsconfigDir, p) : p))]
+    if (tsConfig.exclude) {
+      tsConfig.exclude = [...new Set(tsConfig.exclude!.map(p => isAbsolute(p) ? relativeWithDot(tsconfigDir, p) : p))]
+    }
+
     buildFiles.push({
       path: tsConfigPath,
       contents: JSON.stringify(tsConfig, null, 2),

--- a/src/build.ts
+++ b/src/build.ts
@@ -296,17 +296,40 @@ declare module 'nitropack' {
     });
 
     for (const alias in tsConfig.compilerOptions!.paths) {
-      const paths = tsConfig.compilerOptions!.paths[alias]
-      tsConfig.compilerOptions!.paths[alias] = await Promise.all(paths.map(async (path: string) => {
-        if (!isAbsolute(path)) { return path }
-        const stats = await fsp.stat(path).catch(() => null /* file does not exist */)
-        return relativeWithDot(tsconfigDir, stats?.isFile() ? path.replace(/(?<=\w)\.\w+$/g, '') /* remove extension */ : path)
-      }))
+      const paths = tsConfig.compilerOptions!.paths[alias];
+      tsConfig.compilerOptions!.paths[alias] = await Promise.all(
+        paths.map(async (path: string) => {
+          if (!isAbsolute(path)) {
+            return path;
+          }
+          const stats = await fsp
+            .stat(path)
+            .catch(() => null /* file does not exist */);
+          return relativeWithDot(
+            tsconfigDir,
+            stats?.isFile()
+              ? path.replace(/(?<=\w)\.\w+$/g, "") /* remove extension */
+              : path
+          );
+        })
+      );
     }
 
-    tsConfig.include = [...new Set(tsConfig.include.map(p => isAbsolute(p) ? relativeWithDot(tsconfigDir, p) : p))]
+    tsConfig.include = [
+      ...new Set(
+        tsConfig.include.map((p) =>
+          isAbsolute(p) ? relativeWithDot(tsconfigDir, p) : p
+        )
+      ),
+    ];
     if (tsConfig.exclude) {
-      tsConfig.exclude = [...new Set(tsConfig.exclude!.map(p => isAbsolute(p) ? relativeWithDot(tsconfigDir, p) : p))]
+      tsConfig.exclude = [
+        ...new Set(
+          tsConfig.exclude!.map((p) =>
+            isAbsolute(p) ? relativeWithDot(tsconfigDir, p) : p
+          )
+        ),
+      ];
     }
 
     buildFiles.push({


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves https://github.com/unjs/nitro/issues/1560

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR uses relative paths within tsconfig paths properties, normalising whatever is provided in paths/include/exclude.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
