### PR TITLE
perf: only read assets data when serveStatic is inline

### DIFF
--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -38,8 +38,8 @@ export function publicAssets(nitro: Nitro): Plugin {
           }
           const fullPath = resolve(nitro.options.output.publicDir, id);
           const data = nitro.options.serveStatic === "inline"
-            ? (await fsp.readFile(fullPath)).toString("base64");
-            : undefined
+            ? (await fsp.readFile(fullPath)).toString("base64")
+            : undefined;
           const etag = createEtag(assetData);
           const stat = await fsp.stat(fullPath);
 

--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -41,7 +41,7 @@ export function publicAssets(nitro: Nitro): Plugin {
             nitro.options.serveStatic === "inline"
               ? (await fsp.readFile(fullPath)).toString("base64")
               : undefined;
-          const etag = createEtag(assetData);
+          const etag = createEtag(data);
           const stat = await fsp.stat(fullPath);
 
           const assetId = "/" + decodeURIComponent(id);

--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -37,7 +37,9 @@ export function publicAssets(nitro: Nitro): Plugin {
             mimeType += "; charset=utf-8";
           }
           const fullPath = resolve(nitro.options.output.publicDir, id);
-          const assetData = await fsp.readFile(fullPath);
+          const data = nitro.options.serveStatic === "inline"
+            ? (await fsp.readFile(fullPath)).toString("base64");
+            : undefined
           const etag = createEtag(assetData);
           const stat = await fsp.stat(fullPath);
 
@@ -57,10 +59,7 @@ export function publicAssets(nitro: Nitro): Plugin {
             mtime: stat.mtime.toJSON(),
             size: stat.size,
             path: relative(nitro.options.output.serverDir, fullPath),
-            data:
-              nitro.options.serveStatic === "inline"
-                ? assetData.toString("base64")
-                : undefined,
+            data,
           };
         }
 

--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -37,9 +37,10 @@ export function publicAssets(nitro: Nitro): Plugin {
             mimeType += "; charset=utf-8";
           }
           const fullPath = resolve(nitro.options.output.publicDir, id);
-          const data = nitro.options.serveStatic === "inline"
-            ? (await fsp.readFile(fullPath)).toString("base64")
-            : undefined;
+          const data =
+            nitro.options.serveStatic === "inline"
+              ? (await fsp.readFile(fullPath)).toString("base64")
+              : undefined;
           const etag = createEtag(assetData);
           const stat = await fsp.stat(fullPath);
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR update `#internal/nitro/virtual/public-assets-data` virtual source to only read assets data on file system when required (i.e. when `serveStatic` is set to `inline`)

