### PR TITLE
fix(static): send immediate empty responses for 304 handling

### DIFF
--- a/src/runtime/static.ts
+++ b/src/runtime/static.ts
@@ -6,7 +6,6 @@ import {
   setResponseHeader,
   setResponseStatus,
   removeResponseHeader,
-  send,
 } from "h3";
 import {
   decodePath,
@@ -76,8 +75,7 @@ export default eventHandler((event) => {
   const ifNotMatch = getRequestHeader(event, "if-none-match") === asset.etag;
   if (ifNotMatch) {
     setResponseStatus(event, 304, "Not Modified");
-    send(event, "");
-    return;
+    return ""
   }
 
   const ifModifiedSinceH = getRequestHeader(event, "if-modified-since");
@@ -88,8 +86,7 @@ export default eventHandler((event) => {
     new Date(ifModifiedSinceH) >= mtimeDate
   ) {
     setResponseStatus(event, 304, "Not Modified");
-    send(event, "");
-    return;
+    return ""
   }
 
   if (asset.type && !getResponseHeader(event, "Content-Type")) {

--- a/src/runtime/static.ts
+++ b/src/runtime/static.ts
@@ -75,7 +75,7 @@ export default eventHandler((event) => {
   const ifNotMatch = getRequestHeader(event, "if-none-match") === asset.etag;
   if (ifNotMatch) {
     setResponseStatus(event, 304, "Not Modified");
-    return ""
+    return "";
   }
 
   const ifModifiedSinceH = getRequestHeader(event, "if-modified-since");
@@ -86,7 +86,7 @@ export default eventHandler((event) => {
     new Date(ifModifiedSinceH) >= mtimeDate
   ) {
     setResponseStatus(event, 304, "Not Modified");
-    return ""
+    return "";
   }
 
   if (asset.type && !getResponseHeader(event, "Content-Type")) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

#1638 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->

It just changes `send(event, "")` to `return ""` in `304`。

It seems to be a problem with [h3](https://github.com/unjs/h3), if it returns undefined it will automatically jump to the next middleware

<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
