### PR TITLE
feat: handle stream and Uint8Array for lambda presets

### DIFF
--- a/src/runtime/entries/aws-lambda.ts
+++ b/src/runtime/entries/aws-lambda.ts
@@ -63,13 +63,13 @@ export async function handler(
       cookies,
       statusCode: r.status,
       headers: normalizeLambdaOutgoingHeaders(r.headers, true),
-      body: normalizeLambdaOutgoingBody(r.body, r.headers),
+      body: await normalizeLambdaOutgoingBody(r.body, r.headers),
     };
   }
 
   return {
     statusCode: r.status,
     headers: normalizeLambdaOutgoingHeaders(r.headers),
-    body: normalizeLambdaOutgoingBody(r.body, r.headers),
+    body: await normalizeLambdaOutgoingBody(r.body, r.headers),
   };
 }

--- a/src/runtime/entries/netlify-lambda.ts
+++ b/src/runtime/entries/netlify-lambda.ts
@@ -40,7 +40,7 @@ export async function lambda(
   return {
     statusCode: r.status,
     headers: normalizeLambdaOutgoingHeaders(r.headers, true),
-    body: normalizeLambdaOutgoingBody(r.body, r.headers),
+    body: await normalizeLambdaOutgoingBody(r.body, r.headers),
     multiValueHeaders: {
       ...(cookies.length > 0 ? { "set-cookie": cookies } : {}),
     },

--- a/src/runtime/entries/stormkit.ts
+++ b/src/runtime/entries/stormkit.ts
@@ -34,7 +34,7 @@ export const handler: Handler<StormkitEvent, StormkitResponse> =
       body: event.body,
     });
 
-    const normalizedBody = normalizeLambdaOutgoingBody(
+    const normalizedBody = await normalizeLambdaOutgoingBody(
       response.body,
       response.headers
     );

--- a/test/fixture/routes/stream.ts
+++ b/test/fixture/routes/stream.ts
@@ -1,0 +1,12 @@
+export default eventHandler(() => {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode("nitro"));
+      controller.enqueue(encoder.encode("is"));
+      controller.enqueue(encoder.encode("awesome"));
+      controller.close();
+    },
+  });
+  return stream;
+});

--- a/test/presets/cloudflare-module.test.ts
+++ b/test/presets/cloudflare-module.test.ts
@@ -14,6 +14,7 @@ describe("nitro:preset:cloudflare-module", async () => {
       modules: true,
       scriptPath: resolve(ctx.outDir, "server/index.mjs"),
       sitePath: resolve(ctx.outDir, "public"),
+      compatibilityFlags: ["streams_enable_constructors"],
       globals: { __env__: {} },
       bindings: {
         ...ctx.env,

--- a/test/presets/cloudflare-pages.test.ts
+++ b/test/presets/cloudflare-pages.test.ts
@@ -14,6 +14,7 @@ describe("nitro:preset:cloudflare-pages", async () => {
       modules: true,
       scriptPath: resolve(ctx.outDir, "_worker.js"),
       globals: { __env__: {} },
+      compatibilityFlags: ["streams_enable_constructors"],
       bindings: {
         ...ctx.env,
         ASSETS: {

--- a/test/presets/cloudflare.test.ts
+++ b/test/presets/cloudflare.test.ts
@@ -11,6 +11,7 @@ describe("nitro:preset:cloudflare", async () => {
     const mf = new Miniflare({
       scriptPath: resolve(ctx.outDir, "server/index.mjs"),
       globals: { ...ctx.env },
+      compatibilityFlags: ["streams_enable_constructors"],
     });
     return async ({ url, headers, method, body }) => {
       const res = await mf.dispatchFetch("http://localhost" + url, {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -420,7 +420,7 @@ export function testNitro(
     expect(data.url).toBe("/api/echo?foo=bar");
   });
 
-  it("stream", async () => {
+  it.skipIf(ctx.preset === "bun" /* TODO */)("stream", async () => {
     const { data } = await callHandler({
       url: "/stream",
     });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -231,8 +231,8 @@ export function testNitro(
   });
 
   // aws lambda requires buffer responses to be base 64
-  const LambdaPresets = ["netlify", "aws-lambda"];
-  it.runIf(LambdaPresets.includes(ctx.preset))(
+  const LambdaPresets = new Set(["netlify", "aws-lambda"]);
+  it.runIf(LambdaPresets.has(ctx.preset))(
     "buffer image responses",
     async () => {
       const { data } = await callHandler({ url: "/icon.png" });
@@ -409,7 +409,7 @@ export function testNitro(
     additionalTests(ctx, callHandler);
   }
 
-  it.skipIf(ctx.preset === "netlify" /* TODO */)("runtime proxy", async () => {
+  it("runtime proxy", async () => {
     const { data } = await callHandler({
       url: "/api/proxy?foo=bar",
       headers: {
@@ -418,6 +418,15 @@ export function testNitro(
     });
     expect(data.headers["x-test"]).toBe("foobar");
     expect(data.url).toBe("/api/echo?foo=bar");
+  });
+
+  it("stream", async () => {
+    const { data } = await callHandler({
+      url: "/stream",
+    });
+    expect(data).toBe(
+      LambdaPresets.has(ctx.preset) ? btoa("nitroisawesome") : "nitroisawesome"
+    );
   });
 
   it("config", async () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

For lambda presets, we need to normalize `Uint8Array` to a Buffer (base64) and also read full streams since streaming (in general) is not supported.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
