### PR TITLE
fix: pass custom entry filename when resolving prerenderer

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -79,7 +79,7 @@ export async function prerender(nitro: Nitro) {
   // Import renderer entry
   const serverFilename =
     typeof nitro.options.rollupConfig?.output?.entryFileNames === "string"
-      ? nitro.options.rollupConfig?.output?.entryFileNames
+      ? nitro.options.rollupConfig.output.entryFileNames
       : "index.mjs";
   const serverEntrypoint = resolve(
     nitroRenderer.options.output.serverDir,

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -77,9 +77,13 @@ export async function prerender(nitro: Nitro) {
   await build(nitroRenderer);
 
   // Import renderer entry
+  const serverFilename =
+    typeof nitro.options.rollupConfig?.output?.entryFileNames === "string"
+      ? nitro.options.rollupConfig?.output?.entryFileNames
+      : "index.mjs";
   const serverEntrypoint = resolve(
     nitroRenderer.options.output.serverDir,
-    "index.mjs"
+    serverFilename
   );
   const { closePrerenderer, localFetch } = (await import(
     pathToFileURL(serverEntrypoint).href

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -60,13 +60,6 @@ export async function prerender(nitro: Nitro) {
     rootDir: nitro.options.rootDir,
     logLevel: 0,
     preset: "nitro-prerender",
-    rollupConfig: {
-      ...nitro.options._config.rollupConfig,
-      output: {
-        ...nitro.options._config.rollupConfig?.output,
-        entryFileNames: "index.mjs",
-      },
-    },
   };
   await nitro.hooks.callHook("prerender:config", prerendererConfig);
   const nitroRenderer = await createNitro(prerendererConfig);

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -77,9 +77,14 @@ export async function prerender(nitro: Nitro) {
   await build(nitroRenderer);
 
   // Import renderer entry
+  const serverFilename =
+    typeof nitroRenderer.options.rollupConfig?.output?.entryFileNames ===
+    "string"
+      ? nitroRenderer.options.rollupConfig.output.entryFileNames
+      : "index.mjs";
   const serverEntrypoint = resolve(
     nitroRenderer.options.output.serverDir,
-    "index.mjs"
+    serverFilename
   );
   const { closePrerenderer, localFetch } = (await import(
     pathToFileURL(serverEntrypoint).href

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -60,6 +60,13 @@ export async function prerender(nitro: Nitro) {
     rootDir: nitro.options.rootDir,
     logLevel: 0,
     preset: "nitro-prerender",
+    rollupConfig: {
+      ...nitro.options._config.rollupConfig,
+      output: {
+        ...nitro.options._config.rollupConfig?.output,
+        entryFileNames: "index.mjs",
+      },
+    },
   };
   await nitro.hooks.callHook("prerender:config", prerendererConfig);
   const nitroRenderer = await createNitro(prerendererConfig);
@@ -77,13 +84,9 @@ export async function prerender(nitro: Nitro) {
   await build(nitroRenderer);
 
   // Import renderer entry
-  const serverFilename =
-    typeof nitro.options.rollupConfig?.output?.entryFileNames === "string"
-      ? nitro.options.rollupConfig.output.entryFileNames
-      : "index.mjs";
   const serverEntrypoint = resolve(
     nitroRenderer.options.output.serverDir,
-    serverFilename
+    "index.mjs"
   );
   const { closePrerenderer, localFetch } = (await import(
     pathToFileURL(serverEntrypoint).href

--- a/src/presets/_nitro/nitro-prerender.ts
+++ b/src/presets/_nitro/nitro-prerender.ts
@@ -9,11 +9,6 @@ const nitroPrerender = defineNitroPreset(
       serverDir: "{{ buildDir }}/prerender",
     },
     externals: { trace: false },
-    rollupConfig: {
-      output: {
-        entryFileNames: "index.mjs",
-      },
-    },
   },
   {
     name: "nitro-prerender" as const,

--- a/src/presets/_nitro/nitro-prerender.ts
+++ b/src/presets/_nitro/nitro-prerender.ts
@@ -9,6 +9,11 @@ const nitroPrerender = defineNitroPreset(
       serverDir: "{{ buildDir }}/prerender",
     },
     externals: { trace: false },
+    rollupConfig: {
+      output: {
+        entryFileNames: "index.mjs",
+      },
+    },
   },
   {
     name: "nitro-prerender" as const,


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

Closes #2444

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This allows the `rollupConfig.options.output.entryFileNames` to be passed to the nitro prerenderer if its a string, with the fallback to `index.mjs`. This fixes an issue where prerendering fails if a custom entry filename is used.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
