### PR TITLE
fix: only mock consola in production

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -49,9 +49,13 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
     alias: {
       // General
       "consola/core": "consola/core",
-      consola: "unenv/runtime/npm/consola",
-      // only mock debug in production
-      ...(nitro.options.dev ? {} : { debug: "unenv/runtime/npm/debug" }),
+      // only mock debug and consola in production
+      ...(nitro.options.dev
+        ? {}
+        : {
+            debug: "unenv/runtime/npm/debug",
+            consola: "unenv/runtime/npm/consola",
+          }),
       ...nitro.options.alias,
     },
   };

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -48,12 +48,11 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
   const builtinPreset: Preset = {
     alias: {
       // General
-      "consola/core": "consola/core",
-      // only mock debug and consola in production
       ...(nitro.options.dev
         ? {}
         : {
             debug: "unenv/runtime/npm/debug",
+            "consola/core": "consola/core",
             consola: "unenv/runtime/npm/consola",
           }),
       ...nitro.options.alias,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

#1991

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #1991 

This change uses the full build consola in development mode. It might be confusing if the behavior in development mode and production mode is different, maybe it would be worth writing about this in the documentation?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
