### PR TITLE
fix(cache): invalidate wrongly cached  handler entities

### DIFF
--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -257,7 +257,7 @@ export function defineCachedEventHandler<
       if (entry.value.body === undefined) {
         return false;
       }
-      // https://github.com/unjs/nitro/issues/1850
+      // https://github.com/unjs/nitro/pull/1857
       if (
         entry.value.headers.etag === "undefined" ||
         entry.value.headers["last-modified"] === "undefined"

--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -257,6 +257,13 @@ export function defineCachedEventHandler<
       if (entry.value.body === undefined) {
         return false;
       }
+      // https://github.com/unjs/nitro/issues/1850
+      if (
+        entry.value.headers.etag === "undefined" ||
+        entry.value.headers["last-modified"] === "undefined"
+      ) {
+        return false;
+      }
       return true;
     },
     group: opts.group || "nitro/handlers",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

#1850

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A regression from [v2.7.0](https://github.com/unjs/nitro/releases/tag/v2.7.0) cached the `etag` and `last-modified` headers of cached handler entities to become `undefined`. 

#1855 fixes the issue but if any production deployment used faulty behavior of 2.7.0, they could keep invalid entities in the cache until maxAge reaches.

This PR adds a core hotfix for this unfortunate incident and will be reverted after a while.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
