### PR TITLE
fix(wasm): directly generate chunk exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "dot-prop": "^8.0.2",
     "esbuild": "^0.19.9",
     "escape-string-regexp": "^5.0.0",
-    "estree-walker": "^3.0.3",
     "etag": "^1.8.1",
     "fs-extra": "^11.2.0",
     "globby": "^14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,9 +87,6 @@ importers:
       escape-string-regexp:
         specifier: ^5.0.0
         version: 5.0.0
-      estree-walker:
-        specifier: ^3.0.3
-        version: 3.0.3
       etag:
         specifier: ^1.8.1
         version: 1.8.1

--- a/src/rollup/plugins/wasm.ts
+++ b/src/rollup/plugins/wasm.ts
@@ -71,28 +71,29 @@ export function wasmImport(): Plugin {
     },
     load(id) {
       if (!id.startsWith(WASM_ID_PREFIX)) {
-        return null;
+        return;
       }
       const asset = wasmImports.get(id);
-      if (asset) {
-        return {
-          code: `export default "${asset.id}";`,
-          map: null,
-        };
+      if (!asset) {
+        return;
       }
+      return {
+        code: `export default "${asset.id}";`,
+        map: null,
+      };
     },
     renderChunk(code, chunk, options) {
       if (
         !chunk.moduleIds.some((id) => id.startsWith(WASM_ID_PREFIX)) ||
         !code.includes(WASM_ID_PREFIX)
       ) {
-        return null;
+        return;
       }
 
       const isIIFE = options.format === "iife" || options.format === "umd";
 
       const s = new MagicString(code);
-      const ReplaceRE = new RegExp(`"(${WASM_ID_PREFIX}[^"]+)"`, "g");
+
       const resolveImport = (id) => {
         if (typeof id !== "string" || !id.startsWith(WASM_ID_PREFIX)) {
           return null;
@@ -106,6 +107,8 @@ export function wasmImport(): Plugin {
           (nestedLevel ? "../".repeat(nestedLevel) : "./") + asset.fileName
         );
       };
+
+      const ReplaceRE = new RegExp(`"(${WASM_ID_PREFIX}[^"]+)"`, "g");
       for (const match of code.matchAll(ReplaceRE)) {
         const resolved = resolveImport(match[1]);
         if (!resolved) {

--- a/src/rollup/plugins/wasm.ts
+++ b/src/rollup/plugins/wasm.ts
@@ -33,7 +33,7 @@ export function wasmImport(): Plugin {
         return null;
       }
       if (id.startsWith(WASM_ID_PREFIX)) {
-        return id
+        return id;
       }
 
       // Resolve the source file real path
@@ -78,13 +78,13 @@ export function wasmImport(): Plugin {
       if (asset) {
         return {
           code: `export default "${asset.id}";`,
-          map: null
-        }
+          map: null,
+        };
       }
     },
     renderChunk(code, chunk) {
       if (
-        !chunk.moduleIds.some(id => id.startsWith(WASM_ID_PREFIX)) ||
+        !chunk.moduleIds.some((id) => id.startsWith(WASM_ID_PREFIX)) ||
         !code.includes(WASM_ID_PREFIX)
       ) {
         return null;
@@ -92,10 +92,7 @@ export function wasmImport(): Plugin {
       const s = new MagicString(code);
       const ReplaceRE = new RegExp(`"(${WASM_ID_PREFIX}[^"]+)"`, "g");
       const resolveImport = (id) => {
-        if (
-          typeof id !== "string" ||
-          !id.startsWith(WASM_ID_PREFIX)
-        ) {
+        if (typeof id !== "string" || !id.startsWith(WASM_ID_PREFIX)) {
           return null;
         }
         const asset = wasmImports.get(id);
@@ -110,8 +107,10 @@ export function wasmImport(): Plugin {
       for (const match of code.matchAll(ReplaceRE)) {
         const resolved = resolveImport(match[1]);
         if (!resolved) {
-          console.warn(`Failed to resolve WASM import: ${JSON.stringify(match[1])}`);
-          continue
+          console.warn(
+            `Failed to resolve WASM import: ${JSON.stringify(match[1])}`
+          );
+          continue;
         }
         s.overwrite(
           match.index,
@@ -122,10 +121,10 @@ export function wasmImport(): Plugin {
       if (s.hasChanged()) {
         return {
           code: s.toString(),
-          map: s.generateMap({ includeContent: true })
+          map: s.generateMap({ includeContent: true }),
         };
       }
-    }
+    },
   };
 }
 

--- a/src/rollup/plugins/wasm.ts
+++ b/src/rollup/plugins/wasm.ts
@@ -89,7 +89,7 @@ export function wasmImport(): Plugin {
         return null;
       }
 
-      const isIIFE = options.format === "iife" || options.format === "umd"
+      const isIIFE = options.format === "iife" || options.format === "umd";
 
       const s = new MagicString(code);
       const ReplaceRE = new RegExp(`"(${WASM_ID_PREFIX}[^"]+)"`, "g");
@@ -114,9 +114,9 @@ export function wasmImport(): Plugin {
           );
           continue;
         }
-        let code = `await import("${resolved}").then(r => r?.default || r);`
+        let code = `await import("${resolved}").then(r => r?.default || r);`;
         if (isIIFE) {
-          code = `undefined /* not supported */`
+          code = `undefined /* not supported */`;
         }
         s.overwrite(match.index, match.index + match[0].length, code);
       }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

#1952

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When annotating wasm (virtual) chunk dependencies with `external: true`, roll-up sometimes reverts them to the original external package as external in the bundle.

This PR uses a virtual module (non-externalized) + post-build transform to convert it to relative import to avoid rollup interfering.

**Note:** when option is enabled for iife/umd targets (cloudflare preset) the experimental module is still unsupported now with more explicit check. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
