### PR TITLE
fix: add default field to subpath exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,58 +8,72 @@
   "exports": {
     "./cli": {
       "types": "./cli.d.ts",
+      "default": "./dist/cli/index.mjs",
       "import": "./dist/cli/index.mjs"
     },
     "./config": {
       "types": "./config.d.ts",
+      "default": "./dist/config/index.mjs",
       "import": "./dist/config/index.mjs"
     },
     ".": {
       "types": "./types.d.ts",
+      "default": "./dist/core/index.mjs",
       "import": "./dist/core/index.mjs"
     },
     "./core": {
       "types": "./types.d.ts",
+      "default": "./dist/core/index.mjs",
       "import": "./dist/core/index.mjs"
     },
     "./kit": {
       "types": "./kit.d.ts",
+      "default": "./dist/kit/index.mjs",
       "import": "./dist/kit/index.mjs"
     },
     "./meta": {
       "types": "./dist/meta/index.d.ts",
+      "default": "./dist/meta/index.mjs",
       "import": "./dist/meta/index.mjs"
     },
     "./presets": {
       "types": "./presets.d.ts",
+      "default": "./dist/presets/index.mjs",
       "import": "./dist/presets/index.mjs"
     },
     "./presets/*": {
       "types": "./dist/presets/*.d.ts",
+      "default": "./dist/presets/*.mjs",
       "import": "./dist/presets/*.mjs"
     },
     "./rollup": {
       "types": "./rollup.d.ts",
+      "default": "./dist/rollup/index.mjs",
       "import": "./dist/rollup/index.mjs"
     },
     "./runtime": {
       "types": "./runtime.d.ts",
+      "default": "./dist/runtime/index.mjs",
       "import": "./dist/runtime/index.mjs"
     },
     "./runtime/meta": {
       "types": "./runtime-meta.d.ts",
+      "default": "./runtime-meta.mjs",
       "import": "./runtime-meta.mjs"
     },
     "./runtime/*": {
       "types": "./dist/runtime/*.d.ts",
+      "default": "./dist/runtime/*.mjs",
       "import": "./dist/runtime/*.mjs"
     },
     "./dist/runtime/*": {
       "types": "./dist/runtime/*.d.ts",
+      "default": "./dist/runtime/*.mjs",
       "import": "./dist/runtime/*.mjs"
     },
     "./types": {
       "types": "./types.d.ts",
+      "default": "./dist/types/index.mjs",
       "import": "./dist/types/index.mjs"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

https://github.com/unjs/nitro/issues/2512
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds the `default` field to each subpath export, so that these are correctly resolved by jiti, when used in modules.

Alternatively, nitro could export cjs builds, if that is preferred.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
