### PR TITLE
Fix: make node-server.ts accept iisnode named pipe

### DIFF
--- a/src/runtime/entries/node-server.ts
+++ b/src/runtime/entries/node-server.ts
@@ -24,7 +24,7 @@ const host = process.env.NITRO_HOST || process.env.HOST;
 const path = process.env.NITRO_UNIX_SOCKET;
 
 // @ts-ignore
-const listener = server.listen(path ? { path } : { port, host }, (err) => {
+const listener = server.listen(isNaN(Number(process.env.PORT)) ? {path: port} : path ? { path } : { port, host }, (err) => {
   if (err) {
     console.error(err);
     // eslint-disable-next-line unicorn/no-process-exit

--- a/src/runtime/entries/node-server.ts
+++ b/src/runtime/entries/node-server.ts
@@ -21,10 +21,11 @@ const port = (destr(process.env.NITRO_PORT || process.env.PORT) ||
   3000) as number;
 const host = process.env.NITRO_HOST || process.env.HOST;
 
-const path = process.env.NITRO_UNIX_SOCKET;
+const path =
+  port && Number.isNaN(Number(port)) ? port : process.env.NITRO_UNIX_SOCKET;
 
 // @ts-ignore
-const listener = server.listen(isNaN(Number(process.env.PORT)) ? {path: port} : path ? { path } : { port, host }, (err) => {
+const listener = server.listen(path ? { path } : { port, host }, (err) => {
   if (err) {
     console.error(err);
     // eslint-disable-next-line unicorn/no-process-exit


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/22961

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I have change the condition a little to node-server.ts. It just checks if the port number is a number or not and if the port is not a null and is not a number, it puts the port (string) inside the path variable instead, wich resolve the issue for iisnode. Iisnode uses Named pipe instead of port numbers. Please check issue more infos

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
