### PR TITLE
 fix: make scheduledTasks types consistent

### DIFF
--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -128,6 +128,10 @@ export async function createNitro(
   nitro.options.virtual["#internal/nitro/virtual/tasks"] = () => {
     const _scheduledTasks = Object.entries(nitro.options.scheduledTasks || {})
       .map(([cron, _tasks]) => {
+        if (Array.isArray(_tasks)) {
+          nitro.logger.warn(`[DEPRECATION] \`scheduledTasks\` must be an array. This will be removed in a future release`);
+        }
+        // @todo: Remove isArray condition check when deprecation is effective
         const tasks = (Array.isArray(_tasks) ? _tasks : [_tasks]).filter(
           (name) => {
             if (!nitro.options.tasks[name]) {

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -128,7 +128,7 @@ export async function createNitro(
   nitro.options.virtual["#internal/nitro/virtual/tasks"] = () => {
     const _scheduledTasks = Object.entries(nitro.options.scheduledTasks || {})
       .map(([cron, _tasks]) => {
-        if (Array.isArray(_tasks)) {
+        if (!Array.isArray(_tasks)) {
           nitro.logger.warn(`[DEPRECATION] \`scheduledTasks\` must be an array. This will be removed in a future release`);
         }
         // @todo: Remove isArray condition check when deprecation is effective

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -129,7 +129,9 @@ export async function createNitro(
     const _scheduledTasks = Object.entries(nitro.options.scheduledTasks || {})
       .map(([cron, _tasks]) => {
         if (!Array.isArray(_tasks)) {
-          nitro.logger.warn(`[DEPRECATION] \`scheduledTasks\` must be an array. This will be removed in a future release`);
+          nitro.logger.warn(
+            `[DEPRECATION] \`scheduledTasks\` must be an array. This will be removed in a future release`
+          );
         }
         // @todo: Remove isArray condition check when deprecation is effective
         const tasks = (Array.isArray(_tasks) ? _tasks : [_tasks]).filter(

--- a/src/options.ts
+++ b/src/options.ts
@@ -55,6 +55,7 @@ const NitroDefaults: NitroConfig = {
   serverAssets: [],
   plugins: [],
   tasks: {},
+  scheduledTasks: {},
   imports: {
     exclude: [],
     dirs: [],

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -339,7 +339,7 @@ export interface NitroOptions extends PresetOptions {
   modules?: NitroModuleInput[];
   plugins: string[];
   tasks: { [name: string]: { handler: string; description: string } };
-  scheduledTasks: { [cron: string]: string | string[] };
+  scheduledTasks: { [cron: string]: string[] };
   virtual: Record<string, string | (() => string | Promise<string>)>;
   compressPublicAssets: boolean | CompressOptions;
   ignore: string[];

--- a/test/fixture/nitro.config.ts
+++ b/test/fixture/nitro.config.ts
@@ -101,7 +101,7 @@ export default defineNitroConfig({
     tasks: true,
   },
   scheduledTasks: {
-    "* * * * *": "test",
+    "* * * * *": ["test"],
   },
   cloudflare: {
     pages: {


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

Closes #2283, related to https://github.com/nuxt/devtools/pull/626

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
  - Not exactly breaking, but I put a deprecation warning, not sure if that's the best usage

### 📚 Description

- Make `scheduledTasks` default to `{}` instead of undefined -> Should be fixed to match the type
- Make `scheduledTasks` type consistent with the array notation -> I can revert if unwanted.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly. (no change)
