### PR TITLE
fix(public-assets): do not shadow paths that share prefix

### DIFF
--- a/src/rollup/plugins/public-assets.ts
+++ b/src/rollup/plugins/public-assets.ts
@@ -1,5 +1,6 @@
 import { promises as fsp } from "node:fs";
 import { relative, resolve } from "pathe";
+import { withTrailingSlash } from "ufo";
 import createEtag from "etag";
 import mime from "mime";
 import { globby } from "globby";
@@ -112,7 +113,10 @@ export function readAsset (id) {
         const publicAssetBases = Object.fromEntries(
           nitro.options.publicAssets
             .filter((dir) => !dir.fallthrough && dir.baseURL !== "/")
-            .map((dir) => [dir.baseURL, { maxAge: dir.maxAge }])
+            .map((dir) => [
+              withTrailingSlash(dir.baseURL),
+              { maxAge: dir.maxAge },
+            ])
         );
 
         // prettier-ignore


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Encountered this as a side effect of replicating another bug.

Registering public asset dir with a base URL of, say, `/custom` will lead to paths like `/custom-thing` also being handled by the same handler (and returning a hard 404 if fallthrough is disabled). This is because we do not test if the path begins with `/custom/` but with `/custom`.

Let me know if you need me to provide a reproduction. I think the problem and fix are straightforward to see, but happy to do so!

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
