### PR TITLE
fix(build): correctly watch custom `apiDir` and `routesDir`

### DIFF
--- a/src/core/build/dev.ts
+++ b/src/core/build/dev.ts
@@ -23,8 +23,8 @@ export async function watchDev(nitro: Nitro, rollupConfig: RollupConfig) {
   const reload = debounce(load);
 
   const watchPatterns = nitro.options.scanDirs.flatMap((dir) => [
-    join(dir, "api"),
-    join(dir, "routes"),
+    join(dir, nitro.options.apiDir || "api"),
+    join(dir, nitro.options.routesDir || "routes"),
     join(dir, "middleware", GLOB_SCAN_PATTERN),
     join(dir, "plugins"),
     join(dir, "modules"),


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Nitro supports customizing `apiDir` and `routesDir`, but continues to watch the creation/deletion of files *only* in the default `"api"` and `"routes"` folders.
This PR simply configures the watcher to use the configured ones if provided 🙂

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
