### PR TITLE
fix(openapi): use dynamic host + port

### DIFF
--- a/src/runtime/routes/openapi.ts
+++ b/src/runtime/routes/openapi.ts
@@ -1,5 +1,4 @@
-import destr from "destr";
-import { eventHandler } from "h3";
+import { eventHandler, getRequestURL } from "h3";
 import type {
   OpenAPI3,
   PathItemObject,
@@ -10,18 +9,11 @@ import type {
 import { handlersMeta } from "#internal/nitro/virtual/server-handlers";
 import { useRuntimeConfig } from "#internal/nitro";
 
-const port = (destr(process.env.NITRO_PORT || process.env.PORT) ||
-  3000) as number;
-
 // Served as /_nitro/openapi.json
 export default eventHandler((event) => {
   const base = useRuntimeConfig()?.app?.baseURL;
 
-  const referer = event.headers.get("referer");
-
-  const url = referer
-    ? new URL(referer).origin + base
-    : `http://localhost:${port}${base}`;
+  const url = getRequestURL(event).origin + base;
 
   return <OpenAPI3>{
     openapi: "3.0.0",

--- a/src/runtime/routes/openapi.ts
+++ b/src/runtime/routes/openapi.ts
@@ -10,13 +10,18 @@ import type {
 import { handlersMeta } from "#internal/nitro/virtual/server-handlers";
 import { useRuntimeConfig } from "#internal/nitro";
 
-// Currently, openapi is only available in dev, so there is no runtime difference to be determined here
 const port = (destr(process.env.NITRO_PORT || process.env.PORT) ||
   3000) as number;
 
 // Served as /_nitro/openapi.json
 export default eventHandler((event) => {
   const base = useRuntimeConfig()?.app?.baseURL;
+
+  const referer = event.headers.get("referer");
+
+  const url = referer
+    ? new URL(referer).origin + base
+    : `http://localhost:${port}${base}`;
 
   return <OpenAPI3>{
     openapi: "3.0.0",
@@ -26,7 +31,7 @@ export default eventHandler((event) => {
     },
     servers: [
       {
-        url: `http://localhost:${port}${base}`,
+        url,
         description: "Local Development Server",
         variables: {},
       },

--- a/src/runtime/routes/openapi.ts
+++ b/src/runtime/routes/openapi.ts
@@ -1,3 +1,4 @@
+import destr from "destr";
 import { eventHandler } from "h3";
 import type {
   OpenAPI3,
@@ -8,6 +9,9 @@ import type {
 } from "openapi-typescript";
 import { handlersMeta } from "#internal/nitro/virtual/server-handlers";
 import { useRuntimeConfig } from "#internal/nitro";
+
+const port = (destr(process.env.NITRO_PORT || process.env.PORT) ||
+  3000) as number;
 
 // Served as /_nitro/openapi.json
 export default eventHandler((event) => {
@@ -21,7 +25,7 @@ export default eventHandler((event) => {
     },
     servers: [
       {
-        url: `http://localhost:3000${base}`,
+        url: `http://localhost:${port}${base}`,
         description: "Local Development Server",
         variables: {},
       },

--- a/src/runtime/routes/openapi.ts
+++ b/src/runtime/routes/openapi.ts
@@ -10,6 +10,7 @@ import type {
 import { handlersMeta } from "#internal/nitro/virtual/server-handlers";
 import { useRuntimeConfig } from "#internal/nitro";
 
+// Currently, openapi is only available in dev, so there is no runtime difference to be determined here
 const port = (destr(process.env.NITRO_PORT || process.env.PORT) ||
   3000) as number;
 


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

#2215 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, openapi is only available in dev, so there is no runtime difference to be determined here 🥰

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
