### PR TITLE
fix: disable scheduled tasks in testing environment

### DIFF
--- a/src/runtime/task.ts
+++ b/src/runtime/task.ts
@@ -1,5 +1,6 @@
 import { createError } from "h3";
 import { Cron } from "croner";
+import { isTest } from "std-env";
 import { tasks, scheduledTasks } from "#internal/nitro/virtual/tasks";
 
 type MaybePromise<T> = T | Promise<T>;
@@ -88,7 +89,7 @@ export async function runTask<RT = unknown>(
 
 /** @experimental */
 export function startScheduleRunner() {
-  if (!scheduledTasks || scheduledTasks.length === 0) {
+  if (!scheduledTasks || scheduledTasks.length === 0 || isTest) {
     return;
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a rather lazy fix for the (experimental) scheduled tasks that if run in the testing environment, can cause tests to hang. 

Later we might think of utils to emulate scheduled tasks within testing environment without making side-effects. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
