### PR TITLE
fix(prerender): decode generated routes

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -380,7 +380,7 @@ function extractLinks(
   if (crawlLinks) {
     _links.push(
       ...[...html.matchAll(LINK_REGEX)]
-        .map((m) => escapeHtml(m[1]))
+        .map((m) => decodeURIComponent(escapeHtml(m[1])))
         .filter((link) => allowedExtensions.has(getExtension(link)))
     );
   }

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -155,6 +155,9 @@ export async function prerender(nitro: Nitro) {
   const generateRoute = async (route: string) => {
     const start = Date.now();
 
+    // Ensure route is decoded to start with
+    route = decodeURI(route);
+
     // Check if we should render route
     if (!canPrerender(route)) {
       skippedRoutes.add(route);
@@ -380,19 +383,14 @@ function extractLinks(
   if (crawlLinks) {
     _links.push(
       ...[...html.matchAll(LINK_REGEX)]
-        .map((m) => decodeURIComponent(escapeHtml(m[1])))
+        .map((m) => escapeHtml(m[1]))
         .filter((link) => allowedExtensions.has(getExtension(link)))
     );
   }
 
   // Extract from x-nitro-prerender headers
   const header = res.headers.get("x-nitro-prerender") || "";
-  _links.push(
-    ...header
-      .split(",")
-      .map((i) => i.trim())
-      .map((i) => decodeURIComponent(i))
-  );
+  _links.push(...header.split(",").map((i) => i.trim()));
 
   for (const link of _links.filter(Boolean)) {
     const _link = parseURL(link);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/22660
closes https://github.com/nuxt/nuxt/pull/24320

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When a link is rendered in HTML (e.g. by vue router) with URI components, Nitro currently does not decode these when requesting the URL, which can cause double encoding and a 404 from vue-router.

Instead we should likely decode the link at source, just as we do with headers.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
