### PR TITLE
docs: typo 8.websocket.md

### DIFF
--- a/docs/1.guide/8.websocket.md
+++ b/docs/1.guide/8.websocket.md
@@ -40,7 +40,7 @@ export default defineNuxtConfig({
 ```
 ::
 
-Create a websocket handler in `routes/_ws.ts` or `server/routes/_ws.ts` for Nuxt).
+Create a websocket handler in `routes/_ws.ts` (or `server/routes/_ws.ts` for Nuxt).
 
 <!-- automd:file code src="../../examples/websocket/routes/_ws.ts" -->
 


### PR DESCRIPTION
missing `(`

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

issue templates only for bugs, we need one for docs

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

there was a missing `(`on line 43
```
Create a websocket handler in `routes/_ws.ts` or `server/routes/_ws.ts` for Nuxt).
```
becomes
```
Create a websocket handler in `routes/_ws.ts` (or `server/routes/_ws.ts` for Nuxt).
```
### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
