### PR TITLE
docs(config): fix `setResponseHeader` example params

### DIFF
--- a/docs/content/3.config.md
+++ b/docs/content/3.config.md
@@ -301,7 +301,7 @@ export default defineNitroConfig({
 
 ```js [error.ts]
 export default defineNitroErrorHandler((error, event) => {
-  setResponseHeader('Content-Type', 'text/plain')
+  setResponseHeader(event, 'Content-Type', 'text/plain')
   return send(event, '[custom error handler] ' + error.stack)
 });
 ```


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

none

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

https://github.com/unjs/h3/blob/53703dc860f1ff6fe7ce71d543deff1cfa810b11/src/utils/response.ts#L120

cause error
```
[nitro] [unhandledRejection] TypeError: Cannot read properties of undefined (reading 'res')
    at setResponseHeader (file:///data/workspace/node_modules/.pnpm/h3@1.9.0/node_modules/h3/dist/index.mjs:730:14)
    at file:///data/workspace/.nitro/dev/index.mjs:512:3
    at Object.onError (file:///data/workspace/.nitro/dev/index.mjs:552:14)
    at Server.toNodeHandle (file:///data/workspace/node_modules/.pnpm/h3@1.9.0/node_modules/h3/dist/index.mjs:1892:27)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
