### PR TITLE
fix: exclude typed body from `cachedEventHandler`

### DIFF
--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -195,11 +195,11 @@ export function defineCachedEventHandler<
 >(
   handler: EventHandler<Request, Response>,
   opts?: CachedEventHandlerOptions<Response>
-): EventHandler<Omit<Request, 'body'>, Response>;
+): EventHandler<Omit<Request, "body">, Response>;
 // TODO: remove when appropriate
 // This signature provides backwards compatibility with previous signature where first generic was return type
 export function defineCachedEventHandler<
-  Request =  Omit<EventHandlerRequest, 'body'>,
+  Request = Omit<EventHandlerRequest, "body">,
   Response = EventHandlerResponse,
 >(
   handler: EventHandler<

--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -195,11 +195,11 @@ export function defineCachedEventHandler<
 >(
   handler: EventHandler<Request, Response>,
   opts?: CachedEventHandlerOptions<Response>
-): EventHandler<Request, Response>;
+): EventHandler<Omit<Request, 'body'>, Response>;
 // TODO: remove when appropriate
 // This signature provides backwards compatibility with previous signature where first generic was return type
 export function defineCachedEventHandler<
-  Request = EventHandlerRequest,
+  Request =  Omit<EventHandlerRequest, 'body'>,
   Response = EventHandlerResponse,
 >(
   handler: EventHandler<

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -280,10 +280,15 @@ describe("defineCachedEventHandler", () => {
     >();
   });
   it("should not allow typed input body", () => {
-    const b = defineCachedEventHandler<{ body: string }, Promise<{ message: string }>>(fixture);
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    expectTypeOf(b).toEqualTypeOf<EventHandler<{}, Promise<{ message: string }>>>()
-  })
+    const b = defineCachedEventHandler<
+      { body: string },
+      Promise<{ message: string }>
+    >(fixture);
+    expectTypeOf(b).toEqualTypeOf<
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      EventHandler<{}, Promise<{ message: string }>>
+    >();
+  });
   it("is backwards compatible with old generic signature", () => {
     const a = defineCachedEventHandler<
       Promise<{

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -279,6 +279,11 @@ describe("defineCachedEventHandler", () => {
       >
     >();
   });
+  it("should not allow typed input body", () => {
+    const b = defineCachedEventHandler<{ body: string }, Promise<{ message: string }>>(fixture);
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    expectTypeOf(b).toEqualTypeOf<EventHandler<{}, Promise<{ message: string }>>>()
+  })
   it("is backwards compatible with old generic signature", () => {
     const a = defineCachedEventHandler<
       Promise<{


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/unjs/nitro/pull/1640#issuecomment-1694230209

closes #1646

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Quick improvement iterating on https://github.com/unjs/nitro/pull/1640. This will need to be improved when we add validator inference to `h3`'s event handler, and in future when headers might be added.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
