### PR TITLE
fix(scanner): allow having http method as part of the route name

### DIFF
--- a/src/scan.ts
+++ b/src/scan.ts
@@ -7,7 +7,7 @@ export const GLOB_SCAN_PATTERN = "**/*.{js,mjs,cjs,ts,mts,cts,tsx,jsx}";
 type FileInfo = { path: string; fullPath: string };
 
 const httpMethodRegex =
-  /\.(connect|delete|get|head|options|patch|post|put|trace)/;
+  /\.(connect|delete|get|head|options|patch|post|put|trace)$/;
 
 export async function scanHandlers(nitro: Nitro) {
   const middleware = await scanMiddleware(nitro);

--- a/test/fixture/api/methods/foo.get.get.ts
+++ b/test/fixture/api/methods/foo.get.get.ts
@@ -1,0 +1,1 @@
+export default defineEventHandler(() => "foo.get");

--- a/test/fixture/api/methods/get.ts
+++ b/test/fixture/api/methods/get.ts
@@ -1,0 +1,1 @@
+export default defineEventHandler(() => "get");

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -620,4 +620,13 @@ export function testNitro(
       }
     );
   });
+
+  describe("scanned files", () => {
+    it("Allow having extra method in file name", async () => {
+      expect((await callHandler({ url: "/api/methods/get" })).data).toBe("get");
+      expect((await callHandler({ url: "/api/methods/foo.get" })).data).toBe(
+        "foo.get"
+      );
+    });
+  });
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Partial fix for #1378

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This change allows having an extra method as part of the file name. The last segment will be still removed as extension so `routes/foo.get.get.ts` will be mapped to `/foo.get` but `routes/foo.get.ts` to `/foo` (GET) as before.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
