### PR TITLE
fix(prerender): decode uris in headers

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -390,7 +390,7 @@ function extractLinks(
 
   // Extract from x-nitro-prerender headers
   const header = res.headers.get("x-nitro-prerender") || "";
-  _links.push(...header.split(",").map((i) => i.trim()));
+  _links.push(...header.split(",").map((i) => decodeURIComponent(i.trim())));
 
   for (const link of _links.filter(Boolean)) {
     const _link = parseURL(link);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/unjs/nitro/pull/1914
https://github.com/nuxt/nuxt/actions/runs/6923600748/job/18832536383?pr=24370#step:13:66

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Because we are using the scanned links to create a new URL we need to ensure they are decoded first:

https://github.com/unjs/nitro/blob/df7091dc9593b19977b6183497746e0e97a8b44f/src/prerender.ts#L396-L404

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
