### PR TITLE
fix(cache): allow setting multiple `set-cookie` headers (bad practice)

### DIFF
--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -5,6 +5,7 @@ import {
   createEvent,
   EventHandler,
   isEvent,
+  splitCookiesString,
 } from "h3";
 import type { EventHandlerRequest, EventHandlerResponse, H3Event } from "h3";
 import { parseURL } from "ufo";
@@ -404,7 +405,12 @@ export function defineCachedEventHandler<
     // Send status and headers
     event.node.res.statusCode = response.code;
     for (const name in response.headers) {
-      event.node.res.setHeader(name, response.headers[name]);
+      const value = response.headers[name];
+      if (name === "set-cookie") {
+        event.node.res.appendHeader(name, splitCookiesString(value as string[]));
+      } else {
+        event.node.res.setHeader(name, value);
+      }
     }
 
     // Send body

--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -407,7 +407,10 @@ export function defineCachedEventHandler<
     for (const name in response.headers) {
       const value = response.headers[name];
       if (name === "set-cookie") {
-        event.node.res.appendHeader(name, splitCookiesString(value as string[]));
+        event.node.res.appendHeader(
+          name,
+          splitCookiesString(value as string[])
+        );
       } else {
         event.node.res.setHeader(name, value);
       }

--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -407,6 +407,7 @@ export function defineCachedEventHandler<
     for (const name in response.headers) {
       const value = response.headers[name];
       if (name === "set-cookie") {
+        // TODO: Show warning and remove this header in the next major version of Nitro
         event.node.res.appendHeader(
           name,
           splitCookiesString(value as string[])


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#1837

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

cookie headers can be repeated, adapted from 
https://github.com/unjs/h3/blob/b7aca9614e7e8e8921fd54804463ce78fdb034f1/src/utils/response.ts#L341

I tried writing a test case for this but stuff didnt work as expected (doesnt help that my work PC is kinda locked down and on windows...), but I tested via playground and in my original nuxt project

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
