### PR TITLE
fix(deno-server): always inject `process` from `node:process`

### DIFF
--- a/src/presets/deno-server.ts
+++ b/src/presets/deno-server.ts
@@ -16,13 +16,14 @@ export const denoServer = defineNitroPreset({
   unenv: {
     inject: {
       global: ["unenv/runtime/polyfill/global-this", "default"],
-      Buffer: ["buffer", "Buffer"],
-      setTimeout: ["timers", "setTimeout"],
-      clearTimeout: ["timers", "clearTimeout"],
-      setInterval: ["timers", "setInterval"],
-      clearInterval: ["timers", "clearInterval"],
-      setImmediate: ["timers", "setImmediate"],
-      clearImmediate: ["timers", "clearImmediate"],
+      Buffer: ["node:buffer", "Buffer"],
+      setTimeout: ["node:timers", "setTimeout"],
+      clearTimeout: ["node:timers", "clearTimeout"],
+      setInterval: ["node:timers", "setInterval"],
+      clearInterval: ["node:timers", "clearInterval"],
+      setImmediate: ["node:timers", "setImmediate"],
+      clearImmediate: ["node:timers", "clearImmediate"],
+      process: ["node:process", "default"],
     },
   },
   rollupConfig: {


### PR DESCRIPTION
fix 1/2

It seems with latest 1.x version of Deno, a regression requires it strictly and global polyfill is not effective.

This PR also moves to use explicit `node:` specificier prefix.