### PR TITLE
fix: handle optional `routeHandler.route` in rollup chunk

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -87,7 +87,7 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
     const routeHandler =
       nitro.options.handlers.find((h) => id.startsWith(h.handler as string)) ||
       nitro.scannedHandlers.find((h) => id.startsWith(h.handler as string));
-    if (routeHandler) {
+    if (routeHandler?.route) {
       const path =
         routeHandler.route
           .replace(/:([^/]+)/g, "_$1")


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Was trying to use the Nitro edge on https://github.com/antfu/atinotes and got this error:

<img width="1167" alt="image" src="https://github.com/unjs/nitro/assets/11247099/a3bcb2f0-e6b3-409f-8ffc-8dafe3292421">

Middleware handler can have undefined `.route` value, where here we forgot to check
### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
