### PR TITLE
fix(iisnode): correctly escape backslashes for port fix

### DIFF
--- a/src/presets/iis.ts
+++ b/src/presets/iis.ts
@@ -30,7 +30,8 @@ export const iisNode = defineNitroPreset({
       await writeFile(
         resolve(nitro.options.output.dir, "index.js"),
         `
-        if (Number.isNaN(Number(process.env.PORT))) {
+        const port = process.env.PORT
+        if (port && Number.isNaN(Number(port))) {
           process.env.NITRO_UNIX_SOCKET = process.env.PORT
           delete process.env.PORT
         }

--- a/src/presets/iis.ts
+++ b/src/presets/iis.ts
@@ -30,7 +30,7 @@ export const iisNode = defineNitroPreset({
       await writeFile(
         resolve(nitro.options.output.dir, "index.js"),
         `
-          if (process.env.PORT.startsWith('\\\\')) {
+        if (process.env.PORT.startsWith('\\\\')) {
           process.env.NITRO_UNIX_SOCKET = process.env.PORT
           delete process.env.PORT
         }

--- a/src/presets/iis.ts
+++ b/src/presets/iis.ts
@@ -30,8 +30,7 @@ export const iisNode = defineNitroPreset({
       await writeFile(
         resolve(nitro.options.output.dir, "index.js"),
         `
-        const port = process.env.PORT
-        if (port && Number.isNaN(Number(port))) {
+          if (process.env.PORT.startsWith('\\\\')) {
           process.env.NITRO_UNIX_SOCKET = process.env.PORT
           delete process.env.PORT
         }

--- a/src/presets/iis.ts
+++ b/src/presets/iis.ts
@@ -30,7 +30,7 @@ export const iisNode = defineNitroPreset({
       await writeFile(
         resolve(nitro.options.output.dir, "index.js"),
         `
-        if (process.env.PORT.startsWith('\\')) {
+        if (Number.isNaN(Number(process.env.PORT))) {
           process.env.NITRO_UNIX_SOCKET = process.env.PORT
           delete process.env.PORT
         }


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/22961

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Uses a more general fix than #1783 based on #1697

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
