### PR TITLE
fix(types): account for `undefined` value for `$fetch` return type

### DIFF
--- a/src/types/fetch.ts
+++ b/src/types/fetch.ts
@@ -16,7 +16,7 @@ export type MiddlewareOf<
   Route extends string,
   Method extends RouterMethod | "default",
 > = Method extends keyof InternalApi[MatchedRoutes<Route>]
-  ? Exclude<InternalApi[MatchedRoutes<Route>][Method], Error | void>
+  ? InternalApi[MatchedRoutes<Route>][Method]
   : never;
 
 export type TypedInternalResponse<


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/26411

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a continuation of https://github.com/unjs/nitro/pull/2286 which will fix not inferring `undefined` from server routes (checked this locally and works great).

The origin of the `Exclude` wrapper:
https://github.com/unjs/nitro/blame/adb6c5d1c7820feef63ed0851d7850f04d98ebb1/src/types/fetch.ts#L13

Confirmed with @danielroe whether there was any specific reason for excluding `Error | void` and he's not aware (hence it might be redundant but worth double checking).

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
