### PR TITLE
feat(modules): allow to declare packages as nitro modules

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,8 @@ importers:
         specifier: link:../..
         version: link:../..
 
+  test/fixture: {}
+
 packages:
 
   /@aashutoshrathi/word-wrap@1.2.6:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "examples/**"
+  - "test/fixture"

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,8 +1,6 @@
 import jiti from "jiti";
+import { resolvePath } from "mlly";
 import type { Nitro, NitroModule, NitroModuleInput } from "./types";
-import { normalize } from "path";
-import { pathToFileURL } from 'node:url'
-import { interopDefault, resolvePath } from "mlly"
 
 export function defineNitroModule(def: NitroModule) {
   return def;
@@ -21,7 +19,7 @@ export async function resolveNitroModule(
       globalThis.defineNitroModule || defineNitroModule;
 
     const _jiti = jiti(nitroOptions.rootDir, { interopDefault: true, esmResolve: true });
-    const _modPath = _jiti.resolve(await resolvePath(mod, {url: nitroOptions.rootDir, extensions: ['.mjs', '.mts', '.js', '.ts', '.cjs']}))
+    const _modPath = _jiti.resolve(await resolvePath(mod, { url: nitroOptions.rootDir, extensions: ['.mjs', '.mts', '.js', '.ts', '.cjs'] }))
     _url = _modPath;
     mod = _jiti(_modPath) as NitroModule;
   }
@@ -35,8 +33,8 @@ export async function resolveNitroModule(
     mod.setup = () => {};
   }
 
-  return Promise.resolve({
+  return {
     _url,
     ...mod,
-  });
+  };
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,12 +1,14 @@
 import jiti from "jiti";
 import type { Nitro, NitroModule, NitroModuleInput } from "./types";
-import { resolvePath } from "./utils";
+import { normalize } from "path";
+import { pathToFileURL } from 'node:url'
+import { interopDefault, resolvePath } from "mlly"
 
 export function defineNitroModule(def: NitroModule) {
   return def;
 }
 
-export function resolveNitroModule(
+export async function resolveNitroModule(
   mod: NitroModuleInput,
   nitroOptions: Nitro["options"]
 ): Promise<NitroModule & { _url: string }> {
@@ -18,8 +20,8 @@ export function resolveNitroModule(
       // @ts-ignore
       globalThis.defineNitroModule || defineNitroModule;
 
-    const _jiti = jiti(nitroOptions.rootDir, { interopDefault: true });
-    const _modPath = _jiti.resolve(resolvePath(mod, nitroOptions));
+    const _jiti = jiti(nitroOptions.rootDir, { interopDefault: true, esmResolve: true });
+    const _modPath = _jiti.resolve(await resolvePath(mod, {url: nitroOptions.rootDir}))
     _url = _modPath;
     mod = _jiti(_modPath) as NitroModule;
   }

--- a/src/module.ts
+++ b/src/module.ts
@@ -21,7 +21,7 @@ export async function resolveNitroModule(
       globalThis.defineNitroModule || defineNitroModule;
 
     const _jiti = jiti(nitroOptions.rootDir, { interopDefault: true, esmResolve: true });
-    const _modPath = _jiti.resolve(await resolvePath(mod, {url: nitroOptions.rootDir}))
+    const _modPath = _jiti.resolve(await resolvePath(mod, {url: nitroOptions.rootDir, extensions: ['.mjs', '.mts', '.js', '.ts', '.cjs']}))
     _url = _modPath;
     mod = _jiti(_modPath) as NitroModule;
   }

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -1,0 +1,22 @@
+import { resolve } from "pathe";
+import { describe, it, expect } from "vitest";
+import { startServer, setupTest } from "../tests";
+
+describe('nitro modules', async () => {
+    const ctx = await setupTest("node");
+
+    const entryPath = resolve(ctx.outDir, "server/index.mjs");
+    const { listener } = await import(entryPath);
+
+    await startServer(ctx, listener);
+
+    it('should inject using node_modules', async () => {
+        const res = await ctx.fetch('/node-modules/module-plugin')
+        expect(await res.text()).toBe('injected by a module from the node_modules')
+    })
+
+    it('should inject using a relative path', async () => {
+        const res = await ctx.fetch('/manual-module/module-plugin')
+        expect(await res.text()).toBe('injected by a module specified by the user')
+    })
+})

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -3,6 +3,10 @@ import { defineNitroConfig } from "../../src/config";
 
 export default defineNitroConfig({
   compressPublicAssets: true,
+  modules: [
+    '@fixture/nitro-module',
+    './user-modules/add-route',
+  ],
   imports: {
     presets: [
       {

--- a/test/fixture/node_modules/@fixture/nitro-module/index.js
+++ b/test/fixture/node_modules/@fixture/nitro-module/index.js
@@ -1,0 +1,9 @@
+import { resolvePath } from "mlly"
+import { dirname } from "pathe"
+
+export default {
+    name: 'nitro-module',
+    async setup(nitro) {
+        nitro.options.plugins.push(await resolvePath('./runtime/plugin', { url: dirname(import.meta.url) }))
+    }
+} 

--- a/test/fixture/node_modules/@fixture/nitro-module/package.json
+++ b/test/fixture/node_modules/@fixture/nitro-module/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@fixture/nitro-module",
+  "version": "2.0.1",
+  "exports": "./index.js"
+}

--- a/test/fixture/node_modules/@fixture/nitro-module/runtime/plugin.js
+++ b/test/fixture/node_modules/@fixture/nitro-module/runtime/plugin.js
@@ -1,0 +1,10 @@
+import { eventHandler } from "h3"
+
+export default (nitro) => {
+    nitro.h3App.stack.unshift({
+      route: '/node-modules/module-plugin',
+      handler: eventHandler(() => {
+          return JSON.stringify('injected by a module from the node_modules')
+      })
+    })
+  }

--- a/test/fixture/package.json
+++ b/test/fixture/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "fixture",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/fixture/user-modules/add-route.ts
+++ b/test/fixture/user-modules/add-route.ts
@@ -1,0 +1,10 @@
+import { resolvePath } from "mlly"
+import { dirname } from "pathe"
+import { NitroModule } from "nitropack"
+
+export default <NitroModule>{
+    name: 'nitro-module',
+    async setup(nitro) {
+        nitro.options.plugins.push(await resolvePath('./runtime/plugin.ts', { url: dirname(import.meta.url) }))
+    }
+} 

--- a/test/fixture/user-modules/runtime/plugin.ts
+++ b/test/fixture/user-modules/runtime/plugin.ts
@@ -1,0 +1,10 @@
+import { eventHandler } from "h3"
+
+export default (nitroApp) => {
+  nitroApp.h3App.stack.unshift({
+      route: '/manual-module/module-plugin',
+      handler: eventHandler(() => {
+          return JSON.stringify('injected by a module specified by the user')
+      })
+    })
+  }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

solve https://github.com/unjs/nitro/issues/2029

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hi :wave: this PR allows to declare packages as modules using `mlly` resolvePath when resolving nitro modules

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
