### PR TITLE
fix(openapi): openapi.json ignores custom port

### DIFF
--- a/src/runtime/routes/openapi.ts
+++ b/src/runtime/routes/openapi.ts
@@ -13,6 +13,10 @@ import { useRuntimeConfig } from "#internal/nitro";
 export default eventHandler((event) => {
   const base = useRuntimeConfig()?.app?.baseURL;
 
+  const port = process.env.NITRO_PORT || process.env.PORT || 3000;
+  // Routes start with a / anywhere, so we can safely remove the trailing slash here.
+  const url = `http://localhost:${port}${base}`.replace(/\/$/, "");
+
   return <OpenAPI3>{
     openapi: "3.0.0",
     info: {
@@ -21,7 +25,7 @@ export default eventHandler((event) => {
     },
     servers: [
       {
-        url: `http://localhost:3000${base}`,
+        url,
         description: "Local Development Server",
         variables: {},
       },


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/unjs/nitro/issues/2215

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, we’re using a hard coded string (`http://localhost:3000`) for the base url that is added to the `openapi.json`. If a custom port is configured, it’s just ignored. This PR fixes it by using the same logic that is used in other places:

* Use `process.env.NITRO_PORT`, if it’s not available:
* Use `process.env.PORT`, if it’s not available:
* Fallback to port 3000 (the default)

While I was on it, I’ve also removed the trailing slash from the base URL. It’s not really needed, as all routes start with a `/ ` already, but it looks cleaner. ✨ 

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
