### PR TITLE
fix: deduplicate plugins

### DIFF
--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -330,17 +330,19 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
   // User virtuals
   rollupConfig.plugins.push(virtual(nitro.options.virtual, nitro.vfs));
 
+  const nitroPlugins = [...new Set(nitro.options.plugins)];
+
   // Plugins
   rollupConfig.plugins.push(
     virtual(
       {
         "#internal/nitro/virtual/plugins": `
-${nitro.options.plugins
+${nitroPlugins
   .map((plugin) => `import _${hash(plugin)} from '${plugin}';`)
   .join("\n")}
 
 export const plugins = [
-  ${nitro.options.plugins.map((plugin) => `_${hash(plugin)}`).join(",\n")}
+  ${nitroPlugins.map((plugin) => `_${hash(plugin)}`).join(",\n")}
 ]
     `,
       },


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Noticed when trying out https://github.com/pi0/nitro-cloudflare-dev/blob/main/src/index.ts that multiple copies of the same plugin were injected; this caused the following error:

```
[nitro 14:30:29]  ERROR  RollupError: virtual:#internal/nitro/virtual/plugins (6:7): Identifier "_BsBwid0Z5r" has already been declared


4: import _3SMM7tZjad from '/Users/daniel/code/danielroe/carpenter/node_modules/.pnpm/@nuxthub+core@0.5.11_ioredis@5.4.1...
5: import _BsBwid0Z5r from '/Users/daniel/code/danielroe/carpenter/node_modules/.pnpm/nitro-cloudflare-dev@0.1.4/node_mo...
6: import _BsBwid0Z5r from '/Users/daniel/code/danielroe/carpenter/node_modules/.pnpm/nitro-cloudflare-dev@0.1.4/node_mo...
          ^
7: 
8: export const plugins = [
```

The issue was user error - I was also using `@nuxthub/core` - but regardless, it seems like we should perhaps deduplicate?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
