### PR TITLE
docs: use `npx nypm install` in instead of `npm install`

### DIFF
--- a/docs/2.deploy/20.providers/github-pages.md
+++ b/docs/2.deploy/20.providers/github-pages.md
@@ -34,8 +34,8 @@ jobs:
         with:
           node-version: "18"
 
-      # Pick your own package manager and build script
-      - run: npm install
+      - run: npx nypm install
+      # Pick your own build script
       - run: npm run build
         env:
           NITRO_PRESET: github_pages

--- a/docs/2.deploy/20.providers/github-pages.md
+++ b/docs/2.deploy/20.providers/github-pages.md
@@ -35,7 +35,6 @@ jobs:
           node-version: "18"
 
       - run: npx nypm install
-      # Pick your own build script
       - run: npm run build
         env:
           NITRO_PRESET: github_pages

--- a/docs/2.deploy/20.providers/gitlab-pages.md
+++ b/docs/2.deploy/20.providers/gitlab-pages.md
@@ -15,26 +15,20 @@ Follow the steps to [create a GitLab Pages site](https://docs.gitlab.com/ee/user
 1. Here is an example GitLab Pages workflow to deploy your site to GitLab Pages:
 
 ```yaml [.gitlab-ci.yml]
-# The Docker image that will be used to build your app
 image: node:lts
-# Functions that should be executed before the build script is run
 before_script:
   - npx nypm install
 pages:
   cache:
     paths:
-      # Directories that are cached between builds
       - node_modules/
   variables:
     NITRO_PRESET: gitlab_pages
   script:
-    # Specify the steps involved to build your app here
     - npm run build
   artifacts:
     paths:
-      # The directory that contains the built files to be published
       - .output/public
-  # The directory that contains the built files to be published
   publish: .output/public
   rules:
     # This ensures that only pushes to the default branch

--- a/docs/2.deploy/20.providers/render.md
+++ b/docs/2.deploy/20.providers/render.md
@@ -10,10 +10,9 @@
 
 1. [Create a new Web Service](https://dashboard.render.com/select-repo?type=web) and select the repository that contains your code.
 2. Ensure the 'Node' environment is selected.
-3. Depending on your package manager, set the build command to `yarn && yarn build`, `npm install && npm run build`, or `pnpm i --shamefully-hoist && pnpm build`.
-4. Update the start command to `node .output/server/index.mjs`
-5. Click 'Advanced' and add an environment variable with `NITRO_PRESET` set to `render_com`. You may also need to add a `NODE_VERSION` environment variable set to `18` for the build to succeed ([docs](https://render.com/docs/node-version)).
-6. Click 'Create Web Service'.
+3. Update the start command to `node .output/server/index.mjs`
+4. Click 'Advanced' and add an environment variable with `NITRO_PRESET` set to `render_com`. You may also need to add a `NODE_VERSION` environment variable set to `18` for the build to succeed ([docs](https://render.com/docs/node-version)).
+5. Click 'Create Web Service'.
 
 ## Infrastructure as Code (IaC)
 
@@ -28,7 +27,7 @@ services:
     env: node
     branch: main
     startCommand: node .output/server/index.mjs
-    buildCommand: npm install && npm run build
+    buildCommand: npx nypm install && npm run build
     envVars:
     - key: NITRO_PRESET
       value: render_com


### PR DESCRIPTION


### 🔗 Linked issue

https://github.com/unjs/nitro/pull/2420#discussion_r1592501347

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This simplifies some of the docs by using `nypm` 🚀

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
