### PR TITLE
fix: href regex in prerender

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -357,7 +357,7 @@ async function runParallel<T>(
   await refillQueue();
 }
 
-const LINK_REGEX = /(?<=\s)href=(?!&quot;)["']?([^"'>]+)/g;
+const LINK_REGEX = /(?<=\s)href=["']([^"'>]+)/g;
 
 const HTML_ENTITIES = {
   "&lt;": "<",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

#2104

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #2104

Changes regex to handle only href that is followed by single or double quote.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
