### PR TITLE
fix(types): return `T` from `Serialize` when it extends `undefined`

### DIFF
--- a/src/types/serialize.ts
+++ b/src/types/serialize.ts
@@ -54,6 +54,3 @@ export type SerializeObject<T extends object> = {
 export type Simplify<TType> = TType extends any[] | Date
   ? TType
   : { [K in keyof TType]: Simplify<TType[K]> };
-
-type testA = Serialize<undefined>;
-

--- a/src/types/serialize.ts
+++ b/src/types/serialize.ts
@@ -28,7 +28,7 @@ type FilterKeys<TObj extends object, TFilter> = {
 // prettier-ignore
 export type Serialize<T> =
  IsAny<T> extends true ? any :
- T extends JsonPrimitive ? T :
+ T extends JsonPrimitive | undefined ? T :
  T extends Map<any,any> | Set<any> ? Record<string, never> :
  T extends NonJsonPrimitive ? never :
  T extends { toJSON(): infer U } ? U :
@@ -54,3 +54,6 @@ export type SerializeObject<T extends object> = {
 export type Simplify<TType> = TType extends any[] | Date
   ? TType
   : { [K in keyof TType]: Simplify<TType[K]> };
+
+type testA = Serialize<undefined>;
+

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -312,6 +312,7 @@ describe("defineCachedEventHandler", () => {
 describe("type helpers", () => {
   it("Serialize", () => {
     expectTypeOf<Serialize<undefined>>().toEqualTypeOf<undefined>();
+    expectTypeOf<Serialize<{ test?: string }>>().toEqualTypeOf<{ test?: string }>();
     expectTypeOf<Serialize<{ test: Date }>>().toEqualTypeOf<{ test: string }>();
     expectTypeOf<Serialize<{ test: Map<string, string> }>>().toEqualTypeOf<{
       test: Record<string, never>;

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -311,6 +311,7 @@ describe("defineCachedEventHandler", () => {
 
 describe("type helpers", () => {
   it("Serialize", () => {
+    expectTypeOf<Serialize<undefined>>().toEqualTypeOf<undefined>();
     expectTypeOf<Serialize<{ test: Date }>>().toEqualTypeOf<{ test: string }>();
     expectTypeOf<Serialize<{ test: Map<string, string> }>>().toEqualTypeOf<{
       test: Record<string, never>;

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -315,9 +315,9 @@ describe("type helpers", () => {
     expectTypeOf<Serialize<{ test?: string }>>().toEqualTypeOf<{
       test?: string;
     }>();
-    expectTypeOf<Serialize<{ test: Date }>>().toEqualTypeOf<{ test: string }>()
+    expectTypeOf<Serialize<{ test: Date }>>().toEqualTypeOf<{ test: string }>();
     expectTypeOf<Serialize<{ test?: Date }>>().toEqualTypeOf<{
-      test?: string
+      test?: string;
     }>();
     expectTypeOf<Serialize<{ test: Map<string, string> }>>().toEqualTypeOf<{
       test: Record<string, never>;

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -315,7 +315,10 @@ describe("type helpers", () => {
     expectTypeOf<Serialize<{ test?: string }>>().toEqualTypeOf<{
       test?: string;
     }>();
-    expectTypeOf<Serialize<{ test: Date }>>().toEqualTypeOf<{ test: string }>();
+    expectTypeOf<Serialize<{ test: Date }>>().toEqualTypeOf<{ test: string }>()
+    expectTypeOf<Serialize<{ test?: Date }>>().toEqualTypeOf<{
+      test?: string
+    }>();
     expectTypeOf<Serialize<{ test: Map<string, string> }>>().toEqualTypeOf<{
       test: Record<string, never>;
     }>();

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -312,7 +312,9 @@ describe("defineCachedEventHandler", () => {
 describe("type helpers", () => {
   it("Serialize", () => {
     expectTypeOf<Serialize<undefined>>().toEqualTypeOf<undefined>();
-    expectTypeOf<Serialize<{ test?: string }>>().toEqualTypeOf<{ test?: string }>();
+    expectTypeOf<Serialize<{ test?: string }>>().toEqualTypeOf<{
+      test?: string;
+    }>();
     expectTypeOf<Serialize<{ test: Date }>>().toEqualTypeOf<{ test: string }>();
     expectTypeOf<Serialize<{ test: Map<string, string> }>>().toEqualTypeOf<{
       test: Record<string, never>;


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

resolves https://github.com/unjs/nitro/issues/1762
resolves https://github.com/nuxt/nuxt/issues/26411

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, `Serialize<undefined>` resolves to `never` (matching `T extends NonJsonPrimitive`). This PR returns `T` from `Serialize` when it extends `undefined`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
