### PR TITLE
fix: add `baseURL` to openapi generated url

### DIFF
--- a/src/runtime/routes/openapi.ts
+++ b/src/runtime/routes/openapi.ts
@@ -7,9 +7,12 @@ import type {
   PathsObject,
 } from "openapi-typescript";
 import { handlersMeta } from "#internal/nitro/virtual/server-handlers";
+import { useRuntimeConfig } from "#internal/nitro";
 
 // Served as /_nitro/openapi.json
 export default eventHandler((event) => {
+  const base = useRuntimeConfig()?.app?.baseURL
+
   return <OpenAPI3>{
     openapi: "3.0.0",
     info: {
@@ -18,7 +21,7 @@ export default eventHandler((event) => {
     },
     servers: [
       {
-        url: "http://localhost:3000",
+        url: `http://localhost:3000${base}`,
         description: "Local Development Server",
         variables: {},
       },

--- a/src/runtime/routes/openapi.ts
+++ b/src/runtime/routes/openapi.ts
@@ -11,7 +11,7 @@ import { useRuntimeConfig } from "#internal/nitro";
 
 // Served as /_nitro/openapi.json
 export default eventHandler((event) => {
-  const base = useRuntimeConfig()?.app?.baseURL
+  const base = useRuntimeConfig()?.app?.baseURL;
 
   return <OpenAPI3>{
     openapi: "3.0.0",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

I just found it and fixed it directly

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `servers` property of the generated openAPI spec doesnt taske the baseURL property in the nitro config into account.
This change fixes that.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
