### PR TITLE
fix(azure): pass body to the context as-is

### DIFF
--- a/src/runtime/entries/azure.ts
+++ b/src/runtime/entries/azure.ts
@@ -17,7 +17,7 @@ export async function handle(context: { res: HttpResponse }, req: HttpRequest) {
     url = "/api/" + (req.params.url || "");
   }
 
-  const { body, status, statusText, headers } = await nitroApp.localCall({
+  const { body, status, headers } = await nitroApp.localCall({
     url,
     headers: req.headers,
     method: req.method,
@@ -25,11 +25,12 @@ export async function handle(context: { res: HttpResponse }, req: HttpRequest) {
     body: req.rawBody,
   });
 
+  // (v3 - current) https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v3#http-response
+  // (v4) https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#http-response
   context.res = {
     status,
-    // cookies https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=typescript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#http-response
     cookies: getAzureParsedCookiesFromHeaders(headers),
     headers: normalizeLambdaOutgoingHeaders(headers, true),
-    body: body ? body.toString() : statusText,
+    body,
   };
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves #100

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When sending a binary/Buffer response, azure natively handles it and we don't need to stringify it. (Note: h3 stringifies objects and alike already)

PS: I locally confirmed working based on tests in #2076

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
