### PR TITLE
fix: more compatibility for import from `nitropack/runtime/*`

### DIFF
--- a/src/core/build/types.ts
+++ b/src/core/build/types.ts
@@ -253,14 +253,14 @@ declare module "nitropack/types" {
                 "nitropack/runtime": [
                   relativeWithDot(tsconfigDir, join(runtimeDir, "index")),
                 ],
+                "#internal/nitro": [
+                  relativeWithDot(tsconfigDir, join(runtimeDir, "index")),
+                ],
                 "nitropack/runtime/*": [
                   relativeWithDot(tsconfigDir, join(runtimeDir, "*")),
                 ],
-                "#internal/nitro": [
-                  relativeWithDot(tsconfigDir, join(runtimeDir, "_compat")),
-                ],
                 "#internal/nitro/*": [
-                  relativeWithDot(tsconfigDir, join(runtimeDir, "_compat/*")),
+                  relativeWithDot(tsconfigDir, join(runtimeDir, "*")),
                 ],
               }
             : {}),

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -378,7 +378,7 @@ export const plugins = [
       entries: resolveAliases({
         "#build": buildDir,
         "#nitro-internal-virtual/error-handler": nitro.options.errorHandler,
-        "#internal/nitro": join(runtimeDir, "_compat"),
+        "#internal/nitro": runtimeDir,
         "nitropack/runtime": runtimeDir,
         "~": nitro.options.srcDir,
         "@/": nitro.options.srcDir,

--- a/src/runtime/_compat/app.ts
+++ b/src/runtime/_compat/app.ts
@@ -1,3 +1,0 @@
-// Backward compatibility for imports from "#internal/nitro/app"
-export { useNitroApp } from "../index";
-export type { NitroApp } from "nitropack/types";

--- a/src/runtime/_compat/error.ts
+++ b/src/runtime/_compat/error.ts
@@ -1,2 +1,0 @@
-// Backward compatibility default error handler (#internal/nitro/error)
-export { default } from "../internal/error";

--- a/src/runtime/_compat/index.ts
+++ b/src/runtime/_compat/index.ts
@@ -1,2 +1,0 @@
-// Backward compatibility for imports from "#internal/nitro"
-export * from "../index";

--- a/src/runtime/_compat/utils.ts
+++ b/src/runtime/_compat/utils.ts
@@ -1,2 +1,0 @@
-// Backward compatibility for imports from "#internal/nitro/utils"
-export { isJsonRequest, normalizeError } from "../internal/utils";

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -1,0 +1,4 @@
+// Backward compatibility for imports from "#internal/nitro/*" or "nitropack/runtime/*"
+
+export { useNitroApp } from "./internal/app";
+export type { NitroApp } from "nitropack/types";

--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -1,0 +1,8 @@
+// Backward compatibility for imports from "#internal/nitro/*" or "nitropack/runtime/*"
+
+export {
+  cachedEventHandler,
+  cachedFunction,
+  defineCachedEventHandler,
+  defineCachedFunction,
+} from "./internal/cache";

--- a/src/runtime/config.ts
+++ b/src/runtime/config.ts
@@ -1,3 +1,3 @@
 // Backward compatibility for imports from "#internal/nitro/*" or "nitropack/runtime/*"
 
-export { defineNitroPlugin, nitroPlugin } from "./internal/plugin";
+export { useAppConfig, useRuntimeConfig } from "./internal/config";

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -1,3 +1,3 @@
 // Backward compatibility for imports from "#internal/nitro/*" or "nitropack/runtime/*"
 
-export { defineNitroPlugin, nitroPlugin } from "./internal/plugin";
+export { useEvent } from "./internal/context";

--- a/src/runtime/database.ts
+++ b/src/runtime/database.ts
@@ -1,3 +1,3 @@
 // Backward compatibility for imports from "#internal/nitro/*" or "nitropack/runtime/*"
 
-export { defineNitroPlugin, nitroPlugin } from "./internal/plugin";
+export { useDatabase } from "./internal/database";

--- a/src/runtime/error.ts
+++ b/src/runtime/error.ts
@@ -1,3 +1,3 @@
 // Backward compatibility for imports from "#internal/nitro/*" or "nitropack/runtime/*"
 
-export { defineNitroPlugin, nitroPlugin } from "./internal/plugin";
+export { default } from "./internal/error";

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,0 +1,2 @@
+// // Backward compatibility for import { } from 'nitropack/runtime/plugin
+export { defineNitroPlugin } from "./internal/plugin";

--- a/src/runtime/storage.ts
+++ b/src/runtime/storage.ts
@@ -1,3 +1,3 @@
 // Backward compatibility for imports from "#internal/nitro/*" or "nitropack/runtime/*"
 
-export { defineNitroPlugin, nitroPlugin } from "./internal/plugin";
+export { useStorage } from "./internal/storage";

--- a/src/runtime/task.ts
+++ b/src/runtime/task.ts
@@ -1,3 +1,3 @@
 // Backward compatibility for imports from "#internal/nitro/*" or "nitropack/runtime/*"
 
-export { defineNitroPlugin, nitroPlugin } from "./internal/plugin";
+export { defineTask, runTask } from "./internal/task";

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,3 +1,2 @@
 // Backward compatibility for imports from "#internal/nitro/*" or "nitropack/runtime/*"
-
-export { defineNitroPlugin, nitroPlugin } from "./internal/plugin";
+export { isJsonRequest, normalizeError } from "./internal/utils";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,8 +40,8 @@
       // Virtual files
       "#nitro-internal-virtual/*": ["./src/types/virtual/*"],
       // Compatibility (#internal/nitro)
-      "#internal/nitro": ["./src/runtime/_compat"],
-      "#internal/nitro/*": ["./src/runtime/_compat/*"]
+      "#internal/nitro": ["./src/runtime"],
+      "#internal/nitro/*": ["./src/runtime/*"]
     }
   },
   "include": ["src", "test"],


### PR DESCRIPTION
With #2473 refactors, all runtime imports should be from `nitropack/runtime`.


This PR resolves #2499 (for `nitropack/runtime/plugin`) and possible cases alike that users used `nitropack/runtime/*` and `#internal/nitro/*` paths:

- `nitropack/runtime/app`
- `nitropack/runtime/cache`
- `nitropack/runtime/config`
- `nitropack/runtime/context`
- `nitropack/runtime/database`
- `nitropack/runtime/error`
- `nitropack/runtime/plugin`
- `nitropack/runtime/strorage`
- `nitropack/runtime/task`
- `nitropack/runtime/utils`

