### PR TITLE
docs: fix configuration file name of the custom preset

### DIFF
--- a/docs/content/2.deploy/3.custom-presets.md
+++ b/docs/content/2.deploy/3.custom-presets.md
@@ -18,7 +18,7 @@ Custom presets are local files that have a preset entry that defines builder con
 Check [unjs/nitro-preset-starter](https://github.com/unjs/nitro-preset-starter) for a ready-to-use template.
 ::
 
-First, we have to define our preset entry point in a local directory `preset/index.ts`
+First, we have to define our preset entry point in a local directory `preset/nitro.config.ts`
 
 ```ts [./preset/nitro.config.ts]
 import type { NitroPreset } from "nitropack";

--- a/docs/content/2.deploy/3.custom-presets.md
+++ b/docs/content/2.deploy/3.custom-presets.md
@@ -20,7 +20,7 @@ Check [unjs/nitro-preset-starter](https://github.com/unjs/nitro-preset-starter) 
 
 First, we have to define our preset entry point in a local directory `preset/index.ts`
 
-```ts [./preset/index.ts]
+```ts [./preset/nitro.config.ts]
 import type { NitroPreset } from "nitropack";
 import { fileURLToPath } from "node:url"
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->


entry point `preset/index.ts` is not valid. According to the source code and [this ](https://github.com/unjs/nitro-preset-starter/tree/main/preset) example, I fixed `index.ts` -> `nitro.config.ts`.

![image](https://github.com/unjs/nitro/assets/33551334/2e8e2b07-5334-46a4-bb6b-6b4b7e57ad2a)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
