### PR TITLE
fix(azure): correctly handle maxAge cookie option

### DIFF
--- a/src/runtime/utils.azure.ts
+++ b/src/runtime/utils.azure.ts
@@ -30,7 +30,7 @@ export function getAzureParsedCookiesFromHeaders(
       path: setCookieOptions.path,
       expires: parseNumberOrDate(setCookieOptions.expires),
       sameSite: setCookieOptions.samesite as "Lax" | "Strict" | "None",
-      maxAge: parseNumber(setCookieOptions.maxage),
+      maxAge: parseNumber(setCookieOptions["max-age"]),
       secure: setCookieStr.includes("Secure") ? true : undefined,
       httpOnly: setCookieStr.includes("HttpOnly") ? true : undefined,
     };

--- a/src/runtime/utils.azure.ts
+++ b/src/runtime/utils.azure.ts
@@ -30,7 +30,7 @@ export function getAzureParsedCookiesFromHeaders(
       path: setCookieOptions.path,
       expires: parseNumberOrDate(setCookieOptions.expires),
       sameSite: setCookieOptions.samesite as "Lax" | "Strict" | "None",
-      maxAge: parseNumber(setCookieOptions.maxAge),
+      maxAge: parseNumber(setCookieOptions.maxage),
       secure: setCookieStr.includes("Secure") ? true : undefined,
       httpOnly: setCookieStr.includes("HttpOnly") ? true : undefined,
     };


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

#2399

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In the utils that sets cookies for Azure, it is lowercasing the cookie keys at line 24, so `Max-Age` becomes `max-age`:

const setCookieOptions = Object.fromEntries(
      _setCookieOptions.map(([k, v]) => [k.toLowerCase(), v])
);

But uses another undefined key a few lines later:

maxAge: parseNumber(setCookieOptions.maxAge),

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
