### PR TITLE
feat(netlify): added SWR implementation

### DIFF
--- a/src/presets/netlify.ts
+++ b/src/presets/netlify.ts
@@ -169,29 +169,6 @@ async function writeHeaders(nitro: Nitro) {
     (a, b) => b[0].split(/\/(?!\*)/).length - a[0].split(/\/(?!\*)/).length
   );
 
-  // convert isr rules to header rules
-  for (const [path, routeRules] of rules.filter(
-    ([_, routeRules]) => routeRules.isr !== undefined
-  )) {
-    // create headers if missing
-    nitro.options.routeRules[path].headers ||= {};
-    // transform isr rules to SWR headers https://www.netlify.com/blog/swr-and-fine-grained-cache-control/
-    if (routeRules.isr === true || routeRules.isr === 0) {
-      // set SWR header
-      nitro.options.routeRules[path].headers["Cache-Control"] =
-        "public, max-age=0, must-revalidate"; // Tell browsers to always revalidate
-      nitro.options.routeRules[path].headers[
-        "Netlify-CDN-Cache-Control"
-      ] = `public, max-age=0, stale-while-revalidate=31536000`; // Tell Edge to cache asset for up to a year, but revalidate every call
-    } else if (Number.isInteger(routeRules.isr)) {
-      // set cache header
-      nitro.options.routeRules[path].headers["Cache-Control"] =
-        "public, max-age=0, must-revalidate"; // Tell browsers to always revalidate
-      nitro.options.routeRules[path].headers[
-        "Netlify-CDN-Cache-Control"
-      ] = `public, max-age=${routeRules.isr}, must-revalidate`; // Tell Edge to cache asset for set time
-    }
-  }
   for (const [path, routeRules] of rules.filter(
     ([_, routeRules]) => routeRules.headers
   )) {

--- a/src/runtime/entries/netlify-edge.ts
+++ b/src/runtime/entries/netlify-edge.ts
@@ -1,9 +1,11 @@
 import "#internal/nitro/virtual/polyfill";
 import { nitroApp } from "../app";
+import { getNetlifyCacheHeaders } from "../utils.lambda";
 import { isPublicAssetURL } from "#internal/nitro/virtual/public-assets";
 
 // https://docs.netlify.com/edge-functions/api/
-export default async function (request: Request, _context) {
+export default async function (request: Request, _context: any) {
+  // TODO type this correctly
   const url = new URL(request.url);
 
   if (isPublicAssetURL(url.pathname)) {
@@ -14,9 +16,15 @@ export default async function (request: Request, _context) {
     request.headers.set("x-forwarded-proto", "https");
   }
 
-  let body;
-  if (request.body) {
-    body = await request.arrayBuffer();
+  const body = request.body ? await request.arrayBuffer() : null;
+
+  // augmenting headers for caching strategies
+  const toAdd = getNetlifyCacheHeaders(
+    url.toString(),
+    Object.fromEntries(request.headers.entries())
+  );
+  for (const [hKey, hValue] of Object.entries(toAdd)) {
+    request.headers.set(hKey, hValue);
   }
 
   return nitroApp.localFetch(url.pathname + url.search, {

--- a/src/runtime/entries/netlify-lambda.ts
+++ b/src/runtime/entries/netlify-lambda.ts
@@ -48,15 +48,10 @@ export async function lambda(
       .includes("cache-control")
   ) {
     r.headers["Cache-Control"] = "public, max-age=0, must-revalidate";
-    if (typeof routeRules.isr === "number") {
-      r.headers[
-        "Netlify-CDN-Cache-Control"
-      ] = `public, max-age=${routeRules.isr}, must-revalidate`;
-    } else {
-      r.headers[
-        "Netlify-CDN-Cache-Control"
-      ] = `public, max-age=0, stale-while-revalidate=31536000`;
-    }
+    r.headers["Netlify-CDN-Cache-Control"] =
+      typeof routeRules.isr === "number"
+        ? `public, max-age=${routeRules.isr}, must-revalidate`
+        : `public, max-age=0, stale-while-revalidate=31536000`;
   }
 
   return {

--- a/src/runtime/entries/netlify.ts
+++ b/src/runtime/entries/netlify.ts
@@ -4,7 +4,7 @@ import { withQuery } from "ufo";
 import { getRouteRulesForPath } from "../route-rules";
 import { lambda } from "./netlify-lambda";
 
-export const handler: Handler = async function handler(event, context) {
+export const handler: Handler = function handler(event, context) {
   const query = {
     ...event.queryStringParameters,
     ...event.multiValueQueryStringParameters,

--- a/src/runtime/entries/netlify.ts
+++ b/src/runtime/entries/netlify.ts
@@ -1,28 +1,7 @@
 import "#internal/nitro/virtual/polyfill";
 import type { Handler } from "@netlify/functions/dist/main";
-import { withQuery } from "ufo";
-import { getRouteRulesForPath } from "../route-rules";
 import { lambda } from "./netlify-lambda";
 
 export const handler: Handler = function handler(event, context) {
-  const query = {
-    ...event.queryStringParameters,
-    ...event.multiValueQueryStringParameters,
-  };
-  const url = withQuery(event.path, query);
-  const routeRules = getRouteRulesForPath(url);
-  if (routeRules.isr) {
-    event.headers["Cache-Control"] = "public,max-age=0,must-revalidate";
-    if (typeof routeRules.isr === "number") {
-      event.headers[
-        "Netlify-CDN-Cache-Control"
-      ] = `public,max-age=${routeRules.isr},must-revalidate`;
-    } else {
-      event.headers[
-        "Netlify-CDN-Cache-Control"
-      ] = `public,max-age=0,stale-while-revalidate=31536000`;
-    }
-  }
-
   return lambda(event, context);
 };

--- a/src/runtime/utils.lambda.ts
+++ b/src/runtime/utils.lambda.ts
@@ -109,7 +109,7 @@ export const getNetlifyCacheHeaders = (url: string, currHeaders: _THeaders) => {
     headersToAdd["Cache-Control"] = "public, max-age=0, must-revalidate";
     headersToAdd["Netlify-CDN-Cache-Control"] =
       typeof routeRules.isr === "number"
-        ? `public, max-age=${routeRules.isr}, must-revalidate`
+        ? `public, max-age=${routeRules.isr}, s-maxage=${routeRules.isr}, must-revalidate`
         : `public, max-age=0, stale-while-revalidate=31536000`;
   }
 

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -1,6 +1,7 @@
 import { expectTypeOf } from "expect-type";
 import { describe, it } from "vitest";
 import { EventHandler, EventHandlerRequest, defineEventHandler } from "h3";
+// @ts-ignore
 import { $Fetch } from "../..";
 import { defineNitroConfig } from "../../src/config";
 

--- a/test/presets/netlify.test.ts
+++ b/test/presets/netlify.test.ts
@@ -72,6 +72,8 @@ describe("nitro:preset:netlify", async () => {
   access-control-allow-methods: GET
   access-control-allow-headers: *
   access-control-max-age: 0
+/rules/nested/*
+  x-test: test
 /build/*
   cache-control: public, max-age=3600, immutable
 "`);

--- a/test/presets/netlify.test.ts
+++ b/test/presets/netlify.test.ts
@@ -65,36 +65,13 @@ describe("nitro:preset:netlify", async () => {
         );
         /* eslint-disable no-tabs */
         expect(headers).toMatchInlineSnapshot(`
-"/rules/_/noncached/cached
-  Cache-Control: public, max-age=0, must-revalidate
-  Netlify-CDN-Cache-Control: public, max-age=0, stale-while-revalidate=31536000
-/rules/_/cached/noncached
-/rules/_/noncached/*
-/rules/_/cached/*
-  Cache-Control: public, max-age=0, must-revalidate
-  Netlify-CDN-Cache-Control: public, max-age=0, stale-while-revalidate=31536000
-/rules/headers
+"/rules/headers
   cache-control: s-maxage=60
 /rules/cors
   access-control-allow-origin: *
   access-control-allow-methods: GET
   access-control-allow-headers: *
   access-control-max-age: 0
-/rules/dynamic
-/rules/isr/*
-  Cache-Control: public, max-age=0, must-revalidate
-  Netlify-CDN-Cache-Control: public, max-age=0, stale-while-revalidate=31536000
-/rules/isr-ttl/*
-  Cache-Control: public, max-age=0, must-revalidate
-  Netlify-CDN-Cache-Control: public, max-age=60, must-revalidate
-/rules/swr/*
-  Cache-Control: public, max-age=0, must-revalidate
-  Netlify-CDN-Cache-Control: public, max-age=0, stale-while-revalidate=31536000
-/rules/swr-ttl/*
-  Cache-Control: public, max-age=0, must-revalidate
-  Netlify-CDN-Cache-Control: public, max-age=0, stale-while-revalidate=31536000
-/rules/nested/*
-  x-test: test
 /build/*
   cache-control: public, max-age=3600, immutable
 "`);

--- a/test/presets/netlify.test.ts
+++ b/test/presets/netlify.test.ts
@@ -54,16 +54,7 @@ describe("nitro:preset:netlify", async () => {
         /rules/redirect/obj	https://nitro.unjs.io/	301
         /rules/nested/*	/base	302
         /rules/redirect	/base	302
-        /rules/_/cached/noncached	/.netlify/functions/server 200
-        /rules/_/noncached/cached	/.netlify/builders/server 200
-        /rules/_/cached/*	/.netlify/builders/server 200
-        /rules/_/noncached/*	/.netlify/functions/server 200
-        /rules/swr-ttl/*	/.netlify/builders/server 200
-        /rules/swr/*	/.netlify/builders/server 200
-        /rules/isr-ttl/*	/.netlify/builders/server 200
-        /rules/isr/*	/.netlify/builders/server 200
-        /rules/dynamic	/.netlify/functions/server 200
-        /* /.netlify/functions/server 200"
+        /*	/.netlify/functions/server 200"
       `);
         /* eslint-enable no-tabs */
       });
@@ -74,19 +65,39 @@ describe("nitro:preset:netlify", async () => {
         );
         /* eslint-disable no-tabs */
         expect(headers).toMatchInlineSnapshot(`
-        "/rules/headers
-          cache-control: s-maxage=60
-        /rules/cors
-          access-control-allow-origin: *
-          access-control-allow-methods: GET
-          access-control-allow-headers: *
-          access-control-max-age: 0
-        /rules/nested/*
-          x-test: test
-        /build/*
-          cache-control: public, max-age=3600, immutable
-        "
-      `);
+"/rules/_/noncached/cached
+  Cache-Control: public, max-age=0, must-revalidate
+  Netlify-CDN-Cache-Control: public, max-age=0, stale-while-revalidate=31536000
+/rules/_/cached/noncached
+/rules/_/noncached/*
+/rules/_/cached/*
+  Cache-Control: public, max-age=0, must-revalidate
+  Netlify-CDN-Cache-Control: public, max-age=0, stale-while-revalidate=31536000
+/rules/headers
+  cache-control: s-maxage=60
+/rules/cors
+  access-control-allow-origin: *
+  access-control-allow-methods: GET
+  access-control-allow-headers: *
+  access-control-max-age: 0
+/rules/dynamic
+/rules/isr/*
+  Cache-Control: public, max-age=0, must-revalidate
+  Netlify-CDN-Cache-Control: public, max-age=0, stale-while-revalidate=31536000
+/rules/isr-ttl/*
+  Cache-Control: public, max-age=0, must-revalidate
+  Netlify-CDN-Cache-Control: public, max-age=60, must-revalidate
+/rules/swr/*
+  Cache-Control: public, max-age=0, must-revalidate
+  Netlify-CDN-Cache-Control: public, max-age=0, stale-while-revalidate=31536000
+/rules/swr-ttl/*
+  Cache-Control: public, max-age=0, must-revalidate
+  Netlify-CDN-Cache-Control: public, max-age=0, stale-while-revalidate=31536000
+/rules/nested/*
+  x-test: test
+/build/*
+  cache-control: public, max-age=3600, immutable
+"`);
         /* eslint-enable no-tabs */
       });
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves https://github.com/unjs/nitro/issues/1811

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
As stated in the issue, currently netlify "base" preset handles ISR by redirecting to either a normal function (no caching behaviour) or a builder function (cached on a per-URL basis). This approach has some downsides because of netlify ODB limitations (i.e.: no query parameters passed to the server, not so transparent cache control [specifically ttl parameter is quite hidden and not accessible directly])
<!-- Why is this change required? What problem does it solve? -->
This PR hopes to implement [new netlify caching swr strategy](https://www.netlify.com/blog/swr-and-fine-grained-cache-control/).

### A note on implementation:
I've arbitrarily implemented the SWR header when `isr` is set to true. This means that server response gets cached by up to 1 year in netlify edge cache servers, but gets revalidated each time. In contrast, setting a number in the `isr` routeRule defaults to the other caching method where page gets cached and not revalidated until cache expires.
Let me know if this behaviour is a good implementation of nitro routeRules API or needs to be changed.
### A note on documentation:
I'll document everything after changes gets approved
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
