### PR TITLE
feat: increase generated `tsconfig.json` strictness

### DIFF
--- a/src/core/build/types.ts
+++ b/src/core/build/types.ts
@@ -205,19 +205,31 @@ declare module "nitropack/types" {
     const tsconfigDir = dirname(tsConfigPath);
     const tsConfig: TSConfig = defu(nitro.options.typescript.tsConfig, {
       compilerOptions: {
-        forceConsistentCasingInFileNames: true,
+        /* Base options: */
+        esModuleInterop: true,
+        allowSyntheticDefaultImports: true,
+        skipLibCheck: true,
+        target: 'ESNext',
+        allowJs: true,
+        resolveJsonModule: true,
+        moduleDetection: 'force',
+        isolatedModules: true,
+        verbatimModuleSyntax: true,
+        /* Strictness */
         strict: nitro.options.typescript.strict,
+        noUncheckedIndexedAccess: true,
+        noImplicitOverride: true,
+        forceConsistentCasingInFileNames: true,
+        /* If NOT transpiling with TypeScript: */
+        // TODO: consider using 'module: preserve' (requires TS 5.4+)
+        module: 'ESNext',
         noEmit: true,
-        target: "ESNext",
-        module: "ESNext",
         moduleResolution:
           nitro.options.experimental.typescriptBundlerResolution === false
             ? "Node"
             : "Bundler",
-        allowJs: true,
-        resolveJsonModule: true,
+        /* JSX support */
         jsx: "preserve",
-        allowSyntheticDefaultImports: true,
         jsxFactory: "h",
         jsxFragmentFactory: "Fragment",
         paths: {

--- a/src/core/build/types.ts
+++ b/src/core/build/types.ts
@@ -209,10 +209,10 @@ declare module "nitropack/types" {
         esModuleInterop: true,
         allowSyntheticDefaultImports: true,
         skipLibCheck: true,
-        target: 'ESNext',
+        target: "ESNext",
         allowJs: true,
         resolveJsonModule: true,
-        moduleDetection: 'force',
+        moduleDetection: "force",
         isolatedModules: true,
         verbatimModuleSyntax: true,
         /* Strictness */
@@ -222,7 +222,7 @@ declare module "nitropack/types" {
         forceConsistentCasingInFileNames: true,
         /* If NOT transpiling with TypeScript: */
         // TODO: consider using 'module: preserve' (requires TS 5.4+)
-        module: 'ESNext',
+        module: "ESNext",
         noEmit: true,
         moduleResolution:
           nitro.options.experimental.typescriptBundlerResolution === false


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This increases strictness for the generated `tsconfig.json`. The most significant change, I think, is `noUncheckedIndexedAccess` - feel free to remove if you think this is too much! (But of course it can always be disabled by end user.

Also opening against main in case you prefer it there. (Just close whichever PR is not relevant.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
