### PR TITLE
fix(deno-server): explicitly remove cert/key from options if either is not set

### DIFF
--- a/src/presets/deno-server.ts
+++ b/src/presets/deno-server.ts
@@ -23,7 +23,7 @@ export const denoServer = defineNitroPreset({
       clearInterval: ["node:timers", "clearInterval"],
       setImmediate: ["node:timers", "setImmediate"],
       clearImmediate: ["node:timers", "clearImmediate"],
-      process: ["node:process", "default"],
+      // process: ["node:process", "default"],
     },
   },
   rollupConfig: {

--- a/src/runtime/entries/deno-server.ts
+++ b/src/runtime/entries/deno-server.ts
@@ -20,21 +20,25 @@ if (Deno.env.get("DEBUG")) {
   );
 }
 
-// https://deno.land/api@v1.34.3?s=Deno.serve&unstable=
-Deno.serve(
-  {
-    key: Deno.env.get("NITRO_SSL_KEY"),
-    cert: Deno.env.get("NITRO_SSL_CERT"),
-    port: destr(Deno.env.get("NITRO_PORT") || Deno.env.get("PORT")) || 3000,
-    hostname: Deno.env.get("NITRO_HOST") || Deno.env.get("HOST"),
-    onListen: (opts) => {
-      const baseURL = (useRuntimeConfig().app.baseURL || "").replace(/\/$/, "");
-      const url = `${opts.hostname}:${opts.port}${baseURL}`;
-      console.log(`Listening ${url}`);
-    },
+// https://deno.land/api@v1.42.4?s=Deno.serve
+const serveOptions = {
+  key: Deno.env.get("NITRO_SSL_KEY"),
+  cert: Deno.env.get("NITRO_SSL_CERT"),
+  port: destr(Deno.env.get("NITRO_PORT") || Deno.env.get("PORT")) || 3000,
+  hostname: Deno.env.get("NITRO_HOST") || Deno.env.get("HOST"),
+  onListen: (opts) => {
+    const baseURL = (useRuntimeConfig().app.baseURL || "").replace(/\/$/, "");
+    const url = `${opts.hostname}:${opts.port}${baseURL}`;
+    console.log(`Listening ${url}`);
   },
-  handler
-);
+};
+
+if (!serveOptions.key || !serveOptions.cert) {
+  delete serveOptions.key;
+  delete serveOptions.cert;
+}
+
+Deno.serve(serveOptions, handler);
 
 // Websocket support
 const ws = import.meta._websocket

--- a/src/runtime/entries/deno-server.ts
+++ b/src/runtime/entries/deno-server.ts
@@ -33,6 +33,7 @@ const serveOptions = {
   },
 };
 
+// https://github.com/unjs/nitro/pull/2373
 if (!serveOptions.key || !serveOptions.cert) {
   delete serveOptions.key;
   delete serveOptions.cert;


### PR DESCRIPTION
continuation of https://github.com/unjs/nitro/pull/2372 (reverting other fix for now to investigate more)

Seems a regression behavior after https://github.com/denoland/deno/pull/23289 internal `hasTlsKeyPairOptions` fails if propers `cert` and `key` exist in options even if undefined.