### PR TITLE
fix: handle path negations when scanning public assets

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -61,19 +61,18 @@ export async function copyPublicAssets(nitro: Nitro) {
     if (await isDirectory(srcDir)) {
       const includePatterns = [
         "**",
-        ...nitro.options.ignore
-          .map((p) => {
-            const [_, negation, pattern] = p.match(NEGATION_RE);
-            return (
-              // Convert ignore to include patterns
-              (negation ? "" : "!") +
-              // Make non-glob patterns relative to publicAssetDir
-              (pattern.startsWith("*")
-                ? pattern
-                : relative(srcDir, resolve(nitro.options.srcDir, pattern)))
-            );
-          })
-      ].filter((p) => !PARENT_DIR_GLOB_RE.test(p))
+        ...nitro.options.ignore.map((p) => {
+          const [_, negation, pattern] = p.match(NEGATION_RE);
+          return (
+            // Convert ignore to include patterns
+            (negation ? "" : "!") +
+            // Make non-glob patterns relative to publicAssetDir
+            (pattern.startsWith("*")
+              ? pattern
+              : relative(srcDir, resolve(nitro.options.srcDir, pattern)))
+          );
+        }),
+      ].filter((p) => !PARENT_DIR_GLOB_RE.test(p));
 
       const publicAssets = await globby(includePatterns, {
         cwd: srcDir,

--- a/src/build.ts
+++ b/src/build.ts
@@ -61,11 +61,15 @@ export async function copyPublicAssets(nitro: Nitro) {
         absolute: false,
         dot: true,
         ignore: nitro.options.ignore
-          .map((p) =>
-            p.startsWith("*") || p.startsWith("!*")
-              ? p
-              : relative(srcDir, resolve(nitro.options.srcDir, p))
-          )
+          .map((p) => {
+            const [_, negation, pattern] = p.match(/^(!?)(.*)$/);
+            return (
+              negation +
+              (pattern.startsWith("*")
+                ? pattern
+                : relative(srcDir, resolve(nitro.options.srcDir, pattern)))
+            );
+          })
           .filter((p) => !p.startsWith("../")),
       });
       await Promise.all(

--- a/src/build.ts
+++ b/src/build.ts
@@ -48,6 +48,9 @@ async function prepareDir(dir: string) {
   await fse.emptyDir(dir);
 }
 
+const NEGATION_RE = /^(!?)(.*)$/;
+const PARENT_DIR_GLOB_RE = /!?\.\.\//;
+
 export async function copyPublicAssets(nitro: Nitro) {
   if (nitro.options.noPublicDir) {
     return;
@@ -62,7 +65,7 @@ export async function copyPublicAssets(nitro: Nitro) {
         dot: true,
         ignore: nitro.options.ignore
           .map((p) => {
-            const [_, negation, pattern] = p.match(/^(!?)(.*)$/);
+            const [_, negation, pattern] = p.match(NEGATION_RE);
             return (
               negation +
               (pattern.startsWith("*")
@@ -70,7 +73,7 @@ export async function copyPublicAssets(nitro: Nitro) {
                 : relative(srcDir, resolve(nitro.options.srcDir, pattern)))
             );
           })
-          .filter((p) => !p.startsWith("../")),
+          .filter((p) => !PARENT_DIR_GLOB_RE.test(p)),
       });
       await Promise.all(
         publicAssets.map(async (file) => {

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -32,7 +32,13 @@ export default defineNitroConfig({
       dir: "files",
     },
   ],
-  ignore: ["api/**/_*", "middleware/_ignored.ts", "routes/_*.ts", "**/_*.txt", "!**/_unignored.txt"],
+  ignore: [
+    "api/**/_*",
+    "middleware/_ignored.ts",
+    "routes/_*.ts",
+    "**/_*.txt",
+    "!**/_unignored.txt",
+  ],
   appConfig: {
     "nitro-config": true,
     dynamic: "initial",

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -32,7 +32,7 @@ export default defineNitroConfig({
       dir: "files",
     },
   ],
-  ignore: ["api/**/_*", "middleware/_ignored.ts", "routes/_*.ts", "**/_*.txt"],
+  ignore: ["api/**/_*", "middleware/_ignored.ts", "routes/_*.ts", "**/_*.txt", "!**/_unignored.txt"],
   appConfig: {
     "nitro-config": true,
     dynamic: "initial",

--- a/test/fixture/public/_unignored.txt
+++ b/test/fixture/public/_unignored.txt
@@ -1,0 +1,1 @@
+This file should not be ignored!

--- a/test/presets/cloudflare-pages.test.ts
+++ b/test/presets/cloudflare-pages.test.ts
@@ -40,6 +40,7 @@ describe.skipIf(isWindows)("nitro:preset:cloudflare-pages", async () => {
         "exclude": [
           "/blog/static/*",
           "/build/*",
+          "/_unignored.txt",
           "/favicon.ico",
           "/json-string",
           "/api/hello",

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -543,7 +543,9 @@ export function testNitro(
     it.skipIf(ctx.isWorker || ctx.isDev)(
       "public files can be un-ignored with patterns",
       async () => {
-        expect((await callHandler({ url: "/_unignored.txt" })).status).toBe(200);
+        expect((await callHandler({ url: "/_unignored.txt" })).status).toBe(
+          200
+        );
       }
     );
   });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -539,6 +539,13 @@ export function testNitro(
         expect((await callHandler({ url: "/favicon.ico" })).status).toBe(200);
       }
     );
+
+    it.skipIf(ctx.isWorker || ctx.isDev)(
+      "public files can be un-ignored with patterns",
+      async () => {
+        expect((await callHandler({ url: "/_unignored.txt" })).status).toBe(200);
+      }
+    );
   });
 
   describe("headers", () => {


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Discovered while triaging issue with https://github.com/nuxt/nuxt/pull/26203, we basically weren't handling ignore patterns beginning with `!` if they did not also start with `!*`. (They would end up as part of a directory name.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
