### PR TITLE
fix: respect `imports.autoImport: false`

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -172,12 +172,14 @@ export async function writeTypes(nitro: Nitro) {
     }
 
     autoImportedTypes = [
-      (
-        await nitro.unimport.generateTypeDeclarations({
-          exportHelper: false,
-          resolvePath: (i) => resolvedImportPathMap.get(i.from) ?? i.from,
-        })
-      ).trim(),
+      nitro.options.imports && nitro.options.imports.autoImport !== false
+        ? (
+            await nitro.unimport.generateTypeDeclarations({
+              exportHelper: false,
+              resolvePath: (i) => resolvedImportPathMap.get(i.from) ?? i.from,
+            })
+          ).trim()
+        : "",
     ];
   }
 


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

when `imports.autoImport` is set to false we should not generate unimport declarations:

```ts
declare global {
  const __buildAssetsURL: typeof import('../../node_modules/.pnpm/nuxt@3.10.3_eslint@8.57.0_rollup@3.29.4_typescript@5.4.2_vite@5.1.5_vue-tsc@2.0.6/node_modules/nuxt/dist/core/runtime/nitro/paths')['buildAssetsURL']
  // ...
}
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
