### PR TITLE
fix: import functions from `h3` with relative path

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -131,13 +131,6 @@ export async function writeTypes(nitro: Nitro) {
 
   if (nitro.unimport) {
     await nitro.unimport.init();
-    // TODO: fully resolve utils exported from `#imports`
-    autoImportExports = await nitro.unimport
-      .toExports(typesDir)
-      .then((r) =>
-        r.replace(/#internal\/nitro/g, relative(typesDir, runtimeDir))
-      );
-
     const resolvedImportPathMap = new Map<string, string>();
     const imports = await nitro.unimport
       .getImports()
@@ -171,6 +164,12 @@ export async function writeTypes(nitro: Nitro) {
       resolvedImportPathMap.set(i.from, path);
     }
 
+    // TODO: fully resolve utils exported from `#imports`
+    autoImportExports = await nitro.unimport
+      .toExports(typesDir)
+      .then((r) =>
+        r.replace(/'(.*)'/g, (_, i) => `'${resolvedImportPathMap.get(i) ?? i}'`)
+    );
     autoImportedTypes = [
       (
         await nitro.unimport.generateTypeDeclarations({


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

When I use nuxt with pnpm **without** shamefully-host, I noticed that I can't import functions like `defineEventHandler` from `#imports`. When I inspected the generated types in the `nitro-imports.d.ts` I found why this is. The import in this file is not relative into the node modules store. It is a named re-export like `export { defineEventHandler, ... } from 'h3'`. This re-export will not work because of the not hoisted `h3` package. Every other export/import in this file already used a relative import, so i figured this might be a problem.

With this change, the already existing import resolution map is used to resolve the named import to a relative path. If this named import was by design, I'm interested why, but feel free to just close this PR.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion. (not applicable)
- [ ] I have updated the documentation accordingly. (not applicable)

I also provide a patch for applying the same to nitropack with pnpm patch

<details>
<summary>PNPM patch to test it with nuxt example project</summary>

```jsonc
  "pnpm": {
    "patchedDependencies": {
      "nitropack@2.9.1": "patches/nitropack@2.9.1.patch"
    }
  }
```

```patch
diff --git a/dist/nitro.mjs b/dist/nitro.mjs
index 1dcaaacd17bb17e68d4f740839ce9a2f1221fd73..c2214be1bd73231be52b7ba15cdde4f729a3b0ce 100644
--- a/dist/nitro.mjs
+++ b/dist/nitro.mjs
@@ -2336,9 +2336,6 @@ async function writeTypes(nitro) {
   let autoImportExports;
   if (nitro.unimport) {
     await nitro.unimport.init();
-    autoImportExports = await nitro.unimport.toExports(typesDir).then(
-      (r) => r.replace(/#internal\/nitro/g, relative(typesDir, runtimeDir))
-    );
     const resolvedImportPathMap = /* @__PURE__ */ new Map();
     const imports = await nitro.unimport.getImports().then((r) => r.filter((i) => !i.type));
     for (const i of imports) {
@@ -2368,6 +2365,9 @@ async function writeTypes(nitro) {
       }
       resolvedImportPathMap.set(i.from, path);
     }
+    autoImportExports = await nitro.unimport.toExports(typesDir).then(
+      (r) => r.replace(/'(.*)'/g, (_, i) => `'${resolvedImportPathMap.get(i) ?? i}'`)
+    );
     autoImportedTypes = [
       (await nitro.unimport.generateTypeDeclarations({
         exportHelper: false,
```
</details>
