### PR TITLE
fix(cache): only invalidate if `validate` returns `false`

### DIFF
--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -77,7 +77,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = unknown[]>(
       shouldInvalidateCache ||
       entry.integrity !== integrity ||
       (ttl && Date.now() - (entry.mtime || 0) > ttl) ||
-      !validate(entry);
+      validate(entry) === false;
 
     const _resolve = async () => {
       const isPending = pending[key];
@@ -112,7 +112,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = unknown[]>(
         entry.mtime = Date.now();
         entry.integrity = integrity;
         delete pending[key];
-        if (validate(entry)) {
+        if (validate(entry) !== false) {
           const promise = useStorage()
             .setItem(cacheKey, entry)
             .catch((error) => {
@@ -132,7 +132,7 @@ export function defineCachedFunction<T, ArgsT extends unknown[] = unknown[]>(
       event.waitUntil(_resolvePromise);
     }
 
-    if (opts.swr && validate(entry)) {
+    if (opts.swr && validate(entry) !== false) {
       _resolvePromise.catch((error) => {
         console.error(`[nitro] [cache] SWR handler error.`, error);
         useNitroApp().captureError(error, { event, tags: ["cache"] });


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Unless a custom validator function returns `false`, it should be considered as valid to avoid implicit returns being considered invalid.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
