### PR TITLE
feat: support function/RegExp for `prerender.ignore`

### DIFF
--- a/docs/content/3.config.md
+++ b/docs/content/3.config.md
@@ -357,7 +357,7 @@ Default:
 
 Prerendered options. Any route specified will be fetched during the build and copied to the `.output/public` directory as a static asset.
 
-Any route that starts with a prefix listed in `ignore` will be ignored.
+Any route that starts with a prefix listed in `ignore` will be ignored (or has a regular expression or function that matches the route).
 
 If `crawlLinks` option is set to `true`, nitro starts with `/` by default (or all routes in `routes` array) and for HTML pages extracts `<a>` tags and prerender them as well.
 

--- a/docs/content/3.config.md
+++ b/docs/content/3.config.md
@@ -357,7 +357,7 @@ Default:
 
 Prerendered options. Any route specified will be fetched during the build and copied to the `.output/public` directory as a static asset.
 
-Any route that starts with a prefix listed in `ignore` will be ignored (or has a regular expression or function that matches the route).
+Any route that starts with a prefix listed in `ignore` (or matches a regular expression or function listed in ignore) will be ignored.
 
 If `crawlLinks` option is set to `true`, nitro starts with `/` by default (or all routes in `routes` array) and for HTML pages extracts `<a>` tags and prerender them as well.
 

--- a/docs/content/3.config.md
+++ b/docs/content/3.config.md
@@ -357,7 +357,7 @@ Default:
 
 Prerendered options. Any route specified will be fetched during the build and copied to the `.output/public` directory as a static asset.
 
-Any route that starts with a prefix listed in `ignore` (or matches a regular expression or function listed in ignore) will be ignored.
+Any route (string) that starts with a prefix listed in `ignore` or matches a regular expression or function will be ignored.
 
 If `crawlLinks` option is set to `true`, nitro starts with `/` by default (or all routes in `routes` array) and for HTML pages extracts `<a>` tags and prerender them as well.
 

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -453,12 +453,18 @@ function formatPrerenderRoute(route: PrerenderRoute) {
 type IgnorePattern = string | RegExp | ((path: string) => undefined | null | boolean);
 
 function matchesIgnorePattern(path: string, pattern: IgnorePattern) {
-  // TODO: support radix3 patterns
   if (typeof pattern === "string") {
-    return path.startsWith(pattern);
+    // TODO: support radix3 patterns
+    return path.startsWith(pattern as string);
   }
+
+  if (typeof pattern === "function") {
+    return pattern(path) === true;
+  }
+
   if (pattern instanceof RegExp) {
     return pattern.test(path);
   }
-  return pattern(path);
+
+  return false;
 }

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -104,8 +104,8 @@ export async function prerender(nitro: Nitro) {
     }
 
     // Check for explicitly ignored routes
-    for (const ignore of nitro.options.prerender.ignore) {
-      if (route.startsWith(ignore)) {
+    for (const pattern of nitro.options.prerender.ignore) {
+      if (matchesIgnorePattern(route, pattern)) {
         return false;
       }
     }
@@ -447,4 +447,18 @@ function formatPrerenderRoute(route: PrerenderRoute) {
   }
 
   return chalk.gray(str);
+}
+
+// prettier-ignore
+type IgnorePattern = string | RegExp | ((path: string) => undefined | null | boolean);
+
+function matchesIgnorePattern(path: string, pattern: IgnorePattern) {
+  // TODO: support radix3 patterns
+  if (typeof pattern === "string") {
+    return path.startsWith(pattern);
+  }
+  if (pattern instanceof RegExp) {
+    return pattern.test(path);
+  }
+  return pattern(path);
 }

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -327,7 +327,9 @@ export interface NitroOptions extends PresetOptions {
     interval: number;
     crawlLinks: boolean;
     failOnError: boolean;
-    ignore: string[];
+    ignore: Array<
+      string | RegExp | ((path: string) => undefined | null | boolean)
+    >;
     routes: string[];
     /**
      * Amount of retries. Pass Infinity to retry indefinitely.


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This supports `prerender.ignore` as regular expressions or functions that accept a path and return a boolean.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
