### PR TITLE
perf: use local fetch for proxy route rules

### DIFF
--- a/src/runtime/route-rules.ts
+++ b/src/runtime/route-rules.ts
@@ -9,6 +9,7 @@ import defu from "defu";
 import { createRouter as createRadixRouter, toRouteMatcher } from "radix3";
 import { joinURL, withQuery, getQuery, withoutBase } from "ufo";
 import { useRuntimeConfig } from "./config";
+import { nitroApp } from "./app";
 import type { NitroRouteRules } from "nitropack";
 
 const config = useRuntimeConfig();
@@ -47,7 +48,7 @@ export function createRouteRulesHandler() {
         target = withQuery(target, query);
       }
       return proxyRequest(event, target, {
-        fetch: $fetch.raw as any,
+        fetch: nitroApp.localFetch,
         ...routeRules.proxy,
       });
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

closes #1605

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently we were using an additional layer of ofetch for handling proxy route rules (mainly to enable local fetch functionality). Using nitro app's fetch we can by pass this step.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
