### PR TITLE
feat(cloudflare-pages, cloudflare-module): enable code splitting by default

### DIFF
--- a/docs/content/2.deploy/20.providers/cloudflare.md
+++ b/docs/content/2.deploy/20.providers/cloudflare.md
@@ -22,6 +22,10 @@ compatibility_date = "2022-09-10"
 account_id = "<the account_id you obtained (optional)>"
 route = "<mainly useful when you want to setup custom domains (optional too)>"
 
+rules = [
+  { type = "ESModule", globs = ["**/*.js", "**/*.mjs"]},
+]
+
 [site]
 bucket = ".output/public"
 ```
@@ -295,33 +299,6 @@ SECRET="top-secret"
 ```
 
 ## Advanced
-
-### Experimental Dynamic Imports
-
-By default cloudflare presets output to a single bundle file.
-
-In order to try experimental dynamic imports you need to set the `NITRO_EXP_CLOUDFLARE_DYNAMIC_IMPORTS` environment variable for build command.
-
-::alert{type="warning"}
-This is an experimental mode and is likely not working at the moment!
-::
-
-With `cloudflare_module` preset, you need to add the following rule to your `wrangler.toml` file:
-
-```diff [wrangler.toml]
-  name = "playground"
-  main = "./.output/server/index.mjs"
-  workers_dev = true
-  compatibility_date = "2022-09-10"
-  account_id = "<the account_id you obtained (optional)>"
-  route = "<mainly useful when you want to setup custom domains (optional too)>"
-+ rules = [
-+   { type = "ESModule", globs = ["**/*.js", "**/*.mjs"]},
-+ ]
-
-  [site]
-  bucket = ".output/public"
-```
 
 ### Local Wrangler Dev builds
 

--- a/src/presets/cloudflare-module.ts
+++ b/src/presets/cloudflare-module.ts
@@ -17,17 +17,10 @@ export const cloudflareModule = defineNitroPreset({
     output: {
       format: "esm",
       exports: "named",
+      inlineDynamicImports: false,
     },
   },
   hooks: {
-    "rollup:before"(_nitro, rollupConfig) {
-      if (process.env.NITRO_EXP_CLOUDFLARE_DYNAMIC_IMPORTS) {
-        rollupConfig.output = {
-          ...rollupConfig.output,
-          inlineDynamicImports: false,
-        };
-      }
-    },
     async compiled(nitro: Nitro) {
       await writeFile(
         resolve(nitro.options.output.dir, "package.json"),

--- a/src/presets/cloudflare-pages.ts
+++ b/src/presets/cloudflare-pages.ts
@@ -31,12 +31,15 @@ export const cloudflarePages = defineNitroPreset({
   rollupConfig: {
     output: {
       entryFileNames: "index.js",
-      dir: resolve("{{ output.dir }}", "_worker.js"),
+      dir: "{{ output.dir }}/_worker.js",
       format: "esm",
       inlineDynamicImports: false,
     },
   },
   hooks: {
+    "rollup:before": (nitro, rollupConfig) => {
+      rollupConfig.output.dir = resolve(nitro.options.output.serverDir, "_worker.js");
+    },
     async compiled(nitro: Nitro) {
       await writeCFRoutes(nitro);
     },

--- a/src/presets/cloudflare-pages.ts
+++ b/src/presets/cloudflare-pages.ts
@@ -21,7 +21,7 @@ export const cloudflarePages = defineNitroPreset({
   output: {
     dir: "{{ rootDir }}/dist",
     publicDir: "{{ output.dir }}",
-    serverDir: "{{ output.dir }}",
+    serverDir: "{{ output.dir }}/_worker.js",
   },
   alias: {
     // Hotfix: Cloudflare appends /index.html if mime is not found and things like ico are not in standard lite.js!
@@ -31,18 +31,11 @@ export const cloudflarePages = defineNitroPreset({
   rollupConfig: {
     output: {
       entryFileNames: "index.js",
-      dir: "{{ output.dir }}/_worker.js",
       format: "esm",
       inlineDynamicImports: false,
     },
   },
   hooks: {
-    "rollup:before": (nitro, rollupConfig) => {
-      rollupConfig.output.dir = resolve(
-        nitro.options.output.serverDir,
-        "_worker.js"
-      );
-    },
     async compiled(nitro: Nitro) {
       await writeCFRoutes(nitro);
     },

--- a/src/presets/cloudflare-pages.ts
+++ b/src/presets/cloudflare-pages.ts
@@ -38,7 +38,10 @@ export const cloudflarePages = defineNitroPreset({
   },
   hooks: {
     "rollup:before": (nitro, rollupConfig) => {
-      rollupConfig.output.dir = resolve(nitro.options.output.serverDir, "_worker.js");
+      rollupConfig.output.dir = resolve(
+        nitro.options.output.serverDir,
+        "_worker.js"
+      );
     },
     async compiled(nitro: Nitro) {
       await writeCFRoutes(nitro);

--- a/src/presets/cloudflare-pages.ts
+++ b/src/presets/cloudflare-pages.ts
@@ -30,21 +30,13 @@ export const cloudflarePages = defineNitroPreset({
   },
   rollupConfig: {
     output: {
-      entryFileNames: "_worker.js",
+      entryFileNames: "index.js",
+      dir: resolve("{{ output.dir }}", "_worker.js"),
       format: "esm",
+      inlineDynamicImports: false,
     },
   },
   hooks: {
-    "rollup:before"(nitro, rollupConfig) {
-      if (process.env.NITRO_EXP_CLOUDFLARE_DYNAMIC_IMPORTS) {
-        rollupConfig.output = {
-          ...rollupConfig.output,
-          entryFileNames: "index.js",
-          dir: resolve(nitro.options.output.serverDir, "_worker.js"),
-          inlineDynamicImports: false,
-        };
-      }
-    },
     async compiled(nitro: Nitro) {
       await writeCFRoutes(nitro);
     },

--- a/test/presets/cloudflare-pages.test.ts
+++ b/test/presets/cloudflare-pages.test.ts
@@ -12,7 +12,7 @@ describe("nitro:preset:cloudflare-pages", async () => {
   testNitro(ctx, () => {
     const mf = new Miniflare({
       modules: true,
-      scriptPath: resolve(ctx.outDir, "_worker.js"),
+      scriptPath: resolve(ctx.outDir, "_worker.js", "index.js"),
       globals: { __env__: {} },
       compatibilityFlags: ["streams_enable_constructors"],
       bindings: {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

remove the NITRO_EXP_CLOUDFLARE_DYNAMIC_IMPORTS flag (added in https://github.com/unjs/nitro/pull/1172) used to enable code splitting with lazy loading for the cloudflare-pages and cloudflare_module presets and enable such behavior by default since that is not stable and working with up-to-date versions of wrangler

For the stability of this feature please have a look at these reproductions: https://github.com/dario-piotrowicz/nitro-nuxt-lazy-loading-test/tree/main

They show that things do work fine (both locally and in production) when using lazy loading :muscle: 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
