### PR TITLE
docs(cloudflare): add local dev section

### DIFF
--- a/docs/content/2.deploy/providers/cloudflare.md
+++ b/docs/content/2.deploy/providers/cloudflare.md
@@ -24,11 +24,6 @@ route = "<mainly useful when you want to setup custom domains (optional too)>"
 
 [site]
 bucket = ".output/public"
-
-[build]
-command = "NITRO_PRESET=cloudflare npm run build" // Replace npm with your packagemanager (npm, pnpm, yarn, bun)
-cwd = "./"
-watch_dir = ["./routes", "./nitro.config.ts"]
 ```
 
 ### Testing locally
@@ -36,11 +31,13 @@ watch_dir = ["./routes", "./nitro.config.ts"]
 You can use [wrangler2](https://github.com/cloudflare/wrangler2), to test your app locally:
 
 ```bash
+NITRO_PRESET=cloudflare yarn build
+
 # If you have added a 'wrangler.toml' file like above in the root of your project:
 npx wrangler dev --local
 
 # If you don't have a 'wrangler.toml', directly use:
-npm run build && npx wrangler dev .output/server/index.mjs --site .output/public --local
+npx wrangler dev .output/server/index.mjs --site .output/public --local
 ```
 
 ### Deploy from your local machine using wrangler

--- a/docs/content/2.deploy/providers/cloudflare.md
+++ b/docs/content/2.deploy/providers/cloudflare.md
@@ -24,6 +24,11 @@ route = "<mainly useful when you want to setup custom domains (optional too)>"
 
 [site]
 bucket = ".output/public"
+
+[build]
+command = "npm run NITRO_PRESET=cloudflare build" // Replace npm with your packagemanager (npm, pnpm, yarn, bun)
+cwd = "./"
+watch_dir = ["./routes", "./nitro.config.ts"]
 ```
 
 ### Testing locally
@@ -31,13 +36,11 @@ bucket = ".output/public"
 You can use [wrangler2](https://github.com/cloudflare/wrangler2), to test your app locally:
 
 ```bash
-NITRO_PRESET=cloudflare yarn build
-
 # If you have added a 'wrangler.toml' file like above in the root of your project:
 npx wrangler dev --local
 
 # If you don't have a 'wrangler.toml', directly use:
-npx wrangler dev .output/server/index.mjs --site .output/public --local
+npm run build && npx wrangler dev .output/server/index.mjs --site .output/public --local
 ```
 
 ### Deploy from your local machine using wrangler

--- a/docs/content/2.deploy/providers/cloudflare.md
+++ b/docs/content/2.deploy/providers/cloudflare.md
@@ -322,3 +322,25 @@ With `cloudflare_module` preset, you need to add the following rule to your `wra
   [site]
   bucket = ".output/public"
 ```
+
+### Local Wrangler Dev builds
+
+By default `wrangler dev` requires nitro to be built before it can be served by wrangler.
+
+This can become tiresome if you're making changes to your nitro app and keep rebuilding to test changes in wrangler.
+
+::alert{type="warning"}
+This is a temporary workaround until nitro has better support for wrangler dev mode!
+::
+
+To instruct wrangler to automatically rebuild nitro when it detects file changes, you need to add the following rule to your `wrangler.toml` file:
+
+```[wrangler.toml]
++ [env.development.build]
++ command = "NITRO_PRESET=cloudflare npm run build" // Replace npm with your packagemanager (npm, pnpm, yarn, bun)
++ cwd = "./"
++ watch_dir = ["./routes", "./nitro.config.ts"]
+```
+
+Now you need to run wrangler in development mode using `wrangler dev --env development`
+When files change in nitro, wrangler will rebuild and serve the new files

--- a/docs/content/2.deploy/providers/cloudflare.md
+++ b/docs/content/2.deploy/providers/cloudflare.md
@@ -26,7 +26,7 @@ route = "<mainly useful when you want to setup custom domains (optional too)>"
 bucket = ".output/public"
 
 [build]
-command = "npm run NITRO_PRESET=cloudflare build" // Replace npm with your packagemanager (npm, pnpm, yarn, bun)
+command = "NITRO_PRESET=cloudflare npm run build" // Replace npm with your packagemanager (npm, pnpm, yarn, bun)
 cwd = "./"
 watch_dir = ["./routes", "./nitro.config.ts"]
 ```


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Added a build step to wrangler.toml example

Previously:
Any code changes would require a new `nitropack build` followed by restarting `wrangler dev`

Now:
`wrangler` watches the routes dir and `nitro.config.ts`. On change, `wrangler` dev rebuilds `nitro` Local dev experience when using `wrangler dev` now matches `nitropack dev`

### 📝 Checklist


- [ ] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
