### PR TITLE
docs(cache): add example usage for `cache.varies`

### DIFF
--- a/docs/1.guide/6.cache.md
+++ b/docs/1.guide/6.cache.md
@@ -236,7 +236,7 @@ The `cachedEventHandler` and `cachedFunction` functions accept the following opt
     A function that returns a `boolean` to bypass the current cache without invalidating the existing entry.
   ::
   ::field{name="varies" type="string[]"}
-    An array of request headers to be considered for the cache, [learn more](https://github.com/unjs/nitro/issues/1031).
+    An array of request headers to be considered for the cache, [learn more](https://github.com/unjs/nitro/issues/1031). If utilizing in a multi-tenant environment, you may want to pass `['host', 'x-forwarded-host']` to ensure these headers are not discarded and that the cache is unique per tenant.
   ::
 ::
 


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `cache.varies` option for `routeRules` needs to be better documented to help understand the cache behavior and discarded headers, especially related to multi-tenant implementations.

The explanation is not currently obvious when reading through the docs; however, was better explained in https://github.com/nuxt/nuxt/issues/26102#issuecomment-1980625833 by @pi0. This PR surfaces the explanation and provides docs visitors a keyword of "tenant" they can search for as a hint. (It took me 3 days to figure out why my `host` headers were returning `localhost` 😅 )

I also created a corresponding PR for the Nuxt docs: https://github.com/nuxt/nuxt/pull/26197

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
