### PR TITLE
fix: default to `bundler` module resolution

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -274,9 +274,9 @@ declare module 'nitropack' {
         strict: nitro.options.typescript.strict,
         target: "ESNext",
         module: "ESNext",
-        moduleResolution: nitro.options.experimental.typescriptBundlerResolution
-          ? "Bundler"
-          : "Node",
+        moduleResolution: nitro.options.experimental.typescriptBundlerResolution === false
+          ? "Node"
+          : "Bundler",
         allowJs: true,
         resolveJsonModule: true,
         jsx: "preserve",

--- a/src/build.ts
+++ b/src/build.ts
@@ -274,9 +274,10 @@ declare module 'nitropack' {
         strict: nitro.options.typescript.strict,
         target: "ESNext",
         module: "ESNext",
-        moduleResolution: nitro.options.experimental.typescriptBundlerResolution === false
-          ? "Node"
-          : "Bundler",
+        moduleResolution:
+          nitro.options.experimental.typescriptBundlerResolution === false
+            ? "Node"
+            : "Bundler",
         allowJs: true,
         resolveJsonModule: true,
         jsx: "preserve",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This mirrors the Nuxt update in https://github.com/nuxt/nuxt/pull/24837 to default to bundler module resolution.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
