### PR TITLE
docs(cache): remove duplicate option definition

### DIFF
--- a/docs/1.guide/6.cache.md
+++ b/docs/1.guide/6.cache.md
@@ -225,7 +225,8 @@ The `cachedEventHandler` and `cachedFunction` functions accept the following opt
 
 ::field-group
   ::field{name="base" type="string"}
-    Name of the storage mountpoint to use for caching, default is `'cache'`.
+    Name of the storage mountpoint to use for caching. :br
+    Default to `cache`.
   ::
   ::field{name="name" type="string"}
     Guessed from function name if not provided and fallback to `'_'` otherwise.
@@ -252,10 +253,6 @@ The `cachedEventHandler` and `cachedFunction` functions accept the following opt
   ::field{name="swr" type="boolean"}
     Enable `stale-while-revalidate` behavior to serve a stale cached response while asynchronously revalidating it. :br
     Default to `true`.
-  ::
-  ::field{name="base" type="string"}
-    Name of the storage mountpoint to use for caching. :br
-    Default to `cache`.
   ::
   ::field{name="shouldInvalidateCache()" type="(..args) => boolean"}
     A function that returns a `boolean` to invalidate the current cache and create a new one.


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `base` cache option was documented twice.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
