### PR TITLE
refactor: include framework name in more build packages

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -425,7 +425,9 @@ async function _build(nitro: Nitro, rollupConfig: RollupConfig) {
   await writeFile(buildInfoPath, JSON.stringify(buildInfo, null, 2));
 
   if (!nitro.options.static) {
-    nitro.logger.success(`${nitroServerName(nitro)} built`);
+    if (nitro.options.logging.buildSuccess) {
+      nitro.logger.success(`${nitroServerName(nitro)} built`);
+    }
     if (nitro.options.logLevel > 1) {
       process.stdout.write(
         await generateFSTree(nitro.options.output.serverDir, {

--- a/src/build.ts
+++ b/src/build.ts
@@ -26,6 +26,7 @@ import {
   writeFile,
   isDirectory,
   resolvePath as resolveNitroPath,
+  nitroServerName,
 } from "./utils";
 import { GLOB_SCAN_PATTERN, scanHandlers } from "./scan";
 import type { Nitro, NitroBuildInfo } from "./types";
@@ -397,7 +398,7 @@ async function _build(nitro: Nitro, rollupConfig: RollupConfig) {
 
   if (!nitro.options.static) {
     nitro.logger.info(
-      `Building Nitro Server (preset: \`${nitro.options.preset}\`)`
+      `Building ${nitroServerName(nitro)} (preset: \`${nitro.options.preset}\`)`
     );
     const build = await rollup.rollup(rollupConfig).catch((error) => {
       nitro.logger.error(formatRollupError(error));
@@ -424,7 +425,7 @@ async function _build(nitro: Nitro, rollupConfig: RollupConfig) {
   await writeFile(buildInfoPath, JSON.stringify(buildInfo, null, 2));
 
   if (!nitro.options.static) {
-    nitro.logger.success("Nitro server built");
+    nitro.logger.success(`${nitroServerName(nitro)} built`);
     if (nitro.options.logLevel > 1) {
       process.stdout.write(
         await generateFSTree(nitro.options.output.serverDir, {
@@ -484,14 +485,9 @@ function startRollupWatcher(nitro: Nitro, rollupConfig: RollupConfig) {
       case "END": {
         nitro.hooks.callHook("compiled", nitro);
 
-        if (nitro.options.logging.devBuildSuccess) {
-          let message = `Nitro Server`;
-          if (nitro.options.framework.name !== "nitro") {
-            const _name = upperFirst(nitro.options.framework.name);
-            message = `${_name} ${message}`;
-          }
+        if (nitro.options.logging.buildSuccess) {
           nitro.logger.success(
-            `${message} built`,
+            `${nitroServerName(nitro)} built`,
             start ? `in ${Date.now() - start} ms` : ""
           );
         }

--- a/src/options.ts
+++ b/src/options.ts
@@ -73,7 +73,7 @@ const NitroDefaults: NitroConfig = {
   // Logging
   logging: {
     compressedSizes: true,
-    devBuildSuccess: true,
+    buildSuccess: true,
   },
 
   // Routing

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -309,7 +309,7 @@ export interface NitroOptions extends PresetOptions {
   // Logging
   logging: {
     compressedSizes: boolean;
-    devBuildSuccess: boolean;
+    buildSuccess: boolean;
   };
 
   // Routing

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,6 +8,7 @@ import chalk from "chalk";
 import { getProperty } from "dot-prop";
 import { provider } from "std-env";
 import type { ProviderName } from "std-env";
+import { upperFirst } from "scule";
 import { KebabCase, Nitro } from "../types";
 import type * as _PRESETS from "../presets";
 
@@ -230,4 +231,10 @@ export function provideFallbackValues(obj: Record<string, any>) {
       provideFallbackValues(obj[key]);
     }
   }
+}
+
+export function nitroServerName(nitro: Nitro) {
+  return nitro.options.framework.name === "nitro"
+    ? "Nitro Server"
+    : `${upperFirst(nitro.options.framework.name)} Nitro server`;
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Refactor on top of #1955 

This adds framework name in logs also for custom framework name.

Also renamed `devDuildSuccess` config to `buildSuccess`

![image](https://github.com/unjs/nitro/assets/5158436/ec072a0a-9e44-4242-a2be-7ea168ffc586)


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
