### PR TITLE
fix(externals): skip resolving virtual ids

### DIFF
--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -41,6 +41,9 @@ export function externals(opts: NodeExternalsOptions): Plugin {
 
   const _resolveCache = new Map();
   const _resolve = async (id: string): Promise<string> => {
+    if (id.startsWith("\0")) {
+      return id;
+    }
     let resolved = _resolveCache.get(id);
     if (resolved) {
       return resolved;

--- a/src/rollup/plugins/externals.ts
+++ b/src/rollup/plugins/externals.ts
@@ -66,6 +66,9 @@ export function externals(opts: NodeExternalsOptions): Plugin {
 
   // Utility to check explicit inlines
   const isExplicitInline = (id: string, importer: string) => {
+    if (id.startsWith("\0")) {
+      return true;
+    }
     const inlineMatch = inlineMatchers.find((m) => m(id, importer));
     const externalMatch = externalMatchers.find((m) => m(id, importer));
     if (


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

https://github.com/analogjs/analog/issues/969#issuecomment-2022645294

Reproduction: https://github.com/brandonroberts/analog-nitro-295

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes an issue revealed by https://github.com/unjs/nitro/pull/2289.

After calling (rollup) `this.resolve`, the result might be a virtual import starting with `\0` which we shouldn't attempt to resolve using build-in ESM resolution (ESM).


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
