### PR TITLE
fix: await on `send()` calls

### DIFF
--- a/src/dev/error.ts
+++ b/src/dev/error.ts
@@ -23,7 +23,7 @@ function errorHandler(error: any, event: H3Event) {
       "<progress></progress><script>document.querySelector('progress').indeterminate=true</script>";
   }
 
-  send(
+  return send(
     event,
     `<!DOCTYPE html>
   <html lang="en">

--- a/src/runtime/error.ts
+++ b/src/runtime/error.ts
@@ -46,10 +46,10 @@ export default <NitroErrorHandler>function (error, event) {
 
   if (isJsonRequest(event)) {
     setResponseHeader(event, "Content-Type", "application/json");
-    send(event, JSON.stringify(errorObject));
+    return send(event, JSON.stringify(errorObject));
   } else {
     setResponseHeader(event, "Content-Type", "text/html");
-    send(event, renderHTMLError(errorObject));
+    return send(event, renderHTMLError(errorObject));
   }
 };
 

--- a/src/runtime/renderer.ts
+++ b/src/runtime/renderer.ts
@@ -25,11 +25,10 @@ export function defineRenderHandler(handler: RenderHandler) {
     // TODO: Use serve-placeholder
     if (event.path.endsWith("/favicon.ico")) {
       setResponseHeader(event, "Content-Type", "image/x-icon");
-      send(
+      return send(
         event,
         "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
       );
-      return;
     }
 
     const response = await handler(event);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If not chaining send calls, h3 app may wrongly show 404 pages while response is being sent in next tick.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
