### PR TITLE
fix(vercel): support custom `baseURL`

### DIFF
--- a/src/presets/vercel/preset.ts
+++ b/src/presets/vercel/preset.ts
@@ -18,7 +18,7 @@ const vercel = defineNitroPreset(
     output: {
       dir: "{{ rootDir }}/.vercel/output",
       serverDir: "{{ output.dir }}/functions/__nitro.func",
-      publicDir: "{{ output.dir }}/static",
+      publicDir: "{{ output.dir }}/static/{{ baseURL }}",
     },
     commands: {
       deploy: "",
@@ -48,7 +48,7 @@ const vercelEdge = defineNitroPreset(
     output: {
       dir: "{{ rootDir }}/.vercel/output",
       serverDir: "{{ output.dir }}/functions/__nitro.func",
-      publicDir: "{{ output.dir }}/static",
+      publicDir: "{{ output.dir }}/static/{{ baseURL }}",
     },
     commands: {
       deploy: "",
@@ -88,7 +88,7 @@ const vercelStatic = defineNitroPreset(
     extends: "static",
     output: {
       dir: "{{ rootDir }}/.vercel/output",
-      publicDir: "{{ output.dir }}/static",
+      publicDir: "{{ output.dir }}/static/{{ baseURL }}",
     },
     commands: {
       preview: "npx serve ./static",

--- a/src/presets/vercel/utils.ts
+++ b/src/presets/vercel/utils.ts
@@ -3,7 +3,7 @@ import fsp from "node:fs/promises";
 import { dirname, relative, resolve } from "pathe";
 import { writeFile } from "../_utils";
 import { defu } from "defu";
-import { withoutLeadingSlash } from "ufo";
+import { joinURL, withoutLeadingSlash } from "ufo";
 import type {
   VercelBuildConfigV3,
   VercelServerlessFunctionConfig,
@@ -121,7 +121,7 @@ function generateBuildConfig(nitro: Nitro) {
       // Public asset rules
       ...nitro.options.publicAssets
         .filter((asset) => !asset.fallthrough)
-        .map((asset) => asset.baseURL)
+        .map((asset) => joinURL(nitro.options.baseURL, asset.baseURL || "/"))
         .map((baseURL) => ({
           src: baseURL + "(.*)",
           headers: {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26886
resolves https://github.com/nuxt/nuxt/issues/21780
resolves https://github.com/unjs/nitro/issues/1348

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It's possible to deploy sites to Vercel with a custom `baseURL` and the renderer will correctly handle 404 on `/` and correct responses from `/<baseURL>/` but the public assets aren't configured to respect the `baseURL`.

Published minimal reproduction & patch to https://github.com/danielroe/nuxt-3-vercel-baseurl-test - you can see deployed at https://nuxt-3-vercel-baseurl-test-tan.vercel.app/subdir.

You can confirm that correct headers are added to a request like:

```sh
http --headers https://nuxt-3-vercel-baseurl-test-tan.vercel.app/subdir/_nuxt/C7CLbNSw.js
> HTTP/1.1 200 OK
> Access-Control-Allow-Origin: *
> Age: 88
> Cache-Control: public,max-age=31536000,immutable
> Connection: keep-alive
> Content-Disposition: inline; filename="C7CLbNSw.js"
> Content-Encoding: gzip
> Content-Type: application/javascript; charset=utf-8
> Date: Thu, 23 May 2024 16:37:55 GMT
> Etag: W/"c44aff3c70a5f49fad126ee0c615c297"
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
