### PR TITLE
fix: check if is obj before checking if is a event

### DIFF
--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -150,11 +150,13 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = unknown[]>(
     }
     const key = await (opts.getKey || getKey)(...args);
     const shouldInvalidateCache = opts.shouldInvalidateCache?.(...args);
+    const [firstArg] = args;
+    const firstArgIsEvent = firstArg && typeof firstArg === 'object' && isEvent(firstArg);
     const entry = await get(
       key,
       () => fn(...args),
       shouldInvalidateCache,
-      args[0] && isEvent(args[0]) ? args[0] : undefined
+      firstArgIsEvent ? firstArg : undefined
     );
     let value = entry.value;
     if (opts.transform) {

--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -151,7 +151,8 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = unknown[]>(
     const key = await (opts.getKey || getKey)(...args);
     const shouldInvalidateCache = opts.shouldInvalidateCache?.(...args);
     const [firstArg] = args;
-    const firstArgIsEvent = firstArg && typeof firstArg === 'object' && isEvent(firstArg);
+    const firstArgIsEvent =
+      firstArg && typeof firstArg === "object" && isEvent(firstArg);
     const entry = await get(
       key,
       () => fn(...args),


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### Issue

The problem appeared after updating from nuxt@3.6 -> 3.7

```
TypeError: Cannot use 'in' operator to search for '__is_event__' in 2
      at isEvent (....../node_modules/.pnpm/h3@1.8.0/node_modules/h3/dist/index.mjs:1419:25)
      at <anonymous>(....../node_modules/.pnpm/nitropack@2.6.1/node_modules/nitropack/dist/runtime/cache.mjs:88:18)
````

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
