### PR TITLE
fix(options): set `scheduledTasks` to an empty object by default

### DIFF
--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -126,7 +126,7 @@ export async function createNitro(
 
   // Virtual module for tasks (TODO: Move to rollup plugin)
   nitro.options.virtual["#internal/nitro/virtual/tasks"] = () => {
-    const _scheduledTasks = Object.entries(nitro.options.scheduledTasks)
+    const _scheduledTasks = Object.entries(nitro.options.scheduledTasks || {})
       .map(([cron, _tasks]) => {
         const tasks = (Array.isArray(_tasks) ? _tasks : [_tasks]).filter(
           (name) => {

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -126,7 +126,7 @@ export async function createNitro(
 
   // Virtual module for tasks (TODO: Move to rollup plugin)
   nitro.options.virtual["#internal/nitro/virtual/tasks"] = () => {
-    const _scheduledTasks = Object.entries(nitro.options.scheduledTasks || {})
+    const _scheduledTasks = Object.entries(nitro.options.scheduledTasks)
       .map(([cron, _tasks]) => {
         const tasks = (Array.isArray(_tasks) ? _tasks : [_tasks]).filter(
           (name) => {

--- a/src/options.ts
+++ b/src/options.ts
@@ -55,6 +55,7 @@ const NitroDefaults: NitroConfig = {
   serverAssets: [],
   plugins: [],
   tasks: {},
+  scheduledTasks: {},
   imports: {
     exclude: [],
     dirs: [],


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

Fixes #2283, related to https://github.com/nuxt/devtools/pull/626

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Nitro config types indicate that `nitro.options.scheduledTasks` should always be an object, empty or not.  This PR makes the property an empty object as default as opposed to `undefined` which is not assignable to
```ts
scheduledTasks: { [cron: string]: string | string[] }
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
