### PR TITLE
docs(deploy): add link to zero config providers

### DIFF
--- a/docs/2.deploy/20.providers/cloudflare.md
+++ b/docs/2.deploy/20.providers/cloudflare.md
@@ -13,7 +13,7 @@ This is the recommended preset for Cloudflare deployments, please consider using
 ::
 
 ::note
-Integration with this provider is possible with zero configuration.
+Integration with this provider is possible with [zero configuration](/deploy#zero-config-providers).
 ::
 
 

--- a/docs/2.deploy/20.providers/stormkit.md
+++ b/docs/2.deploy/20.providers/stormkit.md
@@ -7,7 +7,7 @@
 :read-more{title="Stormkit" to="https://www.stormkit.io"}
 
 ::note
-Integration with [Stormkit](https://www.stormkit.io/) is possible with zero configuration.
+Integration with [Stormkit](https://www.stormkit.io/) is possible with [zero configuration](/deploy#zero-config-providers).
 ::
 
 ## Setup


### PR DESCRIPTION
### 🔗 Linked issue


### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Only the [Cloudflare](https://nitro.unjs.io/deploy/providers/cloudflare) page did not have a link to the [Zero-Config Providers](https://nitro.unjs.io/deploy#zero-config-providers).

( Confirmed that AWS Amplify, Azure, Netlify, Vercel and Zeabur are fine. 🙆 )

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
