### PR TITLE
fix: use new h3 generics for `defineCachedEventHandler`

### DIFF
--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -432,3 +432,5 @@ function cloneWithProxy<T extends object = any>(
     },
   });
 }
+
+export const cachedEventHandler = defineCachedEventHandler;

--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -194,6 +194,30 @@ export function defineCachedEventHandler<
   Response = EventHandlerResponse,
 >(
   handler: EventHandler<Request, Response>,
+  opts?: CachedEventHandlerOptions<Response>
+): EventHandler<Request, Response>;
+// TODO: remove when appropriate
+// This signature provides backwards compatibility with previous signature where first generic was return type
+export function defineCachedEventHandler<
+  Request = EventHandlerRequest,
+  Response = EventHandlerResponse,
+>(
+  handler: EventHandler<
+    Request extends EventHandlerRequest ? Request : EventHandlerRequest,
+    Request extends EventHandlerRequest ? Response : Request
+  >,
+  opts?: CachedEventHandlerOptions<
+    Request extends EventHandlerRequest ? Response : Request
+  >
+): EventHandler<
+  Request extends EventHandlerRequest ? Request : EventHandlerRequest,
+  Request extends EventHandlerRequest ? Response : Request
+>;
+export function defineCachedEventHandler<
+  Request extends EventHandlerRequest = EventHandlerRequest,
+  Response = EventHandlerResponse,
+>(
+  handler: EventHandler<Request, Response>,
   opts: CachedEventHandlerOptions<Response> = defaultCacheOptions
 ): EventHandler<Request, Response> {
   const variableHeaderNames = (opts.varies || [])
@@ -408,5 +432,3 @@ function cloneWithProxy<T extends object = any>(
     },
   });
 }
-
-export const cachedEventHandler = defineCachedEventHandler;

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -261,8 +261,7 @@ describe("defineNitroConfig", () => {
 async function fixture() {
   await Promise.resolve();
   return {
-    status: 200,
-    body: "Hello world",
+    message: "Hello world",
   };
 }
 
@@ -275,8 +274,24 @@ describe("defineCachedEventHandler", () => {
       EventHandler<
         EventHandlerRequest,
         Promise<{
-          status: number;
-          body: string;
+          message: string;
+        }>
+      >
+    >();
+  });
+  it("is backwards compatible with old generic signature", () => {
+    const a = defineCachedEventHandler<
+      Promise<{
+        message: string;
+      }>
+    >(fixture);
+    const b = defineEventHandler(fixture);
+    expectTypeOf(a).toEqualTypeOf(b);
+    expectTypeOf(b).toEqualTypeOf<
+      EventHandler<
+        EventHandlerRequest,
+        Promise<{
+          message: string;
         }>
       >
     >();

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -1,5 +1,6 @@
 import { expectTypeOf } from "expect-type";
 import { describe, it } from "vitest";
+import { EventHandler, EventHandlerRequest, defineEventHandler } from "h3";
 import { $Fetch } from "../..";
 import { defineNitroConfig } from "../../src/config";
 
@@ -254,5 +255,30 @@ describe("defineNitroConfig", () => {
         },
       },
     });
+  });
+});
+
+async function fixture() {
+  await Promise.resolve();
+  return {
+    status: 200,
+    body: "Hello world",
+  };
+}
+
+describe("defineCachedEventHandler", () => {
+  it("should infer return type", () => {
+    const a = defineCachedEventHandler(fixture);
+    const b = defineEventHandler(fixture);
+    expectTypeOf(a).toEqualTypeOf(b);
+    expectTypeOf(b).toEqualTypeOf<
+      EventHandler<
+        EventHandlerRequest,
+        Promise<{
+          status: number;
+          body: string;
+        }>
+      >
+    >();
   });
 });


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When updating h3 we missed out updating the generic types for `defineCachedEventHandler`. This PR implements it although note that this is not backwards compatible. (Happy to add an overload as we did in `h3` if we need to support previous generic pattern.)

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
