### PR TITLE
docs(netlify): add note to make sure publish dist is set to `dist`

### DIFF
--- a/docs/content/2.deploy/20.providers/netlify.md
+++ b/docs/content/2.deploy/20.providers/netlify.md
@@ -21,6 +21,10 @@ If you want to add custom redirects, you can do so with [`routeRules`](/config#r
 
 For deployment, just push to your git repository [as you would normally do for Netlify](https://docs.netlify.com/configure-builds/get-started/).
 
+::alert{type="warning"}
+Do not forget to update the publish directory to `dist`. By default, Netlify will use `.nuxt/dist` which is not correct.
+::
+
 ## Netlify Edge Functions
 
 **Preset:** `netlify_edge` ([switch to this preset](/deploy/#changing-the-deployment-preset))
@@ -29,9 +33,12 @@ Netlify Edge Functions use Deno and the powerful V8 JavaScript runtime to let yo
 
 Nitro output can directly run the server at the edge. Closer to your users.
 
+::alert{type="warning"}
+Do not forget to update the publish directory to `dist`. By default, Netlify will use `.nuxt/dist` which is not correct.
+::
+
 ## On-demand Builders
 
 **Preset:** `netlify_builder` ([switch to this preset](/deploy/#changing-the-deployment-preset))
 
 On-demand Builders are serverless functions used to generate web content as needed that’s automatically cached on Netlify’s Edge CDN. They enable you to build pages for your site when a user visits them for the first time and then cache them at the edge for subsequent visits.  ([Read More](https://docs.netlify.com/configure-builds/on-demand-builders/))
-

--- a/docs/content/2.deploy/20.providers/netlify.md
+++ b/docs/content/2.deploy/20.providers/netlify.md
@@ -21,8 +21,8 @@ If you want to add custom redirects, you can do so with [`routeRules`](/config#r
 
 For deployment, just push to your git repository [as you would normally do for Netlify](https://docs.netlify.com/configure-builds/get-started/).
 
-::alert{type="warning"}
-Do not forget to update the publish directory to `dist`. By default, Netlify will use `.nuxt/dist` which is not correct.
+::alert{type="note"}
+Make sure the publish directory is set to `dist` when creating a new project.
 ::
 
 ## Netlify Edge Functions
@@ -33,8 +33,8 @@ Netlify Edge Functions use Deno and the powerful V8 JavaScript runtime to let yo
 
 Nitro output can directly run the server at the edge. Closer to your users.
 
-::alert{type="warning"}
-Do not forget to update the publish directory to `dist`. By default, Netlify will use `.nuxt/dist` which is not correct.
+::alert{type="note"}
+Make sure the publish directory is set to `dist` when creating a new project.
 ::
 
 ## On-demand Builders


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
fix #2032

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Update the documentation to warn users to update the publish directory to `dist` when using Netlify.

By default, Netlify will use `.nuxt/dist` which is not correct and this will break the deployment.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
