### PR TITLE
test: update test for bun headers

### DIFF
--- a/test/tests.ts
+++ b/test/tests.ts
@@ -562,12 +562,6 @@ export function testNitro(
           "foo=bar, bar=baz,test=value; Path=/,test2=value; Path=/";
       }
 
-      // TODO: Bun does not handles set-cookie at all
-      // https://github.com/unjs/nitro/issues/1461
-      if (["bun"].includes(ctx.preset)) {
-        return;
-      }
-
       expect(headers["set-cookie"]).toMatchObject(expectedCookies);
     });
   });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -542,6 +542,7 @@ export function testNitro(
         "nitro-dev",
         "vercel",
         nodeVersion < 18 && "deno-server",
+        nodeVersion < 18 && "bun",
       ].filter(Boolean);
       if (notSplitingPresets.includes(ctx.preset)) {
         expectedCookies =

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -551,7 +551,7 @@ export function testNitro(
             : ["foo=bar, bar=baz", "test=value; Path=/", "test2=value; Path=/"];
       }
 
-      // TODO: verce-ledge joins all cookies for some reason!
+      // TODO: vercel-edge joins all cookies for some reason!
       if (ctx.preset === "vercel-edge") {
         expectedCookies =
           "foo=bar, bar=baz, test=value; Path=/, test2=value; Path=/";


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1461 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I was able to run the header tests locally for bun 0.8.1. However the same tests appear to be failing with the CI.
Investigating, I'm able to make the tests fail locally by downgrading my node version to 16, which match the CI behaviour.
I'm not sure why this is happening, but we can handle this the same way we handle deno

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
