### PR TITLE
fix: upate `cli` preset with esm module format

### DIFF
--- a/src/presets/node/runtime/cli.ts
+++ b/src/presets/node/runtime/cli.ts
@@ -13,17 +13,15 @@ async function cli() {
   debug("StatusCode", r.status);
   debug("StatusMessage", r.statusText);
   // @ts-ignore
-  for (const header of r.headers.entries()) {
+  for (const header of Object.entries(r.headers)) {
     debug(header[0], header[1]);
   }
   console.log("\n", r.body?.toString());
 }
 
-if (require.main === module) {
-  // eslint-disable-next-line unicorn/prefer-top-level-await
-  cli().catch((error) => {
-    console.error(error);
-    // eslint-disable-next-line unicorn/no-process-exit
-    process.exit(1);
-  });
-}
+// eslint-disable-next-line unicorn/prefer-top-level-await
+cli().catch((error) => {
+  console.error(error);
+  // eslint-disable-next-line unicorn/no-process-exit
+  process.exit(1);
+});

--- a/src/presets/node/runtime/cli.ts
+++ b/src/presets/node/runtime/cli.ts
@@ -1,6 +1,6 @@
 import "#nitro-internal-pollyfills";
 import { useNitroApp } from "nitropack/runtime";
-import path from "node:path";
+import { normalize } from "pathe";
 
 const nitroApp = useNitroApp();
 
@@ -20,7 +20,7 @@ async function cli() {
   console.log("\n", r.body?.toString());
 }
 
-if (process.argv.some((arg) => globalThis._importMeta_.url.includes(arg.split(path.sep).join(path.posix.sep)))) {
+if (process.argv.some((arg) => globalThis._importMeta_.url.includes(normalize(arg)))) {
   // eslint-disable-next-line unicorn/prefer-top-level-await
   cli().catch((error) => {
     console.error(error);

--- a/src/presets/node/runtime/cli.ts
+++ b/src/presets/node/runtime/cli.ts
@@ -1,5 +1,6 @@
 import "#nitro-internal-pollyfills";
 import { useNitroApp } from "nitropack/runtime";
+import path from "node:path";
 
 const nitroApp = useNitroApp();
 
@@ -19,9 +20,11 @@ async function cli() {
   console.log("\n", r.body?.toString());
 }
 
-// eslint-disable-next-line unicorn/prefer-top-level-await
-cli().catch((error) => {
-  console.error(error);
-  // eslint-disable-next-line unicorn/no-process-exit
-  process.exit(1);
-});
+if (process.argv.some((arg) => globalThis._importMeta_.url.includes(arg.split(path.sep).join(path.posix.sep)))) {
+  // eslint-disable-next-line unicorn/prefer-top-level-await
+  cli().catch((error) => {
+    console.error(error);
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(1);
+  });
+}

--- a/src/presets/node/runtime/cli.ts
+++ b/src/presets/node/runtime/cli.ts
@@ -20,7 +20,7 @@ async function cli() {
   console.log("\n", r.body?.toString());
 }
 
-if (process.argv.some((arg) => globalThis._importMeta_.url.includes(normalize(arg)))) {
+if (process.argv.some((arg) => import.meta.url.includes(normalize(arg)))) {
   // eslint-disable-next-line unicorn/prefer-top-level-await
   cli().catch((error) => {
     console.error(error);


### PR DESCRIPTION
### 🔗 Linked issue

Part of implementing #2466 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The generated `server/index.mjs` is no longer dependent on the `require`.

Also, it uses `Object.entries` for result headers.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
