### PR TITLE
fix(cache): allow overriding integrity

### DIFF
--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -51,7 +51,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = unknown[]>(
   // Normalize cache params
   const group = opts.group || "nitro/functions";
   const name = opts.name || fn.name || "_";
-  const integrity = hash([opts.integrity, fn, opts]);
+  const integrity = opts.integrity || hash([fn, opts]);
   const validate = opts.validate || (() => true);
 
   async function get(


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Cache integrity should be overirdable. Previously we were always making a hash from function implementation making it impossible to change.

**Note:** This is slight breaking behavior but only effect is that old caches with custom integrity will be invalidated to respect custom one.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
