### PR TITLE
fix(azure): add `18` and `20` to supported node versions

### DIFF
--- a/src/presets/azure.ts
+++ b/src/presets/azure.ts
@@ -26,17 +26,19 @@ async function writeRoutes(nitro: Nitro) {
     version: "2.0",
   };
 
-  let nodeVersion = "16";
+  // https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#supported-versions
+  const supportedNodeVersions = new Set(["16", "18", "20"]);
+  let nodeVersion = "18";
   try {
     const currentNodeVersion = JSON.parse(
       await readFile(join(nitro.options.rootDir, "package.json"), "utf8")
     ).engines.node;
-    if (["16", "14"].includes(currentNodeVersion)) {
+    if (supportedNodeVersions.has(currentNodeVersion)) {
       nodeVersion = currentNodeVersion;
     }
   } catch {
     const currentNodeVersion = process.versions.node.slice(0, 2);
-    if (["16", "14"].includes(currentNodeVersion)) {
+    if (supportedNodeVersions.has(currentNodeVersion)) {
       nodeVersion = currentNodeVersion;
     }
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves #1872

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Support `16`, `18` and `20` for node versions
- Default to `18`
- Drop legacy 18

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
