### PR TITLE
fix(error): respect `accept: text/html` request header

### DIFF
--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -40,15 +40,12 @@ export function hasReqHeader(event: H3Event, name: string, includes: string) {
 }
 
 export function isJsonRequest(event: H3Event) {
-  // First adhere to the "Accept" header, to match what the client expects to receive.
-  if (hasReqHeader(event, "accept", "application/json")) {
-    return true;
-  }
+  // If the client specifically requests HTML, then avoid classifying as JSON.
   if (hasReqHeader(event, "accept", "text/html")) {
     return false;
   }
-  // Fallback rules, when no explicit request for the content type is made.
   return (
+    hasReqHeader(event, "accept", "application/json") ||
     hasReqHeader(event, "user-agent", "curl/") ||
     hasReqHeader(event, "user-agent", "httpie/") ||
     hasReqHeader(event, "sec-fetch-mode", "cors") ||

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -41,8 +41,12 @@ export function hasReqHeader(event: H3Event, name: string, includes: string) {
 
 export function isJsonRequest(event: H3Event) {
   // First adhere to the "Accept" header, to match what the client expects to receive.
-  if (hasReqHeader(event, "accept", "application/json")) return true;
-  if (hasReqHeader(event, "accept", "text/html")) return false;
+  if (hasReqHeader(event, "accept", "application/json")) {
+    return true;
+  }
+  if (hasReqHeader(event, "accept", "text/html")) {
+    return false;
+  }
   // Fallback rules, when no explicit request for the content type is made.
   return (
     hasReqHeader(event, "user-agent", "curl/") ||

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -40,8 +40,11 @@ export function hasReqHeader(event: H3Event, name: string, includes: string) {
 }
 
 export function isJsonRequest(event: H3Event) {
+  // First adhere to the "Accept" header, to match what the client expects to receive.
+  if (hasReqHeader(event, "accept", "application/json")) return true;
+  if (hasReqHeader(event, "accept", "text/html")) return false;
+  // Fallback rules, when no explicit request for the content type is made.
   return (
-    hasReqHeader(event, "accept", "application/json") ||
     hasReqHeader(event, "user-agent", "curl/") ||
     hasReqHeader(event, "user-agent", "httpie/") ||
     hasReqHeader(event, "sec-fetch-mode", "cors") ||


### PR DESCRIPTION
Requests made with the Fetch API cause `sec-fetch-mode` to be set, leading to these requests to be identified as JSON requests. The default error handler uses isJsonRequest to render errors. If a request were to set the Accept header to "text/html" the response should be HTML as well.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#1919 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->

`isJsonRequest` is modified, its only usage (within nitro) is by the default event handler to determine when to serialize errors as HTML or JSON.

<!-- Why is this change required? What problem does it solve? -->
This change is needed because requests made with the Fetch API automatically get the `sec-fetch-mode=cors` header. This header is one of the conditions by which `isJsonRequest` function identifies JSON, but the header has no such meaning as far as the standard is concerned.

More importantly, the function does not provide any means to enforce an HTML response (for `isJsonRequest` to return false) when these fallback detections are used.

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Resolves #1919 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
