### PR TITLE
build: load presets from unbundled `nitropack/presets`

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -34,5 +34,10 @@ export default defineBuildConfig({
       },
     },
   },
-  externals: ["@nuxt/schema", "firebase-functions", "@scalar/api-reference", "nitropack"],
+  externals: [
+    "nitropack",
+    "nitropack/presets",
+    "firebase-functions",
+    "@scalar/api-reference",
+  ],
 });

--- a/src/options.ts
+++ b/src/options.ts
@@ -24,7 +24,6 @@ import type {
 import { runtimeDir, pkgDir } from "./dirs";
 import { nitroImports } from "./imports";
 import { PresetName } from "./presets";
-import { resolvePreset } from "./preset";
 
 const NitroDefaults: NitroConfig = {
   // General
@@ -164,6 +163,9 @@ export async function loadOptions(
 
   // Compatibility date
   const compatibilityDate = process.env.NITRO_COMPATIBILITY_DATE || opts.compatibilityDate;
+
+  // Preset resolver
+  const { resolvePreset } = await import("nitropack/presets");
 
   const c12Config = await (opts.watch ? watchConfig : loadConfig)(<
     WatchConfigOptions

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1,7 +1,5 @@
 import type { NitroPreset, NitroPresetMeta } from "./types";
 import { fileURLToPath } from "node:url";
-import { kebabCase } from "scule";
-import { provider } from 'std-env'
 
 export function defineNitroPreset<
   P extends NitroPreset,
@@ -17,42 +15,3 @@ export function defineNitroPreset<
   }
   return { ...preset, _meta: meta } as P & { _meta: M };
 }
-
-let _presets: typeof import("./presets")["presets"]
-
-export async function resolvePreset(name: string, opts: { static?: boolean, compatibilityDate?: string }): Promise<(NitroPreset & { _meta?: NitroPresetMeta }) | undefined> {
-  if (!_presets) {
-    _presets = (await import("./presets") as typeof import("./presets")).presets;
-  }
-
-  const _name = kebabCase(name) || provider;
-  const _date = new Date(opts.compatibilityDate || 0);
-
-  const matches = _presets.filter((preset) => {
-    const names = [preset._meta.name, preset._meta.stdName, ...(preset._meta.aliases || [])].filter(Boolean);
-    if (!names.includes(_name)) {
-      return false;
-    }
-    if (preset._meta.compatibility?.date && new Date(preset._meta.compatibility?.date || 0) > _date) {
-      return false
-    }
-    return true
-  }).sort((a, b) => {
-    const aDate = new Date(a._meta.compatibility?.date || 0);
-    const bDate = new Date(b._meta.compatibility?.date || 0);
-    return bDate > aDate ? 1 : -1
-  });
-
-  const preset = matches.find(p => (p._meta.static || false) === (opts?.static || false)) || matches[0];
-
-  if (typeof preset === 'function') {
-    return preset();
-  }
-
-  if (!name && !preset) {
-    return opts?.static ? resolvePreset('static', opts) : resolvePreset('node-server', opts)
-  }
-
-  return preset;
-}
-

--- a/src/presets/_resolve.ts
+++ b/src/presets/_resolve.ts
@@ -1,0 +1,37 @@
+import type { NitroPreset, NitroPresetMeta } from "nitropack";
+import { kebabCase } from "scule";
+import { provider } from 'std-env'
+import allPresets from "./_all.gen";
+
+export async function resolvePreset(name: string, opts: { static?: boolean, compatibilityDate?: string }): Promise<(NitroPreset & { _meta?: NitroPresetMeta }) | undefined> {
+  const _name = kebabCase(name) || provider;
+  const _date = new Date(opts.compatibilityDate || 0);
+
+  const matches = allPresets.filter((preset) => {
+    const names = [preset._meta.name, preset._meta.stdName, ...(preset._meta.aliases || [])].filter(Boolean);
+    if (!names.includes(_name)) {
+      return false;
+    }
+    if (preset._meta.compatibility?.date && new Date(preset._meta.compatibility?.date || 0) > _date) {
+      return false
+    }
+    return true
+  }).sort((a, b) => {
+    const aDate = new Date(a._meta.compatibility?.date || 0);
+    const bDate = new Date(b._meta.compatibility?.date || 0);
+    return bDate > aDate ? 1 : -1
+  });
+
+  const preset = matches.find(p => (p._meta.static || false) === (opts?.static || false)) || matches[0];
+
+  if (typeof preset === 'function') {
+    return preset();
+  }
+
+  if (!name && !preset) {
+    return opts?.static ? resolvePreset('static', opts) : resolvePreset('node-server', opts)
+  }
+
+  return preset;
+}
+

--- a/src/presets/index.d.ts
+++ b/src/presets/index.d.ts
@@ -1,3 +1,2 @@
-export { default as presets } from "./_all.gen"
-
 export type { PresetOptions, PresetName, PresetNameInput } from "./_types.gen";
+export { resolvePreset } from './_resolve'

--- a/src/presets/index.mjs
+++ b/src/presets/index.mjs
@@ -1,0 +1,1 @@
+export { resolvePreset } from './_resolve'

--- a/src/presets/netlify/legacy/preset.ts
+++ b/src/presets/netlify/legacy/preset.ts
@@ -2,7 +2,6 @@ import { existsSync, promises as fsp } from "node:fs";
 import { join, dirname } from "pathe";
 import { defineNitroPreset } from "nitropack";
 import type { Nitro } from "nitropack";
-import nitroPkg from "../../../../package.json";
 import { deprecateSWR, writeHeaders, writeRedirects } from "./utils";
 
 // Netlify functions
@@ -111,7 +110,7 @@ const netlifyEdge = defineNitroPreset(
               path: "/*",
               name: "nitro server handler",
               function: "server",
-              generator: `${nitroPkg.name}@${nitroPkg.version}`,
+              generator: `${nitro.options.framework.name}@${nitro.options.framework.version}`,
             },
           ],
         };

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -1,6 +1,6 @@
 import { pathToFileURL } from "node:url";
 import { createRequire, builtinModules } from "node:module";
-import { join, normalize, resolve } from "pathe";
+import { dirname, join, normalize, resolve } from "pathe";
 import type { InputOptions, OutputOptions, Plugin } from "rollup";
 import { defu } from "defu";
 // import terser from "@rollup/plugin-terser"; // TODO: Investigate jiti issue
@@ -431,6 +431,7 @@ export const plugins = [
             "@@/",
             "virtual:",
             "nitropack/runtime",
+            dirname(nitro.options.entry),
             ...(nitro.options.experimental.wasm
               ? [(id: string) => id?.endsWith(".wasm")]
               : []),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "jsx": "preserve",
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment",
+    "noEmit": true,
     "paths": {
       "nitropack": ["./src/index"],
       "nitropack/config": ["./src/config"],


### PR DESCRIPTION
Resolves #2448 

This PR moves internal `resolvePreset` under `nitropack/presets` which is unpacked dist and resolves to correct entries.

As a hotfix, a small change added to rollup config to make sure always entry's parent (usually preset's `/runtime`) is bundled.