### PR TITLE
fix: exclude undefined from hook types

### DIFF
--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -25,9 +25,9 @@ export interface NitroRuntimeHooks {
   close: () => void;
   error: CaptureError;
 
-  request: AppOptions["onRequest"];
-  beforeResponse: AppOptions["onBeforeResponse"];
-  afterResponse: AppOptions["onAfterResponse"];
+  request: NonNullable<AppOptions["onRequest"]>;
+  beforeResponse: NonNullable<AppOptions["onBeforeResponse"]>;
+  afterResponse: NonNullable<AppOptions["onAfterResponse"]>;
 
   "render:response": (
     response: Partial<RenderResponse>,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

nuxt/nuxt#23437

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We need to exclude possibly undefined values from the hook function or it will end up typed as `never` once processed by hookable.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
