### PR TITLE
fix: use relative source map paths and add test 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - run: pnpm build
       - run: pnpm vitest --coverage
         env:
-          NODE_OPTIONS: --experimental-vm-modules
+          NODE_OPTIONS: --experimental-vm-modules --enable-source-maps
       - uses: codecov/codecov-action@v3
       - name: Release Edge
         if: |

--- a/package.json
+++ b/package.json
@@ -36,14 +36,14 @@
     "dev:start": "node playground/.output/server/index.mjs",
     "lint": "eslint --cache --ext .ts,.mjs,.cjs . && prettier -c src",
     "lint:fix": "eslint --cache --fix --ext .ts,.mjs,.cjs . && prettier --write -c src",
-    "nitro": "jiti ./src/cli/cli.ts",
+    "nitro": "NODE_OPTIONS=\"--enable-source-maps\" jiti ./src/cli/cli.ts",
     "prepack": "pnpm build",
     "release": "pnpm test && pnpm build && changelogen --release && pnpm publish && git push --follow-tags",
     "stub": "unbuild --stub",
     "test": "pnpm lint && pnpm vitest-es run --silent",
     "test:fixture:types": "pnpm stub && jiti ./test/scripts/gen-fixture-types.ts && cd test/fixture && tsc --noEmit",
     "test:types": "tsc --noEmit && pnpm test:fixture:types",
-    "vitest-es": "NODE_OPTIONS=--experimental-vm-modules vitest"
+    "vitest-es": "NODE_OPTIONS=\"--enable-source-maps --experimental-vm-modules\" vitest"
   },
   "resolutions": {
     "nitropack": "link:.",

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -110,21 +110,6 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
       sourcemapIgnoreList(relativePath, sourcemapPath) {
         return relativePath.includes("node_modules");
       },
-      sourcemapPathTransform(relativePath, sourcemapPath) {
-        const sourcemapDir = dirname(sourcemapPath);
-        const sourcePath = resolve(sourcemapDir, relativePath);
-        if (nitro.options.dev) {
-          return sourcePath;
-        }
-        if (sourcePath.includes("node_modules/")) {
-          return join(
-            relative(sourcemapDir, nitro.options.output.serverDir),
-            "node_modules",
-            sourcePath.split("node_modules/").pop()
-          );
-        }
-        return relativePath;
-      },
     },
     external: env.external,
     // https://github.com/rollup/rollup/pull/4021#issuecomment-809985618

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -111,12 +111,17 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
         return relativePath.includes("node_modules");
       },
       sourcemapPathTransform(relativePath, sourcemapPath) {
-        const sourcePath = resolve(dirname(sourcemapPath), relativePath);
+        const sourcemapDir = dirname(sourcemapPath);
+        const sourcePath = resolve(sourcemapDir, relativePath);
         if (nitro.options.dev) {
           return sourcePath;
         }
         if (sourcePath.includes("node_modules/")) {
-          return `node_modules/${sourcePath.split("node_modules/").pop()}`;
+          return join(
+            relative(sourcemapDir, nitro.options.output.serverDir),
+            "node_modules",
+            sourcePath.split("node_modules/").pop()
+          );
         }
         return relativePath;
       },

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -13,7 +13,7 @@ import { isWindows } from "std-env";
 import { visualizer } from "rollup-plugin-visualizer";
 import * as unenv from "unenv";
 import type { Preset } from "unenv";
-import { sanitizeFilePath, resolvePath } from "mlly";
+import { sanitizeFilePath, resolvePath, parseNodeModulePath } from "mlly";
 import unimportPlugin from "unimport/unplugin";
 import { hash } from "ohash";
 import type { Nitro, NitroStaticBuildFlags } from "../types";
@@ -111,8 +111,14 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
         return relativePath.includes("node_modules");
       },
       sourcemapPathTransform(relativePath, sourcemapPath) {
-        // TODO: Avoid absolute
-        return resolve(dirname(sourcemapPath), relativePath);
+        const sourcePath = resolve(dirname(sourcemapPath), relativePath);
+        if (nitro.options.dev) {
+          return sourcePath;
+        }
+        if (sourcePath.includes("node_modules/")) {
+          return `node_modules/${sourcePath.split("node_modules/").pop()}`;
+        }
+        return relativePath;
       },
     },
     external: env.external,

--- a/test/fixture/routes/error-stack.ts
+++ b/test/fixture/routes/error-stack.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line require-await
+export default eventHandler(async (event) => {
+  return {
+    stack: new Error("testing error").stack.split("\n"),
+  };
+});

--- a/test/fixture/routes/error-stack.ts
+++ b/test/fixture/routes/error-stack.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line require-await
 export default eventHandler(async (event) => {
   return {
-    stack: new Error("testing error").stack,
+    stack: new Error("testing error").stack.replace(/\\/g, "/"),
   };
 });

--- a/test/fixture/routes/error-stack.ts
+++ b/test/fixture/routes/error-stack.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line require-await
 export default eventHandler(async (event) => {
   return {
-    stack: new Error("testing error").stack.split("\n"),
+    stack: new Error("testing error").stack,
   };
 });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -533,6 +533,11 @@ export function testNitro(
       );
       expect(allErrorMessages).to.includes("Service Unavailable");
     });
+
+    it.skipIf(!ctx.nitro.options.node)("sourcemap works", async () => {
+      const { data } = await callHandler({ url: "/error-stack" });
+      expect(data.stack[1]).toMatch("test/fixture/routes/error-stack.ts:4:1");
+    });
   });
 
   describe("async context", () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -534,7 +534,9 @@ export function testNitro(
       expect(allErrorMessages).to.includes("Service Unavailable");
     });
 
-    it.skipIf(!ctx.nitro.options.node)("sourcemap works", async () => {
+    it.skipIf(
+      !ctx.nitro.options.node || ctx.preset === "bun" /* TODO: Investigate */
+    )("sourcemap works", async () => {
       const { data } = await callHandler({ url: "/error-stack" });
       expect(data.stack[1]).toMatch("test/fixture/routes/error-stack.ts:4:1");
     });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -538,7 +538,7 @@ export function testNitro(
       !ctx.nitro.options.node || ctx.preset === "bun" /* TODO: Investigate */
     )("sourcemap works", async () => {
       const { data } = await callHandler({ url: "/error-stack" });
-      expect(data.stack[1]).toMatch("test/fixture/routes/error-stack.ts:4:1");
+      expect(data.stack).toMatch("test/fixture/routes/error-stack.ts:4:1");
     });
   });
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, we were always generating sourcemaps with absolute paths.

This PR makes nitro to follow default rollup behavior (generating relating sourcemap paths). This makes them portable (running in production assuming `.output` is adjustant to the same expected source structure and also in development mode.

It is worth to note that, we need `NODE_OPTIONS=--enable-source-maps` flag to lerage sourcemaps (documentation to be improved).

I have added a small test to make sure sourcemap works.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
