### PR TITLE
docs: prefix `NITRO_` in `.env` file

### DIFF
--- a/docs/1.guide/97.configuration.md
+++ b/docs/1.guide/97.configuration.md
@@ -81,7 +81,7 @@ Finally, you can update the runtime config using environment variables. You can 
 Create an `.env` file in your project root:
 
 ```bash [.env]
-API_TOKEN="123"
+NITRO_API_TOKEN="123"
 ```
 
 Re-start the development server, fetch the `/api/example` endpoint and you should see `123` as the response instead of `dev_token`.


### PR DESCRIPTION
From my testing, I need to prefix `NITRO_` in .env file to make it work