### PR TITLE
perf: use native fetch for `node >= 18` to reduce `%40` of bundle size

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -10,8 +10,9 @@ import {
 } from "mlly";
 import escapeRE from "escape-string-regexp";
 import { withLeadingSlash, withoutTrailingSlash, withTrailingSlash } from "ufo";
-import { isTest, isDebug } from "std-env";
+import { isTest, isDebug, nodeMajorVersion } from "std-env";
 import { findWorkspaceDir } from "pkg-types";
+import consola from "consola";
 import {
   resolvePath,
   resolveFile,
@@ -376,6 +377,23 @@ export async function loadOptions(
       route: "/_nitro/swagger",
       handler: "#internal/nitro/routes/swagger",
     });
+  }
+
+  // Native fetch
+  if (options.experimental.nodeFetchCompat === undefined) {
+    options.experimental.nodeFetchCompat = nodeMajorVersion < 18;
+    if (options.experimental.nodeFetchCompat) {
+      consola.warn(
+        "Node fetch compatibility is enabled. Please consider upgrading to Node.js >= 18."
+      );
+    }
+  }
+  if (!options.experimental.nodeFetchCompat) {
+    options.alias = {
+      "node-fetch-native/polyfill": "unenv/runtime/mock/empty",
+      "node-fetch-native": "node-fetch-native/native",
+      ...options.alias,
+    };
   }
 
   return options;

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,14 +3,10 @@ import { loadConfig, watchConfig, WatchConfigOptions } from "c12";
 import { klona } from "klona/full";
 import { camelCase } from "scule";
 import { defu } from "defu";
-import {
-  resolveModuleExportNames,
-  resolvePath as resolveModule,
-  parseNodeModulePath,
-} from "mlly";
+import { resolveModuleExportNames } from "mlly";
 import escapeRE from "escape-string-regexp";
 import { withLeadingSlash, withoutTrailingSlash, withTrailingSlash } from "ufo";
-import { isTest, isDebug, nodeMajorVersion } from "std-env";
+import { isTest, isDebug, nodeMajorVersion, provider } from "std-env";
 import { findWorkspaceDir } from "pkg-types";
 import consola from "consola";
 import {
@@ -382,7 +378,7 @@ export async function loadOptions(
   // Native fetch
   if (options.experimental.nodeFetchCompat === undefined) {
     options.experimental.nodeFetchCompat = nodeMajorVersion < 18;
-    if (options.experimental.nodeFetchCompat) {
+    if (options.experimental.nodeFetchCompat && provider !== "stackblitz") {
       consola.warn(
         "Node fetch compatibility is enabled. Please consider upgrading to Node.js >= 18."
       );

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -256,6 +256,10 @@ export interface NitroOptions extends PresetOptions {
      * Disable Experimental Sourcemap Minification
      */
     sourcemapMinify?: false;
+    /**
+     * Backward compatibility support for Node fetch (required for Node < 18)
+     */
+    nodeFetchCompat?: boolean;
   };
   future: {
     nativeSWR: boolean;


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Node.js 16 is EOL and by disabling the polyfill from `node-fetch-native` package, we can save almost **%41** of the default bundle size!

This PR smartly enables `experimental.nodeFetchCompact` when Node.js 16 is being used with a warning to guide about an upgrade.

#### Output results

```
Node.js (current)
Σ Total size: 268 kB (69.9 kB gzip)

Node.js (native fetch)
Σ Total size: 158 kB (38.8 kB gzip)
```

We were also wrongly bundling polyfill for Bun which is not needed and it even saves more on bun (because of crypto export conditions mainly)

```
Bun (current)
Σ Total size: 255 kB (66.7 kB gzip)

Bun (native fetch)
Σ Total size: 146 kB (35.9 kB gzip)
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
