### PR TITLE
feat: `.dev` prefix for dev only route

### DIFF
--- a/test/fixture/routes/dev-route-only.dev.ts
+++ b/test/fixture/routes/dev-route-only.dev.ts
@@ -1,0 +1,4 @@
+const sharedAppConfig = useAppConfig();
+const sharedRuntimeConfig = useRuntimeConfig();
+
+export default eventHandler(() => "You should only see this in dev mode.");

--- a/test/presets/nitro-dev.test.ts
+++ b/test/presets/nitro-dev.test.ts
@@ -21,6 +21,11 @@ describe.skipIf(isCI)("nitro:preset:nitro-dev", async () => {
         const { status } = await callHandler({ url: "/proxy/example" });
         expect(status).toBe(200);
       });
+
+      it("load dev only route", async () => {
+        const { status } = await callHandler({ url: "/dev-route-only" });
+        expect(status).toBe(200);
+      });
     }
   );
 });


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

#1849

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Add the ablity to exclude a routes in production build by adding the `.dev` suffix.

I'm not sure if this should also apply to middlewares too.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
