### PR TITLE
fix(core): scan handlers when initialising nitro

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -18,4 +18,3 @@ export { build } from "./build/build";
 export { copyPublicAssets } from "./build/assets";
 export { prepare } from "./build/prepare";
 export { writeTypes } from "./build/types";
-export { scanHandlers } from "./scan";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -18,3 +18,4 @@ export { build } from "./build/build";
 export { copyPublicAssets } from "./build/assets";
 export { prepare } from "./build/prepare";
 export { writeTypes } from "./build/types";
+export { scanHandlers } from "./scan";

--- a/src/core/nitro.ts
+++ b/src/core/nitro.ts
@@ -12,7 +12,7 @@ import { createUnimport } from "unimport";
 import { loadOptions } from "./config/loader";
 import { updateNitroConfig } from "./config/update";
 import { installModules } from "./module";
-import { scanAndSyncOptions } from "./scan";
+import { scanAndSyncOptions, scanHandlers } from "./scan";
 import { addNitroTasksVirtualFile } from "./task";
 import { createStorage } from "./utils/storage";
 
@@ -78,8 +78,11 @@ export async function createNitro(
     nitro.options.virtual["#nitro"] = 'export * from "#imports"';
   }
 
-  // Scan and install modules as last step
+  // Scan and install modules
   await installModules(nitro);
+
+  // Ensure initial handlers are populated
+  await scanHandlers(nitro);
 
   return nitro;
 }


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This runs `scanHandlers`, which is required to run before `writeTypes` to ensure the return types for the handlers are present + correctly generated:

https://github.com/unjs/nitro/blob/7e0b49ef63f1404657d875543bcbbec6c2a4d6b9/src/core/build/types.ts#L25

I've placed it after running modules so that they could update the directories to be scanned, if required. If that's not necessary we could move it up to these lines - or even include within `scanAndSyncOptions`:

https://github.com/unjs/nitro/blob/86b48239d0a38d08854d4caa49cdc3febca8fe18/src/core/nitro.ts#L40-L42

Alternatively, we could export `scanHandlers` to allow frameworks to do this automatically.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
