### PR TITLE
fix(cache): only return validated stale value

### DIFF
--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -52,7 +52,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = unknown[]>(
   const group = opts.group || "nitro/functions";
   const name = opts.name || fn.name || "_";
   const integrity = opts.integrity || hash([fn, opts]);
-  const validate = opts.validate || (() => true);
+  const validate = opts.validate || ((entry) => entry.value !== undefined);
 
   async function get(
     key: string,
@@ -132,7 +132,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = unknown[]>(
       event.waitUntil(_resolvePromise);
     }
 
-    if (opts.swr && entry.value) {
+    if (opts.swr && validate(entry)) {
       _resolvePromise.catch((error) => {
         console.error(`[nitro] [cache] SWR handler error.`, error);
         useNitroApp().captureError(error, { event, tags: ["cache"] });


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR makes sure any custom `validate` function is passing before sending stale cache value and revalidating in background

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
