### PR TITLE
docs(render-com): add note about node version

### DIFF
--- a/docs/content/2.deploy/providers/render.md
+++ b/docs/content/2.deploy/providers/render.md
@@ -16,7 +16,7 @@ Nitro supports deploying on [Render](https://render.com/) with minimal configura
 
 1. Update the start command to `node .output/server/index.mjs`
 
-1. Click 'Advanced' and add an environment variable with `NITRO_PRESET` set to `render_com`. You may also need to add a `NODE_VERSION` environment variable set to `16/18` for the build to succeed (By default `render.com` uses `node v14.17.0`).
+1. Click 'Advanced' and add an environment variable with `NITRO_PRESET` set to `render_com`. You may also need to add a `NODE_VERSION` environment variable set to `18` for the build to succeed ([docs](https://render.com/docs/node-version)).
 
 1. Click 'Create Web Service'.
  

--- a/docs/content/2.deploy/providers/render.md
+++ b/docs/content/2.deploy/providers/render.md
@@ -16,7 +16,7 @@ Nitro supports deploying on [Render](https://render.com/) with minimal configura
 
 1. Update the start command to `node .output/server/index.mjs`
 
-1. Click 'Advanced' and add an environment variable with `NITRO_PRESET` set to `render_com`. You may need to add a NODE_VERSION environment variable set to 16/18 for the build to succeed (By default render.con uses node v14).
+1. Click 'Advanced' and add an environment variable with `NITRO_PRESET` set to `render_com`. You may also need to add a `NODE_VERSION` environment variable set to `16/18` for the build to succeed (By default `render.com` uses `node v14.17.0`).
 
 1. Click 'Create Web Service'.
  

--- a/docs/content/2.deploy/providers/render.md
+++ b/docs/content/2.deploy/providers/render.md
@@ -19,7 +19,6 @@ Nitro supports deploying on [Render](https://render.com/) with minimal configura
 1. Click 'Advanced' and add an environment variable with `NITRO_PRESET` set to `render_com`. You may also need to add a `NODE_VERSION` environment variable set to `18` for the build to succeed ([docs](https://render.com/docs/node-version)).
 
 1. Click 'Create Web Service'.
- 
 
 ## Infrastructure as Code (IaC)
 

--- a/docs/content/2.deploy/providers/render.md
+++ b/docs/content/2.deploy/providers/render.md
@@ -16,9 +16,10 @@ Nitro supports deploying on [Render](https://render.com/) with minimal configura
 
 1. Update the start command to `node .output/server/index.mjs`
 
-1. Click 'Advanced' and add an environment variable with `NITRO_PRESET` set to `render_com`.
+1. Click 'Advanced' and add an environment variable with `NITRO_PRESET` set to `render_com`. You may need to add a NODE_VERSION environment variable set to 16/18 for the build to succeed (By default render.con uses node v14).
 
 1. Click 'Create Web Service'.
+ 
 
 ## Infrastructure as Code (IaC)
 


### PR DESCRIPTION
render.com uses node v14.17.0 by default and latest nuxt dependencies have a conflict with that. So the proposed change mentions how we can resolve the issue by adding a NODE_VERSION environment variable.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue
Issue #1692 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #1692 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
