### PR TITLE
doc: fix variable name for unix socket

### DIFF
--- a/docs/content/2.deploy/1.node.md
+++ b/docs/content/2.deploy/1.node.md
@@ -38,7 +38,7 @@ You can customize server behavior using following environment variables:
 
 - `NITRO_PORT` or `PORT` (defaults to `3000`)
 - `NITRO_HOST` or `HOST`
-- `NITRO_SOCKET` - if provided (a path to the desired socket file) the service will be served over the provided UNIX socket.
+- `NITRO_UNIX_SOCKET` - if provided (a path to the desired socket file) the service will be served over the provided UNIX socket.
 - `NITRO_SSL_CERT` and `NITRO_SSL_KEY` - if both are present, this will launch the server in HTTPS mode. In the vast majority of cases, this should not be used other than for testing, and the Nitro server should be run behind a reverse proxy like nginx or Cloudflare which terminates SSL.
 - `NITRO_SHUTDOWN` - Enables the graceful shutdown feature when set to `'true'`. If it's set to `'false'`, the graceful shutdown is bypassed to speed up the development process. Defaults to `'false'`.
 - `NITRO_SHUTDOWN_SIGNALS` - Allows you to specify which signals should be handled. Each signal should be separated with a space. Defaults to `'SIGINT SIGTERM'`.


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change


- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Changed the `NITRO_SOCKET` to `NITRO_UNIX_SOCKET` in the documentation since this is the name of the variable actually being used.