### PR TITLE
fix(database): camelCase the connector name

### DIFF
--- a/src/rollup/plugins/database.ts
+++ b/src/rollup/plugins/database.ts
@@ -1,4 +1,5 @@
 import { connectors } from "db0";
+import { camelCase } from "scule";
 import type { Nitro } from "../../types";
 import { virtual } from "./virtual";
 
@@ -22,14 +23,14 @@ export function database(nitro: Nitro) {
     {
       "#internal/nitro/virtual/database": () => {
         return `
-${connectorsNames.map((name) => `import ${name}Connector from "${connectors[name]}";`).join("\n")}
+${connectorsNames.map((name) => `import ${camelCase(name)}Connector from "${connectors[name]}";`).join("\n")}
 
 export const connectionConfigs = {
   ${Object.entries(dbConfigs || {})
     .map(
       ([name, { connector, options }]) =>
         `${name}: {
-          connector: ${connector}Connector,
+          connector: ${camelCase(connector)}Connector,
           options: ${JSON.stringify(options)}
         }`
     )


### PR DESCRIPTION
When using:

```ts
export default defineNitroConfig({
  experimental: {
    database: true
  },
  database: {
    default: {
      connector: "cloudflare-d1",
      options: {
        bindingName: "TEST"
      }
    }
  }
});
```

We had this error:

```bash
[nitro 6:40:47 PM]  ERROR  RollupError: Expected ',', got '-' (Note that you need plugins to import files that are not JavaScript)


1: 
2: import cloudflare-d1Connector from "db0/connectors/cloudflare-d1";
                    ^
3: 
4: export const connectionConfigs = {
```

Using `camelCase` from `scule` make sure to ovoid this error :)

Also add a PR to `db0` to improve the error message too: https://github.com/unjs/db0/pull/60