### PR TITLE
fix(firebase): apply region for gen2 deployments

### DIFF
--- a/src/runtime/entries/firebase-gen-2.ts
+++ b/src/runtime/entries/firebase-gen-2.ts
@@ -1,10 +1,17 @@
 import "#internal/nitro/virtual/polyfill";
+import { setGlobalOptions } from "firebase-functions/v2/options";
 import { onRequest } from "firebase-functions/v2/https";
 import { toNodeListener } from "h3";
 import { nitroApp } from "../app";
 import { useAppConfig } from "#internal/nitro";
 
 const firebaseConfig = useAppConfig().nitro.firebase;
+
+if (firebaseConfig.httpsOptions?.region) {
+  setGlobalOptions({
+    region: firebaseConfig.httpsOptions.region,
+  });
+}
 
 export const __firebaseServerFunctionName__ = onRequest(
   {


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #1655

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #1655

firebase functions gen2 with region specified can be deployed.

#### manual integration tests

Since there is no integrated test code that includes firebase deploy, I manually performed the following three tests.

1. have region and deploy to firebase.

```
export default defineNitroConfig({
  firebase: {
    gen: 2,
    nodeVersion: "18",
    httpsOptions: {
      region: "asia-northeast1",
      maxInstances: 3,
    },
  },
});
```

2. have no httpsOptions configuration and deploy to firebase.

```
export default defineNitroConfig({
  firebase: {
    gen: 2,
    nodeVersion: "18",
  },
});
```

3. have no region configuration and deploy to firebase.

```
export default defineNitroConfig({
  firebase: {
    gen: 2,
    nodeVersion: "18",
    httpsOptions: {
      maxInstances: 3,
    },
  },
});
```

These three tests passed.


### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
