### PR TITLE
feat(defineCachedEventHandler): add `event.context.cache`

### DIFF
--- a/src/runtime/internal/cache.ts
+++ b/src/runtime/internal/cache.ts
@@ -349,7 +349,7 @@ export function defineCachedEventHandler<
           fetch: globalThis.$fetch as any,
         })) as $Fetch<unknown, NitroFetchRequest>;
       event.context = incomingEvent.context;
-      event.context.cached = true;
+      event.context.isCached = true;
       const body = (await handler(event)) || _resSendBody;
 
       // Collect cacheable headers

--- a/src/runtime/internal/cache.ts
+++ b/src/runtime/internal/cache.ts
@@ -349,6 +349,7 @@ export function defineCachedEventHandler<
           fetch: globalThis.$fetch as any,
         })) as $Fetch<unknown, NitroFetchRequest>;
       event.context = incomingEvent.context;
+      event.context.cached = true;
       const body = (await handler(event)) || _resSendBody;
 
       // Collect cacheable headers

--- a/src/runtime/internal/cache.ts
+++ b/src/runtime/internal/cache.ts
@@ -349,7 +349,7 @@ export function defineCachedEventHandler<
           fetch: globalThis.$fetch as any,
         })) as $Fetch<unknown, NitroFetchRequest>;
       event.context = incomingEvent.context;
-      event.context.isCached = true;
+      event.context.cache = {};
       const body = (await handler(event)) || _resSendBody;
 
       // Collect cacheable headers

--- a/src/runtime/internal/cache.ts
+++ b/src/runtime/internal/cache.ts
@@ -349,7 +349,9 @@ export function defineCachedEventHandler<
           fetch: globalThis.$fetch as any,
         })) as $Fetch<unknown, NitroFetchRequest>;
       event.context = incomingEvent.context;
-      event.context.cache = {};
+      event.context.cache = {
+        options: _opts,
+      };
       const body = (await handler(event)) || _resSendBody;
 
       // Collect cacheable headers

--- a/src/types/h3.ts
+++ b/src/types/h3.ts
@@ -1,4 +1,8 @@
-import type { CaptureError, CapturedErrorContext } from "nitropack/types";
+import type {
+  CaptureError,
+  CapturedErrorContext,
+  CacheOptions,
+} from "nitropack/types";
 import type { NitroFetchRequest, $Fetch } from "./fetch/fetch";
 
 export type H3EventFetch = (
@@ -24,6 +28,10 @@ declare module "h3" {
       _waitUntilPromises?: Promise<unknown>[];
       /** @experimental */
       errors: { error?: Error; context: CapturedErrorContext }[];
+    };
+
+    cache: {
+      options: CacheOptions;
     };
   }
 }

--- a/test/fixture/api/cached.ts
+++ b/test/fixture/api/cached.ts
@@ -1,6 +1,6 @@
 export default defineCachedEventHandler((event) => {
   return {
     timestamp: Date.now(),
-    cache: event.context.cache,
+    eventContextCache: event.context.cache,
   };
 });

--- a/test/fixture/api/cached.ts
+++ b/test/fixture/api/cached.ts
@@ -1,3 +1,6 @@
-export default defineCachedEventHandler(() => {
-  return Date.now();
+export default defineCachedEventHandler((event) => {
+  return {
+    timestamp: Date.now(),
+    cache: event.context.cache,
+  };
 });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -652,8 +652,11 @@ export function testNitro(
     it.skipIf(ctx.isIsolated)(
       "should setItem before returning response the first time",
       async () => {
-        const { data: timestamp } = await callHandler({ url: "/api/cached" });
+        const {
+          data: { timestamp, cache },
+        } = await callHandler({ url: "/api/cached" });
 
+        expect(cache).toBeDefined();
         const calls = await Promise.all([
           callHandler({ url: "/api/cached" }),
           callHandler({ url: "/api/cached" }),
@@ -661,7 +664,7 @@ export function testNitro(
         ]);
 
         for (const call of calls) {
-          expect(call.data).toBe(timestamp);
+          expect(call.data.timestamp).toBe(timestamp);
         }
       }
     );

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -653,10 +653,11 @@ export function testNitro(
       "should setItem before returning response the first time",
       async () => {
         const {
-          data: { timestamp, cache },
+          data: { timestamp, eventContextCache },
         } = await callHandler({ url: "/api/cached" });
 
-        expect(cache).toBeDefined();
+        expect(eventContextCache?.options.swr).toBe(true);
+
         const calls = await Promise.all([
           callHandler({ url: "/api/cached" }),
           callHandler({ url: "/api/cached" }),
@@ -665,6 +666,7 @@ export function testNitro(
 
         for (const call of calls) {
           expect(call.data.timestamp).toBe(timestamp);
+          expect(call.data.eventContextCache.options.swr).toBe(true);
         }
       }
     );


### PR DESCRIPTION
This allow the frontend framework connected to Nitro to be aware that the page is cached, useful for handling a flag in the payload to handle a different logic on client-side (e.g: fetch the auth state after hydration)