### PR TITLE
feat: add entry to build info

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -405,6 +405,7 @@ async function _build(nitro: Nitro, rollupConfig: RollupConfig) {
   const buildInfo = {
     date: new Date(),
     preset: nitro.options.preset,
+    entry: nitro.options.entry.split("/").pop(),
     commands: {
       preview: nitro.options.commands.preview,
       deploy: nitro.options.commands.deploy,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves #1650 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

While working on https://github.com/unjs/nitro/pull/1557, I noticed that for presets that can have multiple entries, like firebase, there's no straightforward way to identify which one has been used. This adds a reference to the preset used in the build info.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
