### PR TITLE
feat: preserve prerendered asset `content-type` header

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -225,6 +225,7 @@ export async function prerender(nitro: Nitro) {
     // Allow hooking before generate
     await nitro.hooks.callHook("prerender:generate", _route, nitro);
     if (_route.contentType !== inferredContentType) {
+      nitro._prerenderMeta[_route.fileName] ||= {}
       nitro._prerenderMeta[_route.fileName].contentType = _route.contentType;
     }
 

--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -40,7 +40,7 @@ export function publicAssets(nitro: Nitro): Plugin {
           }
 
           assets[assetId] = {
-            type: mimeType,
+            type: nitro._prerenderMeta?.[id]?.contentType || mimeType,
             encoding,
             etag,
             mtime: stat.mtime.toJSON(),

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -60,6 +60,7 @@ export interface Nitro {
 
   /* @internal */
   _prerenderedRoutes?: PrerenderRoute[];
+  _prerenderMeta?: Record<string, { contentType?: string }>;
 }
 
 export interface PrerenderRoute {
@@ -70,6 +71,7 @@ export interface PrerenderRoute {
   error?: Error & { statusCode: number; statusMessage: string };
   generateTimeMS?: number;
   skip?: boolean;
+  contentType?: string;
 }
 
 /** @deprecated Internal type will be removed in future versions */


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/unjs/nitro/issues/1586

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This preserves `content-type` header and allows user overrides. We only store metadata if the content type differs from the one we would infer in the public-assets plugin.

We might in future support inferring more things, perhaps caching headers?

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
