### PR TITLE
feat: allow overriding allowQuery in vercel prerender-config.json

### DIFF
--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -67,11 +67,17 @@ export const vercel = defineNitroPreset({
           funcPrefix + ".func",
           "junction"
         );
+
+        const allowQuery =
+          _hasProp(value, "allowQuery")
+            ? value.allowQuery
+            : (key.includes("/**") ? ["url"] : undefined);
+
         await writeFile(
           funcPrefix + ".prerender-config.json",
           JSON.stringify({
             expiration: value.isr === true ? false : value.isr,
-            allowQuery: key.includes("/**") ? ["url"] : undefined,
+            allowQuery,
             bypassToken: nitro.options.vercel?.config?.bypassToken,
           })
         );

--- a/src/types/nitro.ts
+++ b/src/types/nitro.ts
@@ -208,6 +208,7 @@ export interface NitroRouteRules
   extends Omit<NitroRouteConfig, "redirect" | "cors" | "swr" | "static"> {
   redirect?: { to: string; statusCode: HTTPStatusCode };
   proxy?: { to: string } & ProxyOptions;
+  allowQuery?: string[];
 }
 
 export interface NitroFrameworkInfo {


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

#1880 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When using ISR on Vercel, you can define which query params should be considered for the cache using the `allowQuery` key in the `.prerender-config.json` files. This is documented in the [Build API docs](https://vercel.com/docs/build-output-api/v3/primitives#prerender-configuration-file).
This PR allows defining a custom allowQuery configuration for each routeRule.
As an example, this configuration would ensure that each query parameter is cached independently:

``` 
routeRules: {
  '/**': {
    isr: true,
    allowQuery: undefined
  },
},
```

If you consider merging this change, I will happily add some documentation for it in the vercel section. Let me know what you think.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
