### PR TITLE
fix(renderer): allow all h3 handled body types

### DIFF
--- a/src/runtime/renderer.ts
+++ b/src/runtime/renderer.ts
@@ -6,7 +6,7 @@ import {
   setResponseHeader,
   setResponseHeaders,
   setResponseStatus,
-  isStream
+  isStream,
 } from "h3";
 import { useNitroApp } from "./app";
 

--- a/src/runtime/renderer.ts
+++ b/src/runtime/renderer.ts
@@ -6,6 +6,7 @@ import {
   setResponseHeader,
   setResponseHeaders,
   setResponseStatus,
+  isStream
 } from "h3";
 import { useNitroApp } from "./app";
 
@@ -58,7 +59,7 @@ export function defineRenderHandler(handler: RenderHandler) {
     }
 
     // Send response body
-    return typeof response.body === "string"
+    return typeof response.body === "string" || isStream(response.body)
       ? response.body
       : JSON.stringify(response.body);
   });

--- a/src/runtime/renderer.ts
+++ b/src/runtime/renderer.ts
@@ -6,7 +6,6 @@ import {
   setResponseHeader,
   setResponseHeaders,
   setResponseStatus,
-  isStream,
 } from "h3";
 import { useNitroApp } from "./app";
 

--- a/src/runtime/renderer.ts
+++ b/src/runtime/renderer.ts
@@ -11,7 +11,7 @@ import {
 import { useNitroApp } from "./app";
 
 export interface RenderResponse {
-  body: string;
+  body: any;
   statusCode: number;
   statusMessage: string;
   headers: Record<string, string>;
@@ -59,8 +59,6 @@ export function defineRenderHandler(handler: RenderHandler) {
     }
 
     // Send response body
-    return typeof response.body === "string" || isStream(response.body)
-      ? response.body
-      : JSON.stringify(response.body);
+    return response.body
   });
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This updates the handling of render response to allow directly returning a stream as well as a string.

Feedback welcome on concept. We could alternatively create a new helper that could handle other common stream-related issues.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
