### PR TITLE
fix(cloudflare-pages): filter out overlapping public assets dirs

### DIFF
--- a/src/presets/cloudflare-pages.ts
+++ b/src/presets/cloudflare-pages.ts
@@ -1,6 +1,11 @@
 import { existsSync, promises as fsp } from "node:fs";
 import { resolve, join } from "pathe";
-import { joinURL, withLeadingSlash, withTrailingSlash, withoutLeadingSlash } from "ufo";
+import {
+  joinURL,
+  withLeadingSlash,
+  withTrailingSlash,
+  withoutLeadingSlash,
+} from "ufo";
 import { globby } from "globby";
 import { defineNitroPreset } from "../preset";
 import type { Nitro } from "../types";
@@ -102,7 +107,8 @@ async function writeCFRoutes(nitro: Nitro) {
       !dir.fallthrough &&
       !array.some(
         (otherDir, otherIndex) =>
-          otherIndex !== index && dir.baseURL.startsWith(withTrailingSlash(otherDir.baseURL))
+          otherIndex !== index &&
+          dir.baseURL.startsWith(withTrailingSlash(otherDir.baseURL))
       )
   );
 

--- a/src/presets/cloudflare-pages.ts
+++ b/src/presets/cloudflare-pages.ts
@@ -103,13 +103,21 @@ async function writeCFRoutes(nitro: Nitro) {
 
   // Exclude public assets from hitting the worker
   const explicitPublicAssets = nitro.options.publicAssets.filter(
-    (dir, index, array) =>
-      !dir.fallthrough &&
-      !array.some(
+    (dir, index, array) => {
+      if (dir.fallthrough) {
+        return false;
+      }
+
+      const normalizedBase = withoutLeadingSlash(dir.baseURL);
+
+      return !array.some(
         (otherDir, otherIndex) =>
           otherIndex !== index &&
-          dir.baseURL.startsWith(withTrailingSlash(otherDir.baseURL))
-      )
+          normalizedBase.startsWith(
+            withoutLeadingSlash(withTrailingSlash(otherDir.baseURL))
+          )
+      );
+    }
   );
 
   // Explicit prefixes

--- a/src/presets/cloudflare-pages.ts
+++ b/src/presets/cloudflare-pages.ts
@@ -98,7 +98,12 @@ async function writeCFRoutes(nitro: Nitro) {
 
   // Exclude public assets from hitting the worker
   const explicitPublicAssets = nitro.options.publicAssets.filter(
-    (dir, index, array) => !dir.fallthrough && !array.some((otherDir, otherIndex) => otherIndex !== index && dir.baseURL.startsWith(otherDir.baseURL + '/'))
+    (dir, index, array) =>
+      !dir.fallthrough &&
+      !array.some(
+        (otherDir, otherIndex) =>
+          otherIndex !== index && dir.baseURL.startsWith(otherDir.baseURL + "/")
+      )
   );
 
   // Explicit prefixes

--- a/src/presets/cloudflare-pages.ts
+++ b/src/presets/cloudflare-pages.ts
@@ -1,6 +1,6 @@
 import { existsSync, promises as fsp } from "node:fs";
 import { resolve, join } from "pathe";
-import { joinURL, withLeadingSlash, withoutLeadingSlash } from "ufo";
+import { joinURL, withLeadingSlash, withTrailingSlash, withoutLeadingSlash } from "ufo";
 import { globby } from "globby";
 import { defineNitroPreset } from "../preset";
 import type { Nitro } from "../types";
@@ -102,7 +102,7 @@ async function writeCFRoutes(nitro: Nitro) {
       !dir.fallthrough &&
       !array.some(
         (otherDir, otherIndex) =>
-          otherIndex !== index && dir.baseURL.startsWith(otherDir.baseURL + "/")
+          otherIndex !== index && dir.baseURL.startsWith(withTrailingSlash(otherDir.baseURL))
       )
   );
 

--- a/src/presets/cloudflare-pages.ts
+++ b/src/presets/cloudflare-pages.ts
@@ -98,7 +98,7 @@ async function writeCFRoutes(nitro: Nitro) {
 
   // Exclude public assets from hitting the worker
   const explicitPublicAssets = nitro.options.publicAssets.filter(
-    (i) => !i.fallthrough
+    (dir, index, array) => !dir.fallthrough && !array.some((otherDir, otherIndex) => otherIndex !== index && dir.baseURL.startsWith(otherDir.baseURL + '/'))
   );
 
   // Explicit prefixes


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves https://github.com/unjs/nitro/issues/1844

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Cloudflare doesn't expect to have overlapping public assets dirs. This prevents using overlapping dirs, preferring instead the top level dir if it overlaps a child dir.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
