### PR TITLE
refactor(cloudflare-pages): update root `wrangler.toml` in CI

### DIFF
--- a/src/presets/cloudflare-pages.ts
+++ b/src/presets/cloudflare-pages.ts
@@ -12,6 +12,7 @@ import { defineNitroPreset } from "../preset";
 import type { Nitro } from "../types";
 import { CloudflarePagesRoutes } from "../types/presets/cloudflare";
 import defu from "defu";
+import { isCI } from "std-env";
 
 export const cloudflarePages = defineNitroPreset({
   extends: "cloudflare",
@@ -237,6 +238,10 @@ async function writeCFWrangler(nitro: Nitro) {
 
   const wranglerConfig: WranglerConfig = defu(configFromFile, inlineConfig);
 
-  const wranglerPath = join(nitro.options.output.publicDir, "wrangler.toml");
+  const wranglerPath = join(
+    isCI ? nitro.options.rootDir : nitro.options.buildDir,
+    "wrangler.toml"
+  );
+
   await fsp.writeFile(wranglerPath, stringifyTOML(wranglerConfig));
 }


### PR DESCRIPTION
Continuation of https://github.com/unjs/nitro/pull/2353 and related to https://github.com/cloudflare/workers-sdk/issues/5579.

This PR updates generated `wrangler.toml` path to top-level dir in case of CI and build dir in case of local builds to allow extending.