### PR TITLE
chore: use `nitropack-nightly` for nightly release channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - chore/nightly
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - chore/nightly
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,12 @@ jobs:
         env:
           NODE_OPTIONS: --experimental-vm-modules --enable-source-maps
       - uses: codecov/codecov-action@v3
-      - name: Release Edge
+      - name: Release Nightly
         if: |
           github.event_name == 'push' &&
           !contains(github.event.head_commit.message, '[skip-release]') &&
           !contains(github.event.head_commit.message, 'chore') &&
           !contains(github.event.head_commit.message, 'docs')
-        run: ./scripts/release-edge.sh
+        run: ./scripts/release-nightly.sh
         env:
           NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}

--- a/docs/content/1.guide/0.getting-started.md
+++ b/docs/content/1.guide/0.getting-started.md
@@ -94,18 +94,18 @@ npm run preview
 ```
 
 
-## Edge Release Channel
+## Nightly Release Channel
 
-Nitro offers an edge release channel that automatically releases for every commit to `main` branch.
+Nitro offers a nightly release channel that automatically releases for every commit to `main` branch.
 
-You can opt-in to the edge release channel by updating your `package.json`:
+You can opt-in to the nightly release channel by updating your `package.json`:
 
 ::code-group
 ```diff [Nitro]
 {
   "devDependencies": {
 --    "nitropack": "^2.0.0"
-++    "nitropack": "npm:nitropack-edge@latest"
+++    "nitropack": "npm:nitropack-nightly@latest"
   }
 }
 ```
@@ -120,7 +120,7 @@ You can opt-in to the edge release channel by updating your `package.json`:
 ::
 
 ::alert
-If you are using Nuxt, [use the Nuxt edge channel](https://nuxt.com/docs/guide/going-further/edge-channel#opting-into-the-edge-channel) as it already includes `nitropack-edge`.
+If you are using Nuxt, [use the Nuxt nightly channel](https://nuxt.com/docs/guide/going-further/nightly-release-channel#opting-in) as it already includes `nitropack-nightly`.
 ::
 
 Remove the lockfile (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, or `bun.lockb`) and reinstall the dependencies.

--- a/scripts/bump-nightly.ts
+++ b/scripts/bump-nightly.ts
@@ -118,7 +118,7 @@ async function main() {
       pkg.data.name,
       `${pkg.data.version}-${date}.${commit}`
     );
-    workspace.rename(pkg.data.name, pkg.data.name + "-edge");
+    workspace.rename(pkg.data.name, pkg.data.name + "-nightly");
     pkg.updateDeps((dep) => {
       if (nightlyPackages[dep.name]) {
         dep.range = "npm:" + nightlyPackages[dep.name] + "@latest";

--- a/scripts/release-nightly.sh
+++ b/scripts/release-nightly.sh
@@ -10,8 +10,8 @@ git restore -s@ -SW  -- .
 # Bump acording to changelog
 pnpm changelogen --bump
 
-# Bump versions to edge
-pnpm jiti ./scripts/bump-edge
+# Bump versions to nightly
+pnpm jiti ./scripts/bump-nightly
 
 # Resolve lockfile
 # pnpm install


### PR DESCRIPTION
- chore: switch to `nitropack-nightly` from `nitropack-edge`
- allow testing ci directly

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
