### PR TITLE
fix: use relative type path to nitro #internal/nitro

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -122,7 +122,7 @@ export async function writeTypes(nitro: Nitro) {
     // TODO: fully resolve utils exported from `#imports`
     autoImportExports = await nitro.unimport
       .toExports(typesDir)
-      .then((r) => r.replace(/#internal\/nitro/g, runtimeDir));
+      .then((r) => r.replace(/#internal\/nitro/g, relative(typesDir, runtimeDir)));
 
     const resolvedImportPathMap = new Map<string, string>();
     const imports = await nitro.unimport

--- a/src/build.ts
+++ b/src/build.ts
@@ -122,7 +122,9 @@ export async function writeTypes(nitro: Nitro) {
     // TODO: fully resolve utils exported from `#imports`
     autoImportExports = await nitro.unimport
       .toExports(typesDir)
-      .then((r) => r.replace(/#internal\/nitro/g, relative(typesDir, runtimeDir)));
+      .then((r) =>
+        r.replace(/#internal\/nitro/g, relative(typesDir, runtimeDir))
+      );
 
     const resolvedImportPathMap = new Map<string, string>();
     const imports = await nitro.unimport


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/unjs/nitro/issues/1560

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This uses relative path for `#internal/nitro` replacement in `nitro-types.d.ts`

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
