### PR TITLE
fix: `deno task dev` compatibility

### DIFF
--- a/src/rollup/plugins/import-meta.ts
+++ b/src/rollup/plugins/import-meta.ts
@@ -18,13 +18,14 @@ export function importMeta(nitro: Nitro): Plugin {
         nitro.options.node && isEntry
           ? "_import_meta_url_"
           : '"file:///_entry.js"';
+      const envImport = nitro.options.node ? "import process from 'node:process';" : "";
       const env = nitro.options.node ? "process.env" : "{}";
       const ref = "globalThis._importMeta_";
       const stub = `{url:${url},env:${env}}`;
       const stubInit = isEntry ? `${ref}=${stub};` : `${ref}=${ref}||${stub};`;
 
       return {
-        code: stubInit + code,
+        code: envImport + stubInit + code,
         map: null,
       };
     },


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://github.com/denoland/deno/issues/22744

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This commit adds an emitted import to the process global of the Node.js adapter output. This ensures the output can be used by Deno's Node compat layer.

Fixes https://github.com/unjs/nitro/issues/2224 
Ref https://github.com/denoland/deno/issues/22744

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
