### PR TITLE
fix(prerender): avoid detecting `.json` routes as implicit html

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -220,7 +220,9 @@ export async function prerender(nitro: Nitro) {
     // Guess route type and populate fileName
     const contentType = res.headers.get("content-type") || "";
     const isImplicitHTML =
-      !route.endsWith(".html") && contentType.includes("html");
+      !route.endsWith(".html") &&
+      !route.endsWith(".json") &&
+      contentType.includes("html");
     const routeWithIndex = route.endsWith("/") ? route + "index" : route;
     const htmlPath =
       route.endsWith("/") || nitro.options.prerender.autoSubfolderIndex


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

On investigation, there are cases where a framework renderer, returns `text/html` responses for routes ending with `.json` extension. Content is most likely also wrong (it does not fix https://github.com/nuxt/nuxt/issues/24487 only generates `manifest.json` with HTML in it!) but at least avoids making wrong structure.

(root cause is that Nuxt ordering is different and first prerenders and then copies public assets)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
