### PR TITLE
docs: add azure functions warn

### DIFF
--- a/docs/content/2.deploy/20.providers/azure.md
+++ b/docs/content/2.deploy/20.providers/azure.md
@@ -74,6 +74,10 @@ If you are using runtimeConfig, you will likely want to configure the correspond
 
 ## Azure Functions
 
+::alert{type="warning"}
+There are several known issues with Azure Function deployments [#48](https://github.com/unjs/nitro-deploys/issues/48).
+::
+
 **Preset:** `azure_functions`
 
 **Note:** If you encounter any issues, please ensure you're using a Node.js 14+ runtime. You can find more information about [how to set the Node version in the Azure docs](https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=v2#setting-the-node-version).


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

This PR adds a warning to the Azure Functions page to clarify that support for this deployment type is not currently working reliably.

I got myself a little stuck in a hole trying to fix this issue for a service I wished to deploy to an Azure Function to later realise that it doesn't really work at present.

The work arounds listed in https://github.com/unjs/nitro-deploys/issues/48 may be helpful to some but I couldn't find a way to get my Nuxt 3 deployment working properly.

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
