### PR TITLE
fix(aws-lambda, netlify): add `isBase64Encoded` response field

### DIFF
--- a/src/runtime/entries/aws-lambda.ts
+++ b/src/runtime/entries/aws-lambda.ts
@@ -69,9 +69,7 @@ export async function handler(
     };
   }
 
-  const outBody = await normalizeLambdaOutgoingBody(r.body, r.headers).then(
-    (r) => r
-  );
+  const outBody = await normalizeLambdaOutgoingBody(r.body, r.headers);
 
   return {
     statusCode: r.status,

--- a/src/runtime/entries/aws-lambda.ts
+++ b/src/runtime/entries/aws-lambda.ts
@@ -69,11 +69,14 @@ export async function handler(
     };
   }
 
+  const outBody = await normalizeLambdaOutgoingBody(r.body, r.headers).then(
+    (r) => r
+  )
+
   return {
     statusCode: r.status,
     headers: normalizeLambdaOutgoingHeaders(r.headers),
-    body: await normalizeLambdaOutgoingBody(r.body, r.headers).then(
-      (r) => r.body
-    ),
+    body: outBody.body,
+    isBase64Encoded: outBody.type === "binary"
   };
 }

--- a/src/runtime/entries/aws-lambda.ts
+++ b/src/runtime/entries/aws-lambda.ts
@@ -71,12 +71,12 @@ export async function handler(
 
   const outBody = await normalizeLambdaOutgoingBody(r.body, r.headers).then(
     (r) => r
-  )
+  );
 
   return {
     statusCode: r.status,
     headers: normalizeLambdaOutgoingHeaders(r.headers),
     body: outBody.body,
-    isBase64Encoded: outBody.type === "binary"
+    isBase64Encoded: outBody.type === "binary",
   };
 }

--- a/src/runtime/entries/netlify-lambda.ts
+++ b/src/runtime/entries/netlify-lambda.ts
@@ -36,13 +36,15 @@ export async function lambda(
   });
 
   const cookies = normalizeCookieHeader(String(r.headers["set-cookie"]));
+  const outBody = await normalizeLambdaOutgoingBody(r.body, r.headers).then(
+    (r) => r
+  )
 
   return {
     statusCode: r.status,
     headers: normalizeLambdaOutgoingHeaders(r.headers, true),
-    body: await normalizeLambdaOutgoingBody(r.body, r.headers).then(
-      (r) => r.body
-    ),
+    body: outBody.body,
+    isBase64Encoded: outBody.type === "binary",
     multiValueHeaders: {
       ...(cookies.length > 0 ? { "set-cookie": cookies } : {}),
     },

--- a/src/runtime/entries/netlify-lambda.ts
+++ b/src/runtime/entries/netlify-lambda.ts
@@ -38,7 +38,7 @@ export async function lambda(
   const cookies = normalizeCookieHeader(String(r.headers["set-cookie"]));
   const outBody = await normalizeLambdaOutgoingBody(r.body, r.headers).then(
     (r) => r
-  )
+  );
 
   return {
     statusCode: r.status,

--- a/src/runtime/entries/netlify-lambda.ts
+++ b/src/runtime/entries/netlify-lambda.ts
@@ -36,9 +36,7 @@ export async function lambda(
   });
 
   const cookies = normalizeCookieHeader(String(r.headers["set-cookie"]));
-  const outBody = await normalizeLambdaOutgoingBody(r.body, r.headers).then(
-    (r) => r
-  );
+  const outBody = await normalizeLambdaOutgoingBody(r.body, r.headers);
 
   return {
     statusCode: r.status,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

[#1274 PR](https://github.com/unjs/nitro/pull/1274)
[#22832 Nuxt](https://github.com/nuxt/nuxt/issues/22832)
[#852](https://github.com/unjs/nitro/issues/852)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

I added the `isBase64Encoded` option to allow Lambda to understand that the request is a base64 encoded document.

I complete the PR [#1274](https://github.com/unjs/nitro/pull/1274) to solve this problem.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
