### PR TITLE
refactor(firebase): update generated `package.json` 

### DIFF
--- a/src/presets/firebase.ts
+++ b/src/presets/firebase.ts
@@ -19,8 +19,7 @@ export const firebase = defineNitroPreset({
       await writeFirebaseConfig(nitro);
       await updatePackageJSON(nitro);
     },
-    "rollup:before": (nitro, rollupConfig) => {
-      // Determine firebase generation and bundled app config
+    "rollup:before": (nitro) => {
       const _gen = nitro.options.firebase?.gen as unknown;
       if (!_gen || _gen === "default") {
         nitro.logger.warn(
@@ -64,7 +63,6 @@ async function writeFirebaseConfig(nitro: Nitro) {
 async function updatePackageJSON(nitro: Nitro) {
   const packageJSONPath = join(nitro.options.output.serverDir, "package.json");
   const packageJSON = await readPackageJSON(packageJSONPath);
-  console.log("BBBB");
   await writePackageJSON(packageJSONPath, {
     ...packageJSON,
     main: "index.mjs",

--- a/src/presets/firebase.ts
+++ b/src/presets/firebase.ts
@@ -1,7 +1,5 @@
-import { createRequire } from "node:module";
 import { existsSync } from "node:fs";
 import { join, relative, resolve } from "pathe";
-import { globby } from "globby";
 import { readPackageJSON } from "pkg-types";
 import { writeFile } from "../utils";
 import { defineNitroPreset } from "../preset";
@@ -14,13 +12,13 @@ export const firebase = defineNitroPreset({
   },
   firebase: {
     // we need this defined here so it's picked up by the template in firebase's entry
-    gen: (process.env.NITRO_FIREBASE_GEN || "default") as any,
+    gen: (Number.parseInt(process.env.NITRO_FIREBASE_GEN) || "default") as any,
   },
   hooks: {
-    async compiled(ctx) {
-      await writeRoutes(ctx);
+    async compiled(nitro) {
+      await writeFirebaseConfig(nitro);
+      await updatePackageJSON(nitro);
     },
-
     "rollup:before": (nitro) => {
       const _gen = nitro.options.firebase?.gen as unknown;
       if (!_gen || _gen === "default") {
@@ -36,64 +34,50 @@ export const firebase = defineNitroPreset({
   },
 });
 
-async function writeRoutes(nitro: Nitro) {
-  if (!existsSync(join(nitro.options.rootDir, "firebase.json"))) {
-    const firebase = {
-      functions: {
-        source: relative(nitro.options.rootDir, nitro.options.output.serverDir),
-      },
-      hosting: [
-        {
-          site: "<your_project_id>",
-          public: relative(
-            nitro.options.rootDir,
-            nitro.options.output.publicDir
-          ),
-          cleanUrls: true,
-          rewrites: [
-            {
-              source: "**",
-              function: "server",
-            },
-          ],
-        },
-      ],
-    };
-    await writeFile(
-      resolve(nitro.options.rootDir, "firebase.json"),
-      JSON.stringify(firebase)
-    );
+async function writeFirebaseConfig(nitro: Nitro) {
+  const firebaseConfigPath = join(nitro.options.rootDir, "firebase.json");
+  if (existsSync(firebaseConfigPath)) {
+    return;
   }
-
-  const _require = createRequire(import.meta.url);
-
-  const jsons = await globby(
-    join(nitro.options.output.serverDir, "node_modules/**/package.json")
-  );
-  const prefixLength = `${nitro.options.output.serverDir}/node_modules/`.length;
-  const suffixLength = "/package.json".length;
-  // eslint-disable-next-line unicorn/no-array-reduce
-  const dependencies = jsons.reduce(
-    (obj, packageJson) => {
-      const dirname = packageJson.slice(prefixLength, -suffixLength);
-      if (!dirname.includes("node_modules")) {
-        obj[dirname] = _require(packageJson).version;
-      }
-      return obj;
+  const firebaseConfig = {
+    functions: {
+      source: relative(nitro.options.rootDir, nitro.options.output.serverDir),
     },
-    {} as Record<string, string>
-  );
+    hosting: [
+      {
+        site: "<your_project_id>",
+        public: relative(nitro.options.rootDir, nitro.options.output.publicDir),
+        cleanUrls: true,
+        rewrites: [
+          {
+            source: "**",
+            function: "server",
+          },
+        ],
+      },
+    ],
+  };
+  await writeFile(firebaseConfigPath, JSON.stringify(firebaseConfig, null, 2));
+}
 
+async function updatePackageJSON(nitro: Nitro) {
   // https://cloud.google.com/functions/docs/concepts/nodejs-runtime
   // const supportedNodeVersions = new Set(["20", "18", "16"]);
   const nodeVersion: string = nitro.options.firebase?.nodeVersion || "18";
 
-  const getPackageVersion = async (id) => {
-    const pkg = await readPackageJSON(id, {
-      url: nitro.options.nodeModulesDirs,
-    });
-    return pkg.version;
-  };
+  const packageJSONPath = join(nitro.options.rootDir, "package.json");
+
+  const packageJSON = await readPackageJSON(packageJSONPath);
+
+  delete packageJSON.bundledDependencies;
+
+  const newPackageJSON = {
+    ...packageJSON
+    private: true,
+    type: "module",
+    main: "./index.mjs",
+    bundledDependencies: undefined,
+  });
 
   await writeFile(
     resolve(nitro.options.output.serverDir, "package.json"),
@@ -102,12 +86,14 @@ async function writeRoutes(nitro: Nitro) {
         private: true,
         type: "module",
         main: "./index.mjs",
-        dependencies: {
-          "firebase-functions-test": "latest",
-          "firebase-admin": await getPackageVersion("firebase-admin"),
-          "firebase-functions": await getPackageVersion("firebase-functions"),
-          ...dependencies,
-        },
+        dependencies: Object.fromEntries(
+          Object.entries({
+            "firebase-functions-test": "latest",
+            "firebase-admin": await getPackageVersion("firebase-admin"),
+            "firebase-functions": await getPackageVersion("firebase-functions"),
+            ...dependencies,
+          }).sort(([a], [b]) => a[0].localeCompare(b[0]))
+        ),
         engines: { node: nodeVersion },
       },
       null,

--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -447,7 +447,6 @@ export function externals(opts: NodeExternalsOptions): Plugin {
       const userPkg = await readPackageJSON(
         opts.rootDir || process.cwd()
       ).catch(() => ({}) as PackageJson);
-
       await writePackageJSON(resolve(opts.outDir, "package.json"), {
         name: (userPkg.name || "server") + "-prod",
         version: userPkg.version || "0.0.0",

--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -447,6 +447,7 @@ export function externals(opts: NodeExternalsOptions): Plugin {
       const userPkg = await readPackageJSON(
         opts.rootDir || process.cwd()
       ).catch(() => ({}) as PackageJson);
+
       await writePackageJSON(resolve(opts.outDir, "package.json"), {
         name: (userPkg.name || "server") + "-prod",
         version: userPkg.version || "0.0.0",


### PR DESCRIPTION
- wip
- update

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Since the Nitro externals plugin is already fully aware of written dependencies, and with improvements in #1607, we can simply try to read the already written `package.json` and try to update it. (however, we might not the updates either in the future by adding `main` and `engines` fields by default to the generated `package.json`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
