### PR TITLE
feat(runtime-config): export `applyEnv` and `getEnv` from nitropack

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,7 @@ export * from "./prerender";
 export * from "./preset";
 export * from "./deps";
 
+export { applyEnv, getEnv } from "./runtime/utils.env";
+
 export { loadOptions } from "./options";
 export type { LoadConfigOptions } from "./options";

--- a/src/runtime/utils.env.ts
+++ b/src/runtime/utils.env.ts
@@ -2,15 +2,17 @@ import destr from "destr";
 import { snakeCase } from "scule";
 
 export type EnvOptions = {
+  env?: Record<string, unknown>;
   prefix?: string;
   altPrefix?: string;
   envExpansion?: boolean;
 };
 
 export function getEnv(key: string, opts: EnvOptions) {
+  const env = opts.env ?? process.env
   const envKey = snakeCase(key).toUpperCase();
   return destr(
-    process.env[opts.prefix + envKey] ?? process.env[opts.altPrefix + envKey]
+    env[opts.prefix + envKey] ?? env[opts.altPrefix + envKey]
   );
 }
 
@@ -47,7 +49,7 @@ export function applyEnv(
     }
     // Experimental env expansion
     if (opts.envExpansion && typeof obj[key] === "string") {
-      obj[key] = _expandFromEnv(obj[key]);
+      obj[key] = _expandFromEnv(obj[key], opts.env);
     }
   }
   return obj;
@@ -55,8 +57,8 @@ export function applyEnv(
 
 const envExpandRx = /{{(.*?)}}/g;
 
-function _expandFromEnv(value: string) {
+function _expandFromEnv(value: string, env: Record<string, any> = process.env) {
   return value.replace(envExpandRx, (match, key) => {
-    return process.env[key] || match;
+    return env[key] || match;
   });
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds `applyEnv` and `getEnv` as exports, as well as allowing them to operate on a custom `env` object instead of reading from `process.env`.

This would be a useful feature for frameworks to provide more accurate `runtimeConfig` at the build time. For example, we already inline these utils in https://github.com/nuxt/test-utils/pull/655 and would need to do the same for https://github.com/nuxt/nuxt/issues/24224 and https://github.com/nuxt/nuxt/issues/26960.

Of course, that would be fine, but it would nicer to be able to simulate the runtime behaviour of Nitro with these utils, as suggested in https://github.com/nuxt/nuxt/issues/24224#issuecomment-1805495557.

I've included them in the core `nitropack` export but I would almost prefer `nitropack/utils`, perhaps, to allow space for other similar utilities?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
