### PR TITLE
fix(server-assets): mark `yaml`, `json`, `json5` and `csv` as text

### DIFF
--- a/src/rollup/plugins/raw.ts
+++ b/src/rollup/plugins/raw.ts
@@ -13,10 +13,14 @@ export function raw(opts: RawOptions = {}): Plugin {
     ".md",
     ".mdx",
     ".yml",
+    ".yaml",
     ".txt",
     ".css",
     ".htm",
     ".html",
+    ".json",
+    ".json5",
+    ".csv",
     ...(opts.extensions || []),
   ]);
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/unjs/nitro/issues/2217

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds more extensions which are definitely not binary files.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
