### PR TITLE
fix(core): resolve modules with esm compatibility

### DIFF
--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -32,6 +32,7 @@ function _resolveNitroModule(
 
     const _jiti = jiti(nitroOptions.rootDir, {
       interopDefault: true,
+      esmResolve: true,
       alias: nitroOptions.alias,
     });
     const _modPath = _jiti.resolve(mod);


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/unjs/nitro/issues/2512


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This enables `esmResolve` for loading modules, so that subpaths are correctly imported.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
