### PR TITLE
fix(aws-lambda,netlify-lambda):  binary body v2 and cookies v1

### DIFF
--- a/src/runtime/entries/aws-lambda.ts
+++ b/src/runtime/entries/aws-lambda.ts
@@ -55,26 +55,22 @@ export async function handler(
     body: event.body, // TODO: handle event.isBase64Encoded
   });
 
-  // Lambda v2 https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.v2
-  if ("cookies" in event || "rawPath" in event) {
-    const cookies = normalizeCookieHeader(r.headers["set-cookie"]);
-
-    return {
-      cookies,
-      statusCode: r.status,
-      headers: normalizeLambdaOutgoingHeaders(r.headers, true),
-      body: await normalizeLambdaOutgoingBody(r.body, r.headers).then(
-        (r) => r.body
-      ),
-    };
-  }
-
-  const outBody = await normalizeLambdaOutgoingBody(r.body, r.headers);
-
+  // ApiGateway v2 https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.v2
+  const isApiGwV2 = "cookies" in event || "rawPath" in event;
+  const { body, bodyType } = await normalizeLambdaOutgoingBody(
+    r.body,
+    r.headers
+  );
+  const cookies = normalizeCookieHeader(r.headers["set-cookie"]);
   return {
+    ...(cookies.length > 0 && {
+      ...(isApiGwV2
+        ? { cookies }
+        : { multiValueHeaders: { "set-cookie": cookies } }),
+    }),
     statusCode: r.status,
-    headers: normalizeLambdaOutgoingHeaders(r.headers),
-    body: outBody.body,
-    isBase64Encoded: outBody.type === "binary",
+    headers: normalizeLambdaOutgoingHeaders(r.headers, true),
+    body,
+    isBase64Encoded: bodyType === "binary",
   };
 }

--- a/src/runtime/entries/aws-lambda.ts
+++ b/src/runtime/entries/aws-lambda.ts
@@ -57,10 +57,7 @@ export async function handler(
 
   // ApiGateway v2 https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.v2
   const isApiGwV2 = "cookies" in event || "rawPath" in event;
-  const { body, bodyType } = await normalizeLambdaOutgoingBody(
-    r.body,
-    r.headers
-  );
+  const awsBody = await normalizeLambdaOutgoingBody(r.body, r.headers);
   const cookies = normalizeCookieHeader(r.headers["set-cookie"]);
   return {
     ...(cookies.length > 0 && {
@@ -70,7 +67,7 @@ export async function handler(
     }),
     statusCode: r.status,
     headers: normalizeLambdaOutgoingHeaders(r.headers, true),
-    body,
-    isBase64Encoded: bodyType === "binary",
+    body: awsBody.body,
+    isBase64Encoded: awsBody.type === "binary",
   };
 }

--- a/src/runtime/entries/netlify-lambda.ts
+++ b/src/runtime/entries/netlify-lambda.ts
@@ -36,16 +36,13 @@ export async function lambda(
   });
 
   const cookies = normalizeCookieHeader(String(r.headers["set-cookie"]));
-  const { body, bodyType } = await normalizeLambdaOutgoingBody(
-    r.body,
-    r.headers
-  );
+  const awsBody = await normalizeLambdaOutgoingBody(r.body, r.headers);
 
   return {
     statusCode: r.status,
     headers: normalizeLambdaOutgoingHeaders(r.headers, true),
-    body,
-    isBase64Encoded: bodyType === "binary",
+    body: awsBody.body,
+    isBase64Encoded: awsBody.type === "binary",
     ...(cookies.length > 0 && {
       multiValueHeaders: { "set-cookie": cookies },
     }),

--- a/src/runtime/entries/netlify-lambda.ts
+++ b/src/runtime/entries/netlify-lambda.ts
@@ -36,15 +36,18 @@ export async function lambda(
   });
 
   const cookies = normalizeCookieHeader(String(r.headers["set-cookie"]));
-  const outBody = await normalizeLambdaOutgoingBody(r.body, r.headers);
+  const { body, bodyType } = await normalizeLambdaOutgoingBody(
+    r.body,
+    r.headers
+  );
 
   return {
     statusCode: r.status,
     headers: normalizeLambdaOutgoingHeaders(r.headers, true),
-    body: outBody.body,
-    isBase64Encoded: outBody.type === "binary",
-    multiValueHeaders: {
-      ...(cookies.length > 0 ? { "set-cookie": cookies } : {}),
-    },
+    body,
+    isBase64Encoded: bodyType === "binary",
+    ...(cookies.length > 0 && {
+      multiValueHeaders: { "set-cookie": cookies },
+    }),
   };
 }

--- a/src/runtime/entries/stormkit.ts
+++ b/src/runtime/entries/stormkit.ts
@@ -34,7 +34,7 @@ export const handler: Handler<StormkitEvent, StormkitResponse> =
       body: event.body,
     });
 
-    const { body, bodyType } = await normalizeLambdaOutgoingBody(
+    const awsBody = await normalizeLambdaOutgoingBody(
       response.body,
       response.headers
     );
@@ -42,7 +42,7 @@ export const handler: Handler<StormkitEvent, StormkitResponse> =
     return <StormkitResponse>{
       statusCode: response.status,
       headers: normalizeOutgoingHeaders(response.headers),
-      [bodyType === "text" ? "body" : "buffer"]: body,
+      [awsBody.type === "text" ? "body" : "buffer"]: awsBody.body,
     };
   };
 

--- a/src/runtime/entries/stormkit.ts
+++ b/src/runtime/entries/stormkit.ts
@@ -34,7 +34,7 @@ export const handler: Handler<StormkitEvent, StormkitResponse> =
       body: event.body,
     });
 
