### PR TITLE
feat: support `inline` mode for `serveStatic`

### DIFF
--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -102,6 +102,7 @@ export function readAsset (id) {
   export function readAsset (id) {
     if (!assets[id]) { return undefined }
     if (assets[id]._data) { return assets[id]._data }
+    if (!assets[id].data) { return assets[id].data }
     assets[id]._data = Uint8Array.from(atob(assets[id].data), (c) => c.charCodeAt(0))
     return assets[id]._data
 }`;

--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -57,7 +57,10 @@ export function publicAssets(nitro: Nitro): Plugin {
             mtime: stat.mtime.toJSON(),
             size: stat.size,
             path: relative(nitro.options.output.serverDir, fullPath),
-            data: assetData.toString("base64"),
+            data:
+              nitro.options.serveStatic === "inline"
+                ? assetData.toString("base64")
+                : undefined,
           };
         }
 

--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -8,6 +8,17 @@ import type { Nitro } from "../../types";
 import { virtual } from "./virtual";
 import type { PublicAsset } from "#internal/nitro/virtual/public-assets";
 
+const readAssetHandler: Record<
+  Exclude<Nitro["options"]["serveStatic"] | "true" | "false", boolean>,
+  "node" | "deno" | "null" | "inline"
+> = {
+  true: "node",
+  node: "node",
+  false: "null",
+  deno: "deno",
+  inline: "inline",
+};
+
 export function publicAssets(nitro: Nitro): Plugin {
   return virtual(
     {
@@ -46,6 +57,7 @@ export function publicAssets(nitro: Nitro): Plugin {
             mtime: stat.mtime.toJSON(),
             size: stat.size,
             path: relative(nitro.options.output.serverDir, fullPath),
+            data: assetData.toString("base64"),
           };
         }
 
@@ -73,6 +85,24 @@ export function readAsset (id) {
   return Deno.readFile(path);
 }`;
       },
+      // #internal/nitro/virtual/public-assets-null
+      "#internal/nitro/virtual/public-assets-null": () => {
+        return `
+    export function readAsset (id) {
+        return Promise.resolve(null);
+    }`;
+      },
+      // #internal/nitro/virtual/public-assets-inline
+      "#internal/nitro/virtual/public-assets-inline": () => {
+        return `
+  import assets from '#internal/nitro/virtual/public-assets-data'
+  export function readAsset (id) {
+    if (!assets[id]) { return undefined }
+    if (assets[id]._data) { return assets[id]._data }
+    assets[id]._data = Uint8Array.from(atob(assets[id].data), (c) => c.charCodeAt(0))
+    return assets[id]._data
+}`;
+      },
       // #internal/nitro/virtual/public-assets
       "#internal/nitro/virtual/public-assets": () => {
         const publicAssetBases = Object.fromEntries(
@@ -81,18 +111,13 @@ export function readAsset (id) {
             .map((dir) => [dir.baseURL, { maxAge: dir.maxAge }])
         );
 
+        const readAssetImport = `#internal/nitro/virtual/public-assets-${
+          readAssetHandler[nitro.options.serveStatic as string] || "none"
+        }`;
+
         return `
 import assets from '#internal/nitro/virtual/public-assets-data'
-${
-  nitro.options.serveStatic
-    ? `export * from "#internal/nitro/virtual/public-assets-${
-        ["deno"].includes(nitro.options.serveStatic as string)
-          ? nitro.options.serveStatic
-          : "node"
-      }"`
-    : "export const readAsset = () => Promise.resolve(null)"
-}
-
+export { readAsset } from "${readAssetImport}"
 export const publicAssetBases = ${JSON.stringify(publicAssetBases)}
 
 export function isPublicAssetURL(id = '') {

--- a/src/runtime/virtual/public-assets.d.ts
+++ b/src/runtime/virtual/public-assets.d.ts
@@ -11,4 +11,5 @@ export interface PublicAsset {
   path: string;
   size: number;
   encoding?: string;
+  data?: string;
 }

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -230,7 +230,7 @@ export interface NitroOptions extends PresetOptions {
   bundledStorage: string[];
   timing: boolean;
   renderer?: string;
-  serveStatic: boolean | "node" | "deno";
+  serveStatic: boolean | "node" | "deno" | "inline";
   noPublicDir: boolean;
   /** @experimental Requires `experimental.wasm` to be effective */
   wasm?: WasmOptions;


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Extracted from #1863.

This new mode allows for edge conditions that it is only possible to serve static assets using their inline value. 

Also makes refactors for future improvements in public asset plugin.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
