### PR TITLE
fix(cloudflare-pages): write `_headers` and `_redirects` 

### DIFF
--- a/src/presets/cloudflare-pages.ts
+++ b/src/presets/cloudflare-pages.ts
@@ -43,6 +43,8 @@ export const cloudflarePages = defineNitroPreset({
   hooks: {
     async compiled(nitro: Nitro) {
       await writeCFRoutes(nitro);
+      await writeCFPagesHeaders(nitro);
+      await writeCFPagesRedirects(nitro);
     },
   },
 });


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

(context: reported in solid discord channel)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR enables writing `_headers` and `_redirects` file for cloudflare pages (non static). This resolves respecting header rules but also allows leveraging more CDN native primitives.

Example `_headers`:

```
/rules/headers
  cache-control: s-maxage=60
/rules/cors
  access-control-allow-origin: *
  access-control-allow-methods: GET
  access-control-allow-headers: *
  access-control-max-age: 0
/rules/nested/*
  x-test: test
/build/*
  cache-control: public, max-age=3600, immutable
```

Example `_redirects`

```
/rules/nested/override	/other	307
/rules/redirect/wildcard/*	https://nitro.unjs.io/**	307
/rules/redirect/obj	https://nitro.unjs.io/	308
/rules/nested/*	/base	307
/rules/redirect	/base	307

```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
