### PR TITLE
refactor(rollup): improve generated chunk names

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -70,8 +70,9 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
     [runtimeDir, "nitro"],
     [buildServerDir, "app"],
     ["\0raw:", "raw"],
-    ["\0", "internal"],
-  ];
+    ["\0nitro-wasm:", "wasm"],
+    ["\0", "virtual"],
+  ] as const;
   function getChunkName(id: string) {
     // Known path prefixes
     for (const [dir, name] of chunkNamePrefixes) {
@@ -98,11 +99,6 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
     );
     if (taskHandler) {
       return `chunks/tasks/[name].mjs`;
-    }
-
-    // Wasm
-    if (id.endsWith(".wasm")) {
-      return `chunks/wasm/[name].mjs`;
     }
 
     // Unknown path

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -67,13 +67,17 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
 
   const chunkNamePrefixes = [
     [nitro.options.buildDir, "build"],
-    [runtimeDir, "nitro"],
     [buildServerDir, "app"],
     ["\0raw:", "raw"],
     ["\0nitro-wasm:", "wasm"],
     ["\0", "virtual"],
   ] as const;
   function getChunkName(id: string) {
+    // Runtime
+    if (id.startsWith(runtimeDir)) {
+      return `chunks/runtime.mjs`;
+    }
+
     // Known path prefixes
     for (const [dir, name] of chunkNamePrefixes) {
       if (id.startsWith(dir)) {

--- a/src/rollup/plugins/wasm.ts
+++ b/src/rollup/plugins/wasm.ts
@@ -10,7 +10,7 @@ export function wasm(options: WasmOptions): Plugin {
   return options.esmImport ? wasmImport() : wasmBundle(options.rollup);
 }
 
-const WASM_ID_PREFIX = "\0nitro:wasm/";
+const WASM_ID_PREFIX = "\0nitro-wasm:";
 
 export function wasmImport(): Plugin {
   type WasmAssetInfo = {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Generated chunk names went out of maintenance over the time. This PR is mainly an initial attempt to organize chunk names generated in `.output/server/chunks` into categorized directories.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
