### PR TITLE
docs: add instructions for using nuxt edge release channel

### DIFF
--- a/docs/content/1.guide/0.getting-started.md
+++ b/docs/content/1.guide/0.getting-started.md
@@ -92,7 +92,8 @@ Nitro offers an edge release channel that automatically releases for every commi
 
 You can opt-in to the edge release channel by updating your `package.json`:
 
-```diff
+::code-group
+```diff [Nitro]
 {
   "devDependencies": {
 --    "nitropack": "^2.0.0"
@@ -100,6 +101,15 @@ You can opt-in to the edge release channel by updating your `package.json`:
   }
 }
 ```
+```diff [Nuxt]
+{
+  "devDependencies": {
+--    "nuxt": "^3.0.0"
+++    "nuxt": "npm:nuxt3@latest"
+  }
+}
+```
+::
 
 Remove an lockfile (`package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`) and reinstall the dependencies.
 

--- a/docs/content/1.guide/0.getting-started.md
+++ b/docs/content/1.guide/0.getting-started.md
@@ -111,6 +111,9 @@ You can opt-in to the edge release channel by updating your `package.json`:
 ```
 ::
 
-Remove an lockfile (`package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`) and reinstall the dependencies.
+::alert
+If you are using Nuxt, [use the Nuxt edge channel](https://nuxt.com/docs/guide/going-further/edge-channel#opting-into-the-edge-channel) as it already includes `nitropack-edge`.
+::
+
 
 

--- a/docs/content/1.guide/0.getting-started.md
+++ b/docs/content/1.guide/0.getting-started.md
@@ -115,5 +115,6 @@ You can opt-in to the edge release channel by updating your `package.json`:
 If you are using Nuxt, [use the Nuxt edge channel](https://nuxt.com/docs/guide/going-further/edge-channel#opting-into-the-edge-channel) as it already includes `nitropack-edge`.
 ::
 
+Remove any lockfile (`package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`) and reinstall the dependencies.
 
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
While attempting to test the latest Nitro edge release, I couldn't get Nuxt to build using the edge version, despite the console telling me that I was on the edge release. [See #1663](https://github.com/unjs/nitro/pull/1663#issuecomment-1703908120). @pi0 suggested to use the Nuxt edge release as it includes the Nitro edge release.

This PR adds a code example and a link to the relevant Nuxt docs.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
