### PR TITLE
fix(stormkit): properly send buffer responses

### DIFF
--- a/src/runtime/entries/stormkit.ts
+++ b/src/runtime/entries/stormkit.ts
@@ -3,7 +3,7 @@ import "#internal/nitro/virtual/polyfill";
 import { nitroApp } from "../app";
 import { normalizeLambdaOutgoingBody } from "#internal/nitro/utils.lambda";
 
-interface StormkitEvent {
+type StormkitEvent = {
   url: string; // e.g. /my/path, /my/path?with=query
   path: string;
   method: string;
@@ -11,45 +11,48 @@ interface StormkitEvent {
   query?: Record<string, Array<string>>;
   headers?: Record<string, string>;
   rawHeaders?: Array<string>;
-}
-
-export interface StormkitResult {
-  statusCode: number;
-  headers?: { [header: string]: boolean | number | string } | undefined;
-  body?: string | undefined;
-}
-
-export const handler: Handler<StormkitEvent, StormkitResult> = async function (
-  event,
-  context
-) {
-  const method = event.method || "get";
-
-  const r = await nitroApp.localCall({
-    event,
-    url: event.url,
-    context,
-    headers: event.headers, // TODO: Normalize headers
-    method,
-    query: event.query,
-    body: event.body,
-  });
-
-  // TODO: Handle cookies with lambda v1 or v2 ?
-  return {
-    statusCode: r.status,
-    headers: normalizeOutgoingHeaders(r.headers),
-    body: normalizeLambdaOutgoingBody(r.body, r.headers),
-  };
 };
+
+type StormkitResponse = {
+  headers?: Record<string, string>;
+  body?: string;
+  buffer?: string;
+  statusCode: number;
+  errorMessage?: string;
+  errorStack?: string;
+};
+
+export const handler: Handler<StormkitEvent, StormkitResponse> =
+  async function (event, context) {
+    const response = await nitroApp.localCall({
+      event,
+      url: event.url,
+      context,
+      headers: event.headers,
+      method: event.method || "GET",
+      query: event.query,
+      body: event.body,
+    });
+
+    const normalizedBody = normalizeLambdaOutgoingBody(
+      response.body,
+      response.headers
+    );
+
+    return <StormkitResponse>{
+      statusCode: response.status,
+      headers: normalizeOutgoingHeaders(response.headers),
+      [normalizedBody === response.body ? "body" : "buffer"]: normalizedBody,
+    };
+  };
 
 function normalizeOutgoingHeaders(
   headers: Record<string, number | string | string[] | undefined>
-) {
+): Record<string, string> {
   return Object.fromEntries(
     Object.entries(headers).map(([k, v]) => [
       k,
-      Array.isArray(v) ? v.join(",") : v!,
+      Array.isArray(v) ? v.join(",") : String(v),
     ])
   );
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Stormkit requires buffer responses to be stringified AND be sent via `buffer` field instead of `body`.

This PR also updates types to match the underlying struct and normalized header.

Happy deployment: https://nuxt-image-remote-ipx.stormkit.dev/

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
