### PR TITLE
Docs: replace getRouteParam with getRouterParam

### DIFF
--- a/docs/content/1.guide/3.routing.md
+++ b/docs/content/1.guide/3.routing.md
@@ -51,11 +51,11 @@ You do not need to import `defineEventHandler` as it is automatically imported t
 
 #### Single param
 
-To define a route with params, use the `[<param>]` syntax where `<param>` is the name of the param. The param will be available in the `event.context.params` object or using the `getRouteParam` utility from [unjs/h3](https://h3.unjs.io).
+To define a route with params, use the `[<param>]` syntax where `<param>` is the name of the param. The param will be available in the `event.context.params` object or using the `getRouterParam` utility from [unjs/h3](https://h3.unjs.io).
 
 ```ts [/hello/[name].ts]
 export default defineEventHandler(event => {
-  const name = getRouteParam(event, 'name')
+  const name = getRouterParam(event, 'name')
 
   return `Hello ${name}!`
 })
@@ -73,8 +73,8 @@ You can define multiple params in a route using `[<param1>]/[<param2>]` syntax w
 
 ```ts [/hello/[name]/[age].ts]
 export default defineEventHandler(event => {
-  const name = getRouteParam(event, 'name')
-  const age = getRouteParam(event, 'age')
+  const name = getRouterParam(event, 'name')
+  const age = getRouterParam(event, 'age')
 
   return `Hello ${name}! You are ${age} years old.`
 })
@@ -86,7 +86,7 @@ You can capture all the remaining parts of a URL using `[...<param>]` syntax. Th
 
 ```ts [/hello/[...name].ts]
 export default defineEventHandler(event => {
-  const name = getRouteParam(event, 'name')
+  const name = getRouterParam(event, 'name')
 
   return `Hello ${name}!`
 })
@@ -106,7 +106,7 @@ You can append the HTTP method to the filename to force the route to be matched 
 ```js [GET]
 // routes/users/[id].get.ts
 export default defineEventHandler(async (event) => {
-  const id = getRouteParam(event, 'id')
+  const id = getRouterParam(event, 'id')
 
   // Do something with id
 
@@ -126,7 +126,7 @@ export default defineEventHandler(async event => {
 ```
 ::
 
-Check out [h3 JSDocs](https://www.jsdocs.io/package/h3) for all available utilities like `getRouteParam` or `readBody`.
+Check out [h3 JSDocs](https://www.jsdocs.io/package/h3) for all available utilities like `getRouterParam` or `readBody`.
 
 ### Catch all route
 


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR replaces getRouteParam with getRouterParam. There is no getRouteParam utility in h3, maybe it's been renamed or it's just a typo.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
