### PR TITLE
refactor(cloudflare): remove `--local` from perview commands

### DIFF
--- a/src/presets/cloudflare-module.ts
+++ b/src/presets/cloudflare-module.ts
@@ -9,7 +9,7 @@ export const cloudflareModule = defineNitroPreset({
   entry: "#internal/nitro/entries/cloudflare-module",
   exportConditions: ["workerd"],
   commands: {
-    preview: "npx wrangler dev ./server/index.mjs --site ./public --local",
+    preview: "npx wrangler dev ./server/index.mjs --site ./public",
     deploy: "npx wrangler deploy",
   },
   rollupConfig: {

--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -8,7 +8,7 @@ export const cloudflare = defineNitroPreset({
   entry: "#internal/nitro/entries/cloudflare",
   exportConditions: ["workerd"],
   commands: {
-    preview: "npx wrangler dev ./server/index.mjs --site ./public --local",
+    preview: "npx wrangler dev ./server/index.mjs --site ./public",
     deploy: "npx wrangler deploy",
   },
   wasm: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`wrangler dev` doesn't require `--local` anymore (and it will be removed in a future major version) so it should be removed from the cloudflare preview commands

See:
![Screenshot at 2023-12-03 19-28-16](https://github.com/unjs/nitro/assets/61631103/74ba9992-7f87-44d3-9302-f535e639b1da)
