### PR TITLE
docs(storage): fix unstorage links

### DIFF
--- a/docs/content/1.guide/4.storage.md
+++ b/docs/content/1.guide/4.storage.md
@@ -6,7 +6,7 @@ icon: ri:database-2-line
 
 Nitro provides a built-in storage layer that can abstract filesystem or database or any other data source.
 
-`useStorage()` is an instance of [createStorage](https://unstorage.unjs.io/usage) using the [memory driver](https://unstorage.unjs.io/drivers/memory).
+`useStorage()` is an instance of [createStorage](https://unstorage.unjs.io/getting-started/usage) using the [memory driver](https://unstorage.unjs.io/drivers/memory).
 
 **Example:** Simple (in memory) operations
 
@@ -19,7 +19,7 @@ await useStorage('test').setItem('foo', { hello: 'world' })
 await useStorage('test').getItem('foo')
 ```
 
-See [Unstorage](https://unstorage.unjs.io/usage) for detailed usage.
+See [Unstorage](https://unstorage.unjs.io/getting-started/usage) for detailed usage.
 
 ## Mountpoints
 
@@ -121,7 +121,7 @@ await useStorage().setItem('redis:foo', { hello: 'world' })
 await useStorage().getItem('redis:foo')
 ```
 
-Usage with [generics](https://unstorage.unjs.io/usage#type-inference):
+Usage with [generics](https://unstorage.unjs.io/getting-started/usage#generic-types):
 
 ```ts
 await useStorage().getItem<string>('foo')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

I know there is already a PR with storage docs changes (#2086), but I could see that it did not contain fixes for the "dead" links to unstorage, so I went ahead and fixes them in this PR.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
