### PR TITLE
refactor!: always use native fetch in builds

### DIFF
--- a/src/core/config/resolvers/fetch.ts
+++ b/src/core/config/resolvers/fetch.ts
@@ -1,21 +1,11 @@
 import consola from "consola";
 import type { NitroOptions } from "nitro/types";
-import { nodeMajorVersion, provider } from "std-env";
 
 export async function resolveFetchOptions(options: NitroOptions) {
-  if (options.experimental.nodeFetchCompat === undefined) {
-    options.experimental.nodeFetchCompat = (nodeMajorVersion || 0) < 18;
-    if (options.experimental.nodeFetchCompat && provider !== "stackblitz") {
-      consola.warn(
-        "Node fetch compatibility is enabled. Please consider upgrading to Node.js >= 18."
-      );
-    }
-  }
-  if (!options.experimental.nodeFetchCompat) {
-    options.alias = {
-      "node-fetch-native/polyfill": "unenv/runtime/mock/empty",
-      "node-fetch-native": "node-fetch-native/native",
-      ...options.alias,
-    };
-  }
+  // Use native fetch in builds
+  options.alias = {
+    "node-fetch-native/polyfill": "unenv/runtime/mock/empty",
+    "node-fetch-native": "node-fetch-native/native",
+    ...options.alias,
+  };
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -117,10 +117,6 @@ export interface NitroOptions extends PresetOptions {
      */
     sourcemapMinify?: false;
     /**
-     * Backward compatibility support for Node fetch (required for Node < 18)
-     */
-    nodeFetchCompat?: boolean;
-    /**
      * Allow env expansion in runtime config
      *
      * @see https://github.com/unjs/nitro/pull/2043


### PR DESCRIPTION
this PR drops `nodeFetchCompat` flag, always defaulting `node-fetch-native` to the platform `fetch` and disable from build since Node 16 is not supported anymore. 

Escape hatch: Using `alias` config, node-fetch-native can still be overriden