### PR TITLE
fix(vercel,netlify): don't deprecate `swr` when `cache: false`

### DIFF
--- a/src/presets/netlify.ts
+++ b/src/presets/netlify.ts
@@ -221,11 +221,12 @@ function deprecateSWR(nitro: Nitro) {
     }
     if (_hasProp(value, "static")) {
       value.isr = !(value as { static: boolean }).static;
+      hasLegacyOptions = true;
     }
     if (value && value.cache && _hasProp(value.cache, "swr")) {
       value.isr = value.cache.swr;
+      hasLegacyOptions = true;
     }
-    hasLegacyOptions = hasLegacyOptions || _hasProp(value, "isr");
   }
   if (hasLegacyOptions) {
     console.warn(

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -278,11 +278,12 @@ function deprecateSWR(nitro: Nitro) {
     }
     if (_hasProp(value, "static")) {
       value.isr = !(value as { static: boolean }).static;
+      hasLegacyOptions = true;
     }
     if (value.cache && _hasProp(value.cache, "swr")) {
       value.isr = value.cache.swr;
+      hasLegacyOptions = true;
     }
-    hasLegacyOptions = hasLegacyOptions || _hasProp(value, "isr");
   }
   if (hasLegacyOptions) {
     console.warn(


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/22699
resolves https://github.com/unjs/nitro/issues/1602

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Wrongly we were warning about legacy use of `swr` when `cache: false`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
