### PR TITLE
fix: generate root/src directory aliases

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -301,16 +301,28 @@ declare module 'nitropack' {
             relativeWithDot(tsconfigDir, join(typesDir, "nitro-imports")),
           ],
           "~/*": [
-            relativeWithDot(tsconfigDir, join(nitro.options.alias["~"] || nitro.options.srcDir, '*')),
+            relativeWithDot(
+              tsconfigDir,
+              join(nitro.options.alias["~"] || nitro.options.srcDir, "*")
+            ),
           ],
           "@/*": [
-            relativeWithDot(tsconfigDir, join(nitro.options.alias["@"] || nitro.options.srcDir, '*')),
+            relativeWithDot(
+              tsconfigDir,
+              join(nitro.options.alias["@"] || nitro.options.srcDir, "*")
+            ),
           ],
           "~~/*": [
-            relativeWithDot(tsconfigDir, join(nitro.options.alias["~~"] || nitro.options.rootDir, '*')),
+            relativeWithDot(
+              tsconfigDir,
+              join(nitro.options.alias["~~"] || nitro.options.rootDir, "*")
+            ),
           ],
           "@@/*": [
-            relativeWithDot(tsconfigDir, join(nitro.options.alias["@@"] || nitro.options.rootDir, '*')),
+            relativeWithDot(
+              tsconfigDir,
+              join(nitro.options.alias["@@"] || nitro.options.rootDir, "*")
+            ),
           ],
           ...(nitro.options.typescript.internalPaths
             ? {

--- a/src/build.ts
+++ b/src/build.ts
@@ -300,6 +300,18 @@ declare module 'nitropack' {
           "#imports": [
             relativeWithDot(tsconfigDir, join(typesDir, "nitro-imports")),
           ],
+          "~/*": [
+            relativeWithDot(tsconfigDir, join(nitro.options.alias["~"] || nitro.options.srcDir, '*')),
+          ],
+          "@/*": [
+            relativeWithDot(tsconfigDir, join(nitro.options.alias["@"] || nitro.options.srcDir, '*')),
+          ],
+          "~~/*": [
+            relativeWithDot(tsconfigDir, join(nitro.options.alias["~~"] || nitro.options.rootDir, '*')),
+          ],
+          "@@/*": [
+            relativeWithDot(tsconfigDir, join(nitro.options.alias["@@"] || nitro.options.rootDir, '*')),
+          ],
           ...(nitro.options.typescript.internalPaths
             ? {
                 "#internal/nitro": [


### PR DESCRIPTION

### 🔗 Linked issue

context: https://github.com/un/inbox/pull/175

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds missing types for `~`, `~~`, `@` and `@@` aliases when nitro is used on its own (without nuxt, for example).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
