### PR TITLE
fix(prerenderer): write responses with json signuture to original path

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -14,6 +14,8 @@ import { compressPublicAssets } from "./compress";
 
 const allowedExtensions = new Set(["", ".json"]);
 
+const JsonSigRx = /^\s*["[{]|^\s*-?\d{1,16}(\.\d{1,17})?([Ee][+-]?\d+)?\s*$/;
+
 const linkParents = new Map<string, Set<string>>();
 
 export async function prerender(nitro: Nitro) {
@@ -220,7 +222,9 @@ export async function prerender(nitro: Nitro) {
     // Guess route type and populate fileName
     const contentType = res.headers.get("content-type") || "";
     const isImplicitHTML =
-      !route.endsWith(".html") && contentType.includes("html");
+      !route.endsWith(".html") &&
+      contentType.includes("html") &&
+      !JsonSigRx.test(dataBuff.subarray(0, 32).toString("utf8"));
     const routeWithIndex = route.endsWith("/") ? route + "index" : route;
     const htmlPath =
       route.endsWith("/") || nitro.options.prerender.autoSubfolderIndex

--- a/test/fixture/routes/json-string.ts
+++ b/test/fixture/routes/json-string.ts
@@ -1,0 +1,3 @@
+export default eventHandler(() => {
+  return '{"foo":"bar"}';
+});

--- a/test/fixture/routes/prerender.ts
+++ b/test/fixture/routes/prerender.ts
@@ -12,6 +12,7 @@ export default defineEventHandler((event) => {
     "../api/hey",
     "/api/param/foo.json",
     "/api/param/foo.css",
+    "/json-string",
     event.path.includes("?") ? "/api/param/hidden" : "/prerender?withQuery",
   ];
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

See #1962 for some context

When prerendering, a route without `.html` extension (like `/foo` or `/foo.json`, etc) could contain a JSON response (wrongly because returned by h3 handler or a SSR renderer). 

Nitro were trusting purely on content-type to detect HTML routes and write `/foo` to `public/foo/index.html`.

With this PR, if response contents of `/foo` contains a JSON signature, we write it to `public/foo` as-is.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
