### PR TITLE
docs: register error handler using hook instead of `hookOnce`

### DIFF
--- a/docs/content/1.guide/7.plugins.md
+++ b/docs/content/1.guide/7.plugins.md
@@ -77,7 +77,7 @@ You can use plugins to capture all application errors.
 
 ```ts
 export default defineNitroPlugin((nitro) => {
-  nitro.hooks.hookOnce("error", async (error, { event }) => {
+  nitro.hooks.hook("error", async (error, { event }) => {
     console.error(`${event.path} Application error:`, error)
   });
 })


### PR DESCRIPTION
See https://github.com/unjs/nitro/issues/1736#issuecomment-1724519928

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
