### PR TITLE
feat: remove x-powered-by by default

### DIFF
--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -78,7 +78,7 @@ function createNitroApp(): NitroApp {
         .catch((error) => {
           captureError(error, { event, tags: ["request", "response"] });
         });
-      removeResponseHeader(event, "x-powered-by")
+      removeResponseHeader(event, "x-powered-by");
     },
     onAfterResponse: async (event, response) => {
       await nitroApp.hooks

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -10,6 +10,7 @@ import {
   H3Error,
   isEvent,
   H3Event,
+  removeResponseHeader,
 } from "h3";
 import { createFetch, Headers } from "ofetch";
 import destr from "destr";
@@ -77,6 +78,7 @@ function createNitroApp(): NitroApp {
         .catch((error) => {
           captureError(error, { event, tags: ["request", "response"] });
         });
+      removeResponseHeader(event, "x-powered-by")
     },
     onAfterResponse: async (event, response) => {
       await nitroApp.hooks

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -78,7 +78,7 @@ function createNitroApp(): NitroApp {
         .catch((error) => {
           captureError(error, { event, tags: ["request", "response"] });
         });
-      //removeResponseHeader(event, "x-powered-by");
+      // removeResponseHeader(event, "x-powered-by");
     },
     onAfterResponse: async (event, response) => {
       await nitroApp.hooks

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -147,7 +147,7 @@ function createNitroApp(): NitroApp {
       event.captureError = (error, context) => {
         captureError(error, { event, ...context });
       };
-      //removeResponseHeader(event, "x-powered-by");
+      // removeResponseHeader(event, "x-powered-by");
     })
   );
 

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -78,7 +78,6 @@ function createNitroApp(): NitroApp {
         .catch((error) => {
           captureError(error, { event, tags: ["request", "response"] });
         });
-      // removeResponseHeader(event, "x-powered-by");
     },
     onAfterResponse: async (event, response) => {
       await nitroApp.hooks
@@ -148,6 +147,7 @@ function createNitroApp(): NitroApp {
       event.captureError = (error, context) => {
         captureError(error, { event, ...context });
       };
+      removeResponseHeader(event, "x-powered-by");
     })
   );
 

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -78,7 +78,7 @@ function createNitroApp(): NitroApp {
         .catch((error) => {
           captureError(error, { event, tags: ["request", "response"] });
         });
-      removeResponseHeader(event, "x-powered-by");
+      //removeResponseHeader(event, "x-powered-by");
     },
     onAfterResponse: async (event, response) => {
       await nitroApp.hooks

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -147,7 +147,7 @@ function createNitroApp(): NitroApp {
       event.captureError = (error, context) => {
         captureError(error, { event, ...context });
       };
-      removeResponseHeader(event, "x-powered-by");
+      //removeResponseHeader(event, "x-powered-by");
     })
   );
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -233,8 +233,8 @@ export function testNitro(
   it("removes the x-powered-by header", async () => {
     const res = await callHandler({ url: "/api/hello" });
     expect(res.headers["x-powered-by"]).toBe(null);
-  })
-  
+  });
+
   it("Handle 404 not found", async () => {
     const res = await callHandler({ url: "/api/not-found" });
     expect(res.status).toBe(404);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -232,7 +232,7 @@ export function testNitro(
 
   it("removes the x-powered-by header", async () => {
     const res = await callHandler({ url: "/api/hello" });
-    expect(res.headers["x-powered-by"]).toBe(null);
+    expect(res.headers["x-powered-by"]).toBe(undefined);
   });
 
   it("Handle 404 not found", async () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -230,6 +230,11 @@ export function testNitro(
     expect(paramsData2).toBe("foo/bar/baz");
   });
 
+  it("removes the x-powered-by header", async () => {
+    const res = await callHandler({ url: "/api/hello" });
+    expect(res.headers["x-powered-by"]).toBe(null);
+  })
+  
   it("Handle 404 not found", async () => {
     const res = await callHandler({ url: "/api/not-found" });
     expect(res.status).toBe(404);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
The x-powered-by header provides no value to the client besides give a hint towards vulnerabilities to be used against the host based on the technology used. Although it's technically a server standard to keep this header in, it's a security standard to be omitted and should be done on the framework level as opposed to higher level abstractions like modules or plugins.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
