### PR TITLE
docs(cloudflare): update deployment guide

### DIFF
--- a/docs/content/2.deploy/0.index.md
+++ b/docs/content/2.deploy/0.index.md
@@ -17,7 +17,7 @@ When running Nitro in development mode, Nitro will always use a special preset c
 
 ## Zero-Config Providers
 
-When deploying to the production using CI/CD, Nitro tries to automatically detect the provider environment and set the right one without any additional configuration. Currently, providers below can be auto-detected with zero config.
+When deploying to production using CI/CD, Nitro tries to automatically detect the provider environment and set the right one without any additional configuration required. Currently, the providers below can be auto-detected with zero config.
 
 - [aws amplify](/deploy/providers/aws-amplify)
 - [azure](/deploy/providers/azure)
@@ -27,19 +27,25 @@ When deploying to the production using CI/CD, Nitro tries to automatically detec
 - [vercel](/deploy/providers/vercel)
 - [zeabur](/deploy/providers/zeabur)
 
+::alert{type="info"}
+**Note:** Even with these presets, if you need to build your application locally (for development or testing purposes) targeting the provider environment, you still need to tell Nitro what preset it needs to use (you can see below how).
+::
+
 ## Changing the deployment preset
 
-If you need to build Nitro against a specific provider, you can override it using an environment variable or `nitro.config.ts`. Using environment variable is recommended for deployments depending on CI/CD.
+If you need to build Nitro against a specific provider, you can target it by defining an environment variable named `NITRO_PRESET` or `SERVER_PRESET`, or by updating your Nitro [configuration](/guide/configuration).
 
-**Example:** Using `NITRO_PRESET`
+Using the environment variable approach is recommended for deployments depending on CI/CD.
+
+**Example:** Defining a `NITRO_PRESET` environment variable
 ```bash
 NITRO_PRESET=aws_lambda nitro build
 ```
 
-**Example:** Using [nitro.config.ts](/guide/configuration)
+**Example:** Updating the `nitro.config.ts` file
 
 ```ts
 export default defineNitroConfig({
-  preset: 'node-server'
+  preset: 'aws_lambda'
 })
 ```

--- a/docs/content/2.deploy/0.index.md
+++ b/docs/content/2.deploy/0.index.md
@@ -6,11 +6,11 @@ icon: ri:upload-cloud-2-line
 
 Nitro can generate different output formats suitable for different hosting providers from the same code base.
 
-Using built-in presets, you can easily configure Nitro to adjust it's output format with almost no additional code or configuration!
+Using built-in presets, you can easily configure Nitro to adjust its output format with almost no additional code or configuration!
 
 ## Default output
 
-Default production output preset is [Node.js server](/deploy/node).
+The default production output preset is [Node.js server](/deploy/node).
 
 When running Nitro in development mode, Nitro will always use a special preset called `nitro-dev` using Node.js with ESM in an isolated Worker environment with behavior as close as possible to the production environment.
 
@@ -27,25 +27,21 @@ When deploying to production using CI/CD, Nitro tries to automatically detect th
 - [vercel](/deploy/providers/vercel)
 - [zeabur](/deploy/providers/zeabur)
 
-::alert{type="info"}
-**Note:** Even with these presets, if you need to build your application locally (for development or testing purposes) targeting the provider environment, you still need to tell Nitro what preset it needs to use (you can see below how).
-::
-
 ## Changing the deployment preset
 
-If you need to build Nitro against a specific provider, you can target it by defining an environment variable named `NITRO_PRESET` or `SERVER_PRESET`, or by updating your Nitro [configuration](/guide/configuration).
+If you need to build Nitro against a specific provider, you can target it by defining an environment variable named `NITRO_PRESET` or `SERVER_PRESET`, or by updating your Nitro [configuration](/guide/configuration) or using `--preset` argument.
 
 Using the environment variable approach is recommended for deployments depending on CI/CD.
 
 **Example:** Defining a `NITRO_PRESET` environment variable
 ```bash
-NITRO_PRESET=aws_lambda nitro build
+nitro build --preset cloudflare_pages
 ```
 
 **Example:** Updating the `nitro.config.ts` file
 
 ```ts
 export default defineNitroConfig({
-  preset: 'aws_lambda'
+  preset: 'cloudflare_pages'
 })
 ```

--- a/docs/content/2.deploy/20.providers/cloudflare.md
+++ b/docs/content/2.deploy/20.providers/cloudflare.md
@@ -80,7 +80,7 @@ npx wrangler pages deploy dist
 ::
 
 ::alert{type="warning"}
-**Note:** This preset is deprecated.
+**Note:** Using this preset is not recommended.
 ::
 
 When using Workers you will need a `wrangler.toml` file, in your root directory.


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)

### 📚 Description

This PR updates the Cloudflare deployment docs by:
     - making the `cloudflare_pages` preset the recommended one
     - making the worker presets deprecated
     - giving more information regarding Bindings
     - applying other cleanups

Besides the Cloudflare docs update this PR also includes small changes to the deployment overview doc to hopefully slightly clarify things
