### PR TITLE
fix(cache): write swr and update errors to console

### DIFF
--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -116,6 +116,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = unknown[]>(
           const promise = useStorage()
             .setItem(cacheKey, entry)
             .catch((error) => {
+              console.error(`[nitro] [cache] Cache write error.`, error);
               useNitroApp().captureError(error, { event, tags: ["cache"] });
             });
           if (event && event.waitUntil) {
@@ -132,11 +133,10 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = unknown[]>(
     }
 
     if (opts.swr && entry.value) {
-      // eslint-disable-next-line no-console
       _resolvePromise.catch((error) => {
+        console.error(`[nitro] [cache] SWR handler error.`, error);
         useNitroApp().captureError(error, { event, tags: ["cache"] });
       });
-      // eslint-disable-next-line unicorn/no-useless-promise-resolve-reject
       return entry;
     }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

After the introduction of `captureError` API and integrating it with cache API, we removed explicit `console.error` logs when an issue happens for updating cache storage or evaluating SWR handler in the background.

This PR adds them back. As a future improvement, we might smartly show errors only if there is no error handler but it might also cause DX issues if all handlers are system handlers. So something to explore more later.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
