### PR TITLE
docs: fix server assets example path

### DIFF
--- a/docs/1.guide/8.assets.md
+++ b/docs/1.guide/8.assets.md
@@ -55,7 +55,7 @@ All assets in `assets/` directory will be added to the server bundle. After buil
 
 They can be addressed by the `assets:server` mount point using the [storage layer](/guide/storage).
 
-For example, you could store a json file in `assets/server/data.json` and retrieve it in your handler:
+For example, you could store a json file in `assets/data.json` and retrieve it in your handler:
 
 ```js
 export default defineEventHandler(async () => {


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In current docs, there is a bad example path for server assets ([here](https://nitro.unjs.io/guide/assets#server-assets))
the path `/assets/server/...` is not correct


- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
