### PR TITLE
docs: escape filename paths and prepend routes folder

### DIFF
--- a/docs/content/1.guide/3.routing.md
+++ b/docs/content/1.guide/3.routing.md
@@ -53,7 +53,7 @@ You do not need to import `defineEventHandler` as it is automatically imported t
 
 To define a route with params, use the `[<param>]` syntax where `<param>` is the name of the param. The param will be available in the `event.context.params` object or using the `getRouteParam` utility from [unjs/h3](https://h3.unjs.io).
 
-```ts [/hello/[name].ts]
+```ts [/routes/hello/[name\\].ts]
 export default defineEventHandler(event => {
   const name = getRouteParam(event, 'name')
 
@@ -71,7 +71,7 @@ Hello nitro!
 
 You can define multiple params in a route using `[<param1>]/[<param2>]` syntax where each param is a folder. You **cannot** define multiple params in a single filename of folder.
 
-```ts [/hello/[name]/[age].ts]
+```ts [/routes/hello/[name\\]/[age\\].ts]
 export default defineEventHandler(event => {
   const name = getRouteParam(event, 'name')
   const age = getRouteParam(event, 'age')
@@ -84,7 +84,7 @@ export default defineEventHandler(event => {
 
 You can capture all the remaining parts of a URL using `[...<param>]` syntax. This will include the `/` in the param.
 
-```ts [/hello/[...name].ts]
+```ts [/routes/hello/[...name\\].ts]
 export default defineEventHandler(event => {
   const name = getRouteParam(event, 'name')
 
@@ -134,7 +134,7 @@ You can create a special route that will match all routes that are not matched b
 
 To create a catch all route, create a file named `[...].ts` in the `routes/` or `api/` directory or in any subdirectory.
 
-```ts [/routes/[...].ts]
+```ts [/routes/[...\\].ts]
 export default defineEventHandler(event => {
   const url = getRequestURL(event)
 

--- a/docs/content/1.guide/5.cache.md
+++ b/docs/content/1.guide/5.cache.md
@@ -110,7 +110,7 @@ export const cachedGHStars = definedCachedFunction(async (repo: string) => {
   getKey: (repo: string) => repo
 })
 ```
-```ts [api/stars/[...repo].ts]
+```ts [api/stars/[...repo\\].ts]
 export default defineEventHandler(async (event) => {
   const repo = event.context.params.repo
   const stars = await cachedGHStars(repo).catch(() => 0)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Filenames in the documentation that contains `[<param>]` was not escaped correctly. Furthermore, a couple of the same filenames was not prefixes with the `/routes/` folder, like it is in other examples. This PR addresses these issues.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