-    const normalizedBody = await normalizeLambdaOutgoingBody(
+    const { body, bodyType } = await normalizeLambdaOutgoingBody(
       response.body,
       response.headers
     );
@@ -42,7 +42,7 @@ export const handler: Handler<StormkitEvent, StormkitResponse> =
     return <StormkitResponse>{
       statusCode: response.status,
       headers: normalizeOutgoingHeaders(response.headers),
-      [normalizedBody.type === "text" ? "body" : "buffer"]: normalizedBody.body,
+      [bodyType === "text" ? "body" : "buffer"]: body,
     };
   };
 

--- a/src/runtime/utils.lambda.ts
+++ b/src/runtime/utils.lambda.ts
@@ -31,18 +31,18 @@ export function normalizeLambdaOutgoingHeaders(
 export async function normalizeLambdaOutgoingBody(
   body: BodyInit | ReadableStream | Buffer | Readable | Uint8Array,
   headers: Record<string, number | string | string[] | undefined>
-): Promise<{ bodyType: "text" | "binary"; body: string }> {
+): Promise<{ type: "text" | "binary"; body: string }> {
   if (typeof body === "string") {
-    return { bodyType: "text", body };
+    return { type: "text", body };
   }
   if (!body) {
-    return { bodyType: "text", body: "" };
+    return { type: "text", body: "" };
   }
   const buffer = await _toBuffer(body as any);
   const contentType = (headers["content-type"] as string) || "";
   return isTextType(contentType)
-    ? { bodyType: "text", body: buffer.toString("utf8") }
-    : { bodyType: "binary", body: buffer.toString("base64") };
+    ? { type: "text", body: buffer.toString("utf8") }
+    : { type: "binary", body: buffer.toString("base64") };
 }
 
 function _toBuffer(data: ReadableStream | Readable | Uint8Array) {

--- a/src/runtime/utils.lambda.ts
+++ b/src/runtime/utils.lambda.ts
@@ -31,18 +31,18 @@ export function normalizeLambdaOutgoingHeaders(
 export async function normalizeLambdaOutgoingBody(
   body: BodyInit | ReadableStream | Buffer | Readable | Uint8Array,
   headers: Record<string, number | string | string[] | undefined>
-): Promise<{ type: "text" | "binary"; body: string }> {
+): Promise<{ bodyType: "text" | "binary"; body: string }> {
   if (typeof body === "string") {
-    return { type: "text", body };
+    return { bodyType: "text", body };
   }
   if (!body) {
-    return { type: "text", body: "" };
+    return { bodyType: "text", body: "" };
   }
   const buffer = await _toBuffer(body as any);
   const contentType = (headers["content-type"] as string) || "";
   return isTextType(contentType)
-    ? { type: "text", body: buffer.toString("utf8") }
-    : { type: "binary", body: buffer.toString("base64") };
+    ? { bodyType: "text", body: buffer.toString("utf8") }
+    : { bodyType: "binary", body: buffer.toString("base64") };
 }
 
 function _toBuffer(data: ReadableStream | Readable | Uint8Array) {

--- a/test/presets/aws-lambda.test.ts
+++ b/test/presets/aws-lambda.test.ts
@@ -24,7 +24,7 @@ describe("nitro:preset:aws-lambda", async () => {
         body: body || "",
       };
       const res = await handler(event);
-      return makeResponse(res, "v1");
+      return makeResponse(res);
     };
   });
   // Lambda v2 paylod
@@ -57,20 +57,18 @@ describe("nitro:preset:aws-lambda", async () => {
         body: body || "",
       };
       const res = await handler(event);
-      return makeResponse(res, "v2");
+      return makeResponse(res);
     };
   });
 });
 
-const makeResponse = (response: any, version: "v1" | "v2") => {
-  const headers = { ...response.headers };
+const makeResponse = (response: any) => {
+  const headers = response.headers;
 
-  if (version === "v1") {
-    headers["set-cookie"] = response?.multiValueHeaders?.["set-cookie"];
-  }
-  if (version === "v2") {
-    headers["set-cookie"] = response?.cookies;
-  }
+  // APIgw v2 uses cookies, v1 uses multiValueHeaders
+  headers["set-cookie"] =
+    response?.cookies ?? response?.multiValueHeaders?.["set-cookie"];
+
   return {
     data: destr(response.body),
     status: response.statusCode,

--- a/test/presets/aws-lambda.test.ts
+++ b/test/presets/aws-lambda.test.ts
@@ -65,13 +65,11 @@ describe("nitro:preset:aws-lambda", async () => {
 const makeResponse = (response: any, version: "v1" | "v2") => {
   const headers = { ...response.headers };
 
-  const cookies = version === "v2" ? "cookies" : "multiValueHeaders";
-
   if (version === "v1") {
-    headers["set-cookie"] = response[cookies]?.["set-cookie"];
+    headers["set-cookie"] = response?.multiValueHeaders?.["set-cookie"];
   }
   if (version === "v2") {
-    headers["set-cookie"] = response[cookies];
+    headers["set-cookie"] = response?.cookies;
   }
   return {
     data: destr(response.body),

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -556,12 +556,6 @@ export function testNitro(
           "foo=bar, bar=baz, test=value; Path=/, test2=value; Path=/";
       }
 
-      // Aws lambda v1
-      if (ctx.preset === "aws-lambda" && ctx.lambdaV1) {
-        expectedCookies =
-          "foo=bar, bar=baz,test=value; Path=/,test2=value; Path=/";
-      }
-
       // TODO: Bun does not handles set-cookie at all
       // https://github.com/unjs/nitro/issues/1461
       if (["bun"].includes(ctx.preset)) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Fix https://github.com/unjs/nitro/issues/852

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The aws-lambda preset works with apigw v1 and v2. 
This PR fix the body type for apigw v2, and the cookies for apigw v1

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
