### PR TITLE
fix(netlify-v2): netlify not finding getGeneratorString

### DIFF
--- a/src/presets/netlify-v2.ts
+++ b/src/presets/netlify-v2.ts
@@ -202,7 +202,7 @@ function generateNetlifyFunction(nitro: Nitro) {
 export { default } from "./main.mjs";
 export const config = {
   name: "server handler",
-  generator: getGeneratorString(nitro),
+  generator: ${getGeneratorString(nitro)},
   path: "/*",
   preferStatic: true,
 };

--- a/src/presets/netlify-v2.ts
+++ b/src/presets/netlify-v2.ts
@@ -202,7 +202,7 @@ function generateNetlifyFunction(nitro: Nitro) {
 export { default } from "./main.mjs";
 export const config = {
   name: "server handler",
-  generator: ${getGeneratorString(nitro)},
+  generator: "${getGeneratorString(nitro)}",
   path: "/*",
   preferStatic: true,
 };


### PR DESCRIPTION
### 🔗 Linked issue

#2426

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Publishing to netlify, the functions fails with this error: `getGeneratorString is not defined`

@serhalp could you take a quick look?

Reproduction link in linked issue

https://github.com/Rigo-m/netlify-v2-repro/tree/patch-fix this branch contains a custom preset with the proposed fix
and it displays correctly in netlify https://patch-fix--netlify-v2-nitro.netlify.app/


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
