### PR TITLE
chore(cf-pages): only create wrangler.toml if config is not empty

### DIFF
--- a/src/presets/cloudflare-pages.ts
+++ b/src/presets/cloudflare-pages.ts
@@ -238,10 +238,13 @@ async function writeCFWrangler(nitro: Nitro) {
 
   const wranglerConfig: WranglerConfig = defu(configFromFile, inlineConfig);
 
-  const wranglerPath = join(
-    isCI ? nitro.options.rootDir : nitro.options.buildDir,
-    "wrangler.toml"
-  );
+  // Write wrangler.toml only if config is not empty
+  if (Object.keys(wranglerConfig).length) {
+    const wranglerPath = join(
+      isCI ? nitro.options.rootDir : nitro.options.buildDir,
+      "wrangler.toml"
+    );
 
-  await fsp.writeFile(wranglerPath, stringifyTOML(wranglerConfig));
+    await fsp.writeFile(wranglerPath, stringifyTOML(wranglerConfig));
+  }
 }

--- a/src/presets/cloudflare-pages.ts
+++ b/src/presets/cloudflare-pages.ts
@@ -225,6 +225,7 @@ async function writeCFWrangler(nitro: Nitro) {
   const inlineConfig: WranglerConfig =
     nitro.options.cloudflare?.wrangler || ({} as WranglerConfig);
 
+  // Write wrangler.toml only if config is not empty
   if (Object.keys(inlineConfig).length === 0) {
     return;
   }
@@ -242,7 +243,6 @@ async function writeCFWrangler(nitro: Nitro) {
 
   const wranglerConfig: WranglerConfig = defu(configFromFile, inlineConfig);
 
-  // Write wrangler.toml only if config is not empty
   const wranglerPath = join(
     isCI ? nitro.options.rootDir : nitro.options.buildDir,
     "wrangler.toml"

--- a/src/presets/cloudflare-pages.ts
+++ b/src/presets/cloudflare-pages.ts
@@ -239,7 +239,7 @@ async function writeCFWrangler(nitro: Nitro) {
   const wranglerConfig: WranglerConfig = defu(configFromFile, inlineConfig);
 
   // Write wrangler.toml only if config is not empty
-  if (Object.keys(wranglerConfig).length) {
+  if (Object.keys(wranglerConfig).length > 0) {
     const wranglerPath = join(
       isCI ? nitro.options.rootDir : nitro.options.buildDir,
       "wrangler.toml"

--- a/src/presets/cloudflare-pages.ts
+++ b/src/presets/cloudflare-pages.ts
@@ -225,6 +225,10 @@ async function writeCFWrangler(nitro: Nitro) {
   const inlineConfig: WranglerConfig =
     nitro.options.cloudflare?.wrangler || ({} as WranglerConfig);
 
+  if (Object.keys(inlineConfig).length === 0) {
+    return;
+  }
+
   let configFromFile: WranglerConfig = {} as WranglerConfig;
   const configPath = resolve(
     nitro.options.rootDir,
@@ -239,12 +243,10 @@ async function writeCFWrangler(nitro: Nitro) {
   const wranglerConfig: WranglerConfig = defu(configFromFile, inlineConfig);
 
   // Write wrangler.toml only if config is not empty
-  if (Object.keys(wranglerConfig).length > 0) {
-    const wranglerPath = join(
-      isCI ? nitro.options.rootDir : nitro.options.buildDir,
-      "wrangler.toml"
-    );
+  const wranglerPath = join(
+    isCI ? nitro.options.rootDir : nitro.options.buildDir,
+    "wrangler.toml"
+  );
 
-    await fsp.writeFile(wranglerPath, stringifyTOML(wranglerConfig));
-  }
+  await fsp.writeFile(wranglerPath, stringifyTOML(wranglerConfig));
 }


### PR DESCRIPTION
We should not create an empty `wrangler.toml` to keep CF CI uses the dashboard bindings.