### PR TITLE
fix(prerender): call `nitroApp` close hook when done prerendering

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -81,9 +81,9 @@ export async function prerender(nitro: Nitro) {
     nitroRenderer.options.output.serverDir,
     "index.mjs"
   );
-  const { localFetch } = (await import(
+  const { closePrerenderer, localFetch } = (await import(
     pathToFileURL(serverEntrypoint).href
-  )) as { localFetch: $Fetch };
+  )) as { closePrerenderer: () => Promise<void>; localFetch: $Fetch };
 
   // Create route rule matcher
   const _routeRulesMatcher = toRouteMatcher(
@@ -295,6 +295,8 @@ export async function prerender(nitro: Nitro) {
     concurrency: nitro.options.prerender.concurrency,
     interval: nitro.options.prerender.interval,
   });
+
+  await closePrerenderer();
 
   await nitro.hooks.callHook("prerender:done", {
     prerenderedRoutes: nitro._prerenderedRoutes,

--- a/src/runtime/entries/nitro-prerenderer.ts
+++ b/src/runtime/entries/nitro-prerenderer.ts
@@ -3,6 +3,7 @@ import { nitroApp } from "../app";
 import { trapUnhandledNodeErrors } from "../utils";
 
 export const localFetch = nitroApp.localFetch;
+export const closePrerenderer = () => nitroApp.hooks.callHook("close");
 
 // Trap unhandled errors
 trapUnhandledNodeErrors();


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Discovered while investigating original reproduction in nuxt/cli#193.

Nitro prerenderer was never calling nitro 'close' hook which meant there was no way for runtime code to clean up after itself.

resolves nuxt/cli#193

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
