### PR TITLE
fix: provide fetch utils to `cacheEventHandler` event

### DIFF
--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -349,6 +349,8 @@ export function defineCachedEventHandler<
 
       // Call handler
       const event = createEvent(reqProxy, resProxy);
+      event.fetch = incomingEvent.fetch
+      event.$fetch = incomingEvent.$fetch
       event.context = incomingEvent.context;
       const body = (await handler(event)) || _resSendBody;
 

--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -349,8 +349,8 @@ export function defineCachedEventHandler<
 
       // Call handler
       const event = createEvent(reqProxy, resProxy);
-      event.fetch = incomingEvent.fetch
-      event.$fetch = incomingEvent.$fetch
+      event.fetch = incomingEvent.fetch;
+      event.$fetch = incomingEvent.$fetch;
       event.context = incomingEvent.context;
       const body = (await handler(event)) || _resSendBody;
 

--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -349,8 +349,8 @@ export function defineCachedEventHandler<
 
       // Call handler
       const event = createEvent(reqProxy, resProxy);
-      event.fetch = incomingEvent.fetch;
-      event.$fetch = incomingEvent.$fetch;
+      event.fetch = globalThis.fetch;
+      event.$fetch = globalThis.$fetch;
       event.context = incomingEvent.context;
       const body = (await handler(event)) || _resSendBody;
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves https://github.com/unjs/nitro/issues/1848

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I have an endpoint that may or may not be cached that is relying on `event.$fetch` for internal fetch's, when cached using route rules, it will throw an error.

>  e.$fetch is not a function.

I don't see why the mock event can't have these, let me know if I missed something though.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
