### PR TITLE
refactor(cloudflare): remove unused import

### DIFF
--- a/src/presets/cloudflare-module.ts
+++ b/src/presets/cloudflare-module.ts
@@ -1,4 +1,3 @@
-import { readFile } from "node:fs/promises";
 import { resolve } from "pathe";
 import { writeFile } from "../utils";
 import { defineNitroPreset } from "../preset";


### PR DESCRIPTION
I just spotted an unused import in the `cloudflare-module.ts` file and figured I could remove it :stuck_out_tongue: 
