### PR TITLE
fix: don't use `_originalPath`

### DIFF
--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -207,7 +207,7 @@ export function defineCachedEventHandler<T = any>(
         return escapeKey(customKey);
       }
       // Auto-generated key
-      const _path = event._originalPath || event.path;
+      const _path = event.path;
       const _pathname =
         escapeKey(decodeURI(parseURL(_path).pathname)).slice(0, 16) || "index";
       const _hashedPath = `${_pathname}.${hash(_path)}`;


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Dropped in https://github.com/unjs/h3/pull/506

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I think caching on `path` probably makes sense but we could also use `event.node.req.originalUrl || event.node.req.url ||` to match current behaviour.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
