### PR TITLE
feat(storage): provide type safety for useStorage

### DIFF
--- a/src/runtime/storage.ts
+++ b/src/runtime/storage.ts
@@ -1,8 +1,8 @@
 import type { Storage, StorageValue } from "unstorage";
 import { prefixStorage } from "unstorage";
+import { mountPoints } from "../../utils/storage";
+import type { StorageKeys } from "../../types/utils";
 import { storage } from "#internal/nitro/virtual/storage";
-import {mountPoints} from "../../utils/storage"
-import type {StorageKeys} from "../../types/utils"
 
 export function useStorage<T extends StorageValue = StorageValue>(
   base = StorageKeys<typeof mountPoints> | undefined

--- a/src/runtime/storage.ts
+++ b/src/runtime/storage.ts
@@ -4,7 +4,7 @@ import { mountPoints } from "../../utils/storage";
 import { storage } from "#internal/nitro/virtual/storage";
 
 export function useStorage<T extends StorageValue = StorageValue>(
-  base?: keyof typeof mountPoints | "" = "" 
+  base?: keyof typeof mountPoints | "" = ""
 ): Storage<T> {
   return base ? prefixStorage<T>(storage, base) : storage;
 }

--- a/src/runtime/storage.ts
+++ b/src/runtime/storage.ts
@@ -1,7 +1,6 @@
 import type { Storage, StorageValue } from "unstorage";
 import { prefixStorage } from "unstorage";
 import { mountPoints } from "../../utils/storage";
-import type { StorageKeys } from "../../types/utils";
 import { storage } from "#internal/nitro/virtual/storage";
 
 export function useStorage<T extends StorageValue = StorageValue>(

--- a/src/runtime/storage.ts
+++ b/src/runtime/storage.ts
@@ -4,7 +4,7 @@ import { mountPoints } from "../../utils/storage";
 import { storage } from "#internal/nitro/virtual/storage";
 
 export function useStorage<T extends StorageValue = StorageValue>(
-  base: keyof typeof mountPoints | "" = ""
+  base extends keyof typeof mountPoints = ""
 ): Storage<T> {
   return base ? prefixStorage<T>(storage, base) : storage;
 }

--- a/src/runtime/storage.ts
+++ b/src/runtime/storage.ts
@@ -4,7 +4,7 @@ import { mountPoints } from "../../utils/storage";
 import { storage } from "#internal/nitro/virtual/storage";
 
 export function useStorage<T extends StorageValue = StorageValue>(
-  base extends keyof typeof mountPoints = ""
+  base: keyof typeof mountPoints = ""
 ): Storage<T> {
   return base ? prefixStorage<T>(storage, base) : storage;
 }

--- a/src/runtime/storage.ts
+++ b/src/runtime/storage.ts
@@ -5,7 +5,7 @@ import type { StorageKeys } from "../../types/utils";
 import { storage } from "#internal/nitro/virtual/storage";
 
 export function useStorage<T extends StorageValue = StorageValue>(
-  base extends StorageKeys<typeof mountPoints> | undefined ="" 
+  base = keyof mountPoints | ""
 ): Storage<T> {
   return base ? prefixStorage<T>(storage, base) : storage;
 }

--- a/src/runtime/storage.ts
+++ b/src/runtime/storage.ts
@@ -4,7 +4,7 @@ import { mountPoints } from "../../utils/storage";
 import { storage } from "#internal/nitro/virtual/storage";
 
 export function useStorage<T extends StorageValue = StorageValue>(
-  base = keyof mountPoints | ""
+  base?: keyof typeof mountPoints | "" = "" 
 ): Storage<T> {
   return base ? prefixStorage<T>(storage, base) : storage;
 }

--- a/src/runtime/storage.ts
+++ b/src/runtime/storage.ts
@@ -1,9 +1,10 @@
 import type { Storage, StorageValue } from "unstorage";
 import { prefixStorage } from "unstorage";
 import { storage } from "#internal/nitro/virtual/storage";
-
+import {mountPoints} from "../../utils/storage"
+import type {StorageKeys} from "../../types/utils"
 export function useStorage<T extends StorageValue = StorageValue>(
-  base = ""
+  base = StorageKeys<typeof mountPoints> | undefined
 ): Storage<T> {
   return base ? prefixStorage<T>(storage, base) : storage;
 }

--- a/src/runtime/storage.ts
+++ b/src/runtime/storage.ts
@@ -1,6 +1,6 @@
 import type { Storage, StorageValue } from "unstorage";
 import { prefixStorage } from "unstorage";
-import { mountPoints } from "../utils/storage";
+import { mountPoints } from "../storage";
 import { storage } from "#internal/nitro/virtual/storage";
 
 export function useStorage<T extends StorageValue = StorageValue>(

--- a/src/runtime/storage.ts
+++ b/src/runtime/storage.ts
@@ -4,7 +4,7 @@ import { mountPoints } from "../../utils/storage";
 import { storage } from "#internal/nitro/virtual/storage";
 
 export function useStorage<T extends StorageValue = StorageValue>(
-  base?: keyof typeof mountPoints | "" = ""
+  base: keyof typeof mountPoints | "" = ""
 ): Storage<T> {
   return base ? prefixStorage<T>(storage, base) : storage;
 }

--- a/src/runtime/storage.ts
+++ b/src/runtime/storage.ts
@@ -3,6 +3,7 @@ import { prefixStorage } from "unstorage";
 import { storage } from "#internal/nitro/virtual/storage";
 import {mountPoints} from "../../utils/storage"
 import type {StorageKeys} from "../../types/utils"
+
 export function useStorage<T extends StorageValue = StorageValue>(
   base = StorageKeys<typeof mountPoints> | undefined
 ): Storage<T> {

--- a/src/runtime/storage.ts
+++ b/src/runtime/storage.ts
@@ -1,6 +1,6 @@
 import type { Storage, StorageValue } from "unstorage";
 import { prefixStorage } from "unstorage";
-import { mountPoints } from "../../utils/storage";
+import { mountPoints } from "../utils/storage";
 import { storage } from "#internal/nitro/virtual/storage";
 
 export function useStorage<T extends StorageValue = StorageValue>(

--- a/src/runtime/storage.ts
+++ b/src/runtime/storage.ts
@@ -5,7 +5,7 @@ import type { StorageKeys } from "../../types/utils";
 import { storage } from "#internal/nitro/virtual/storage";
 
 export function useStorage<T extends StorageValue = StorageValue>(
-  base = StorageKeys<typeof mountPoints> | undefined
+  base extends StorageKeys<typeof mountPoints> | undefined ="" 
 ): Storage<T> {
   return base ? prefixStorage<T>(storage, base) : storage;
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,7 +1,7 @@
 import { createStorage as _createStorage, builtinDrivers } from "unstorage";
 import type { Nitro } from "./types";
 
-export const mountPoints = [];
+export const mountPoints = {};
 
 export async function createStorage(nitro: Nitro) {
   const storage = _createStorage();
@@ -17,7 +17,7 @@ export async function createStorage(nitro: Nitro) {
         builtinDrivers[opts.driver] || opts.driver
       ).then((r) => r.default || r);
       storage.mount(path, driver(opts));
-      mountPoints.push(path);
+      mountPoints[path]=1;
     } else {
       nitro.logger.warn(`No \`driver\` set for storage mount point "${path}".`);
     }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,6 +1,8 @@
 import { createStorage as _createStorage, builtinDrivers } from "unstorage";
 import type { Nitro } from "./types";
 
+export const mountPoints=[]
+
 export async function createStorage(nitro: Nitro) {
   const storage = _createStorage();
 
@@ -15,6 +17,7 @@ export async function createStorage(nitro: Nitro) {
         builtinDrivers[opts.driver] || opts.driver
       ).then((r) => r.default || r);
       storage.mount(path, driver(opts));
+      mountPoints.push(path)
     } else {
       nitro.logger.warn(`No \`driver\` set for storage mount point "${path}".`);
     }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,7 +1,7 @@
 import { createStorage as _createStorage, builtinDrivers } from "unstorage";
 import type { Nitro } from "./types";
 
-export const mountPoints = {};
+export const mountPoints: Record<string,any> = {};
 
 export async function createStorage(nitro: Nitro) {
   const storage = _createStorage();

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,7 +1,7 @@
 import { createStorage as _createStorage, builtinDrivers } from "unstorage";
 import type { Nitro } from "./types";
 
-export const mountPoints=[]
+export const mountPoints = [];
 
 export async function createStorage(nitro: Nitro) {
   const storage = _createStorage();
@@ -17,7 +17,7 @@ export async function createStorage(nitro: Nitro) {
         builtinDrivers[opts.driver] || opts.driver
       ).then((r) => r.default || r);
       storage.mount(path, driver(opts));
-      mountPoints.push(path)
+      mountPoints.push(path);
     } else {
       nitro.logger.warn(`No \`driver\` set for storage mount point "${path}".`);
     }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,7 +1,7 @@
 import { createStorage as _createStorage, builtinDrivers } from "unstorage";
 import type { Nitro } from "./types";
 
-export const mountPoints: Record<string,any> = {};
+export const mountPoints: Record<string, any> = {};
 
 export async function createStorage(nitro: Nitro) {
   const storage = _createStorage();

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -17,7 +17,7 @@ export async function createStorage(nitro: Nitro) {
         builtinDrivers[opts.driver] || opts.driver
       ).then((r) => r.default || r);
       storage.mount(path, driver(opts));
-      mountPoints[path]=1;
+      mountPoints[path] = 1;
     } else {
       nitro.logger.warn(`No \`driver\` set for storage mount point "${path}".`);
     }

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -109,3 +109,7 @@ export type KebabCase<
 > = T extends `${infer F}${infer R}`
   ? KebabCase<R, `${A}${F extends Lowercase<F> ? "" : "-"}${Lowercase<F>}`>
   : A;
+
+export type StorageKeys<T> = {
+			[K in keyof T]: K;
+}[keyof T];

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -111,5 +111,5 @@ export type KebabCase<
   : A;
 
 export type StorageKeys<T> = {
-			[K in keyof T]: K;
+  [K in keyof T]: K;
 }[keyof T];

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -109,7 +109,3 @@ export type KebabCase<
 > = T extends `${infer F}${infer R}`
   ? KebabCase<R, `${A}${F extends Lowercase<F> ? "" : "-"}${Lowercase<F>}`>
   : A;
-
-export type StorageKeys<T> = {
-  [K in keyof T]: K;
-}[keyof T];


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
Resolves #1994 
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
This PR provides type safety for `useStorage` to improve the DX. It autocompletes the registered (valid) mount points when used.

There is a question to be asked here whether there should be a more "context aware" solution to provide the Nitro instance and read from the storage there, but it seems to me a bit overcomplicated and I didn't have adequate time to fully check if it's even feasible. I'm curious to hear what you think about it, because if we do want to go for the context aware solution useStorage will likely have to be reworked. One way to potentially do so would be to store a reference to the Nitro instance in the same place, but I'm wondering if such approach can bring some potential issues.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
