### PR TITLE
fix(build): workaround bun's difference in `function.toString()`

### DIFF
--- a/src/rollup/plugins/server-assets.ts
+++ b/src/rollup/plugins/server-assets.ts
@@ -97,7 +97,7 @@ const _assets = {\n${Object.entries(assets)
     )
     .join(",\n")}\n}
 
-${normalizeKey.toString()}
+const normalizeKey = ${normalizeKey.toString()}
 
 export const assets = {
   getKeys() {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Closes https://github.com/oven-sh/bun/issues/3793

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Bun does not always return a perfectly accurate string for `Function.prototype.toString`, so `normalizeKey` converted to a string will return:
```ts
function(key) {
  ...code..
}
```
In Node:
```ts
function normalizeKey(key) {
  ...code..
}
```

Nitro inlines this specific function into a generated source file, which will causes syntax error when building a Nitro project within the Bun runtime.

### 📝 Checklist

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
