### PR TITLE
fix: pass relative ignore paths when scanning public assets

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -55,7 +55,7 @@ export async function copyPublicAssets(nitro: Nitro) {
         dot: true,
         ignore: nitro.options.ignore
           .map((p) =>
-            p.startsWith("*")
+            p.startsWith("*") || p.startsWith("!*")
               ? p
               : relative(srcDir, resolve(nitro.options.srcDir, p))
           )

--- a/src/build.ts
+++ b/src/build.ts
@@ -53,7 +53,13 @@ export async function copyPublicAssets(nitro: Nitro) {
         cwd: srcDir,
         absolute: false,
         dot: true,
-        ignore: nitro.options.ignore,
+        ignore: nitro.options.ignore
+          .map((p) =>
+            p.startsWith("*")
+              ? p
+              : relative(srcDir, resolve(nitro.options.srcDir, p))
+          )
+          .filter((p) => !p.startsWith("../")),
       });
       await Promise.all(
         publicAssets.map(async (file) => {

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -32,7 +32,7 @@ export default defineNitroConfig({
       dir: "files",
     },
   ],
-  ignore: ["api/**/_*", "middleware/_ignored.ts", "routes/_*.ts", "_*.txt"],
+  ignore: ["api/**/_*", "middleware/_ignored.ts", "routes/_*.ts", "**/_*.txt"],
   appConfig: {
     "nitro-config": true,
     dynamic: "initial",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We now support ignoring public assets (https://github.com/unjs/nitro/pull/945) but at the moment we do not resolve/relativise paths, so an ignore pattern of `public/test.txt` would not match `test.txt` when scanning the `public/` directory. The issue is that it then becomes impossible to specify ignore patterns that _only_ apply in public directories, for example.

This is a **change in behaviour** but I think more intuitive.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
