### PR TITLE
docs: fix links to /guide/auto-imports

### DIFF
--- a/docs/content/1.guide/1.configuration.md
+++ b/docs/content/1.guide/1.configuration.md
@@ -76,7 +76,7 @@ export default defineEventHandler((event) => {
 ```
 ::
 
-`useRuntimeConfig(event)` is an auto-imported function. Read more about [auto-imports](/auto-imports).
+`useRuntimeConfig(event)` is an auto-imported function. Read more about [auto-imports](/guide/auto-imports).
 
 ### Local development
 

--- a/docs/content/1.guide/3.routing.md
+++ b/docs/content/1.guide/3.routing.md
@@ -45,7 +45,7 @@ export default defineEventHandler(() => {
 })
 ```
 
-You do not need to import `defineEventHandler` as it is automatically imported thanks to [auto-import feature](/auto-imports).
+You do not need to import `defineEventHandler` as it is automatically imported thanks to [auto-import feature](/guide/auto-imports).
 
 ### Route with params
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
Links to /auto-imports now correctly guide to /guide/auto-imports
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
