### PR TITLE
fix(pkg): remove node 14 from supported `engines`

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
   },
   "packageManager": "pnpm@8.6.12",
   "engines": {
-    "node": "^^16.11.0 || >=17.0.0"
+    "node": "^16.11.0 || >=17.0.0"
   },
   "pnpm": {
     "peerDependencyRules": {

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
   },
   "packageManager": "pnpm@8.6.12",
   "engines": {
-    "node": "^14.16.0 || ^16.11.0 || >=17.0.0"
+    "node": "^^16.11.0 || >=17.0.0"
   },
   "pnpm": {
     "peerDependencyRules": {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

closes #1583

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Node.js 14 is not supported for Nitro build time anymore installations can be broken with ih.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
