### PR TITLE
docs: correct directory name

### DIFF
--- a/docs/1.guide/0.index.md
+++ b/docs/1.guide/0.index.md
@@ -72,7 +72,7 @@ The `routes/` directory contains your application handlers. You can create subdi
 
 ### `api/`
 
-The `api/` directory is similar to `route/` with only difference that routes inside it will be prefixed with `/api/` for convenience.
+The `api/` directory is similar to `routes/` with only difference that routes inside it will be prefixed with `/api/` for convenience.
 
 :read-more{to="/guide/routing"}
 


### PR DESCRIPTION
Fixes incorrectly singularized directory name in documentation