### PR TITLE
fix: make sure nitro runtime goes to one chunk

### DIFF
--- a/src/presets/_types.gen.ts
+++ b/src/presets/_types.gen.ts
@@ -1,11 +1,11 @@
 // Auto-generated using gen-presets script
 
-import type { PresetOptions as AwsAmplifyOptions } from "./aws-amplify/preset";
-import type { PresetOptions as AzureOptions } from "./azure/preset";
-import type { PresetOptions as CloudflareOptions } from "./cloudflare/preset";
-import type { PresetOptions as FirebaseOptions } from "./firebase/preset";
-import type { PresetOptions as NetlifyOptions } from "./netlify/preset";
-import type { PresetOptions as VercelOptions } from "./vercel/preset";
+import { PresetOptions as AwsAmplifyOptions } from "./aws-amplify/preset";
+import { PresetOptions as AzureOptions } from "./azure/preset";
+import { PresetOptions as CloudflareOptions } from "./cloudflare/preset";
+import { PresetOptions as FirebaseOptions } from "./firebase/preset";
+import { PresetOptions as NetlifyOptions } from "./netlify/preset";
+import { PresetOptions as VercelOptions } from "./vercel/preset";
 
 export interface PresetOptions {
   awsAmplify: AwsAmplifyOptions;

--- a/src/presets/_types.gen.ts
+++ b/src/presets/_types.gen.ts
@@ -1,11 +1,11 @@
 // Auto-generated using gen-presets script
 
-import { PresetOptions as AwsAmplifyOptions } from "./aws-amplify/preset";
-import { PresetOptions as AzureOptions } from "./azure/preset";
-import { PresetOptions as CloudflareOptions } from "./cloudflare/preset";
-import { PresetOptions as FirebaseOptions } from "./firebase/preset";
-import { PresetOptions as NetlifyOptions } from "./netlify/preset";
-import { PresetOptions as VercelOptions } from "./vercel/preset";
+import type { PresetOptions as AwsAmplifyOptions } from "./aws-amplify/preset";
+import type { PresetOptions as AzureOptions } from "./azure/preset";
+import type { PresetOptions as CloudflareOptions } from "./cloudflare/preset";
+import type { PresetOptions as FirebaseOptions } from "./firebase/preset";
+import type { PresetOptions as NetlifyOptions } from "./netlify/preset";
+import type { PresetOptions as VercelOptions } from "./vercel/preset";
 
 export interface PresetOptions {
   awsAmplify: AwsAmplifyOptions;

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -8,7 +8,11 @@ import json from "@rollup/plugin-json";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import { defu } from "defu";
 import { resolvePath, sanitizeFilePath } from "mlly";
-import { runtimeDependencies, runtimeDir, pkgDir } from "nitropack/runtime/meta";
+import {
+  pkgDir,
+  runtimeDependencies,
+  runtimeDir,
+} from "nitropack/runtime/meta";
 import type {
   Nitro,
   NitroStaticBuildFlags,
@@ -85,7 +89,11 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
   ] as const;
 
   function getChunkGroup(id: string): string | void {
-    if (id.startsWith(runtimeDir) || id.startsWith('#internal/nitro') || id.startsWith(pkgDir)) {
+    if (
+      id.startsWith(runtimeDir) ||
+      id.startsWith("#internal/nitro") ||
+      id.startsWith(pkgDir)
+    ) {
       return "nitro";
     }
   }
@@ -141,7 +149,7 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
         return getChunkName(lastModule);
       },
       manualChunks(id) {
-        return getChunkGroup(id)
+        return getChunkGroup(id);
       },
       inlineDynamicImports: nitro.options.inlineDynamicImports,
       format: "esm",
@@ -189,8 +197,8 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
     },
   });
 
-  if(rollupConfig.output.inlineDynamicImports) {
-    delete rollupConfig.output.manualChunks
+  if (rollupConfig.output.inlineDynamicImports) {
+    delete rollupConfig.output.manualChunks;
   }
 
   if (nitro.options.timing) {

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -8,11 +8,7 @@ import json from "@rollup/plugin-json";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import { defu } from "defu";
 import { resolvePath, sanitizeFilePath } from "mlly";
-import {
-  pkgDir,
-  runtimeDependencies,
-  runtimeDir,
-} from "nitropack/runtime/meta";
+import { runtimeDependencies, runtimeDir } from "nitropack/runtime/meta";
 import type {
   Nitro,
   NitroStaticBuildFlags,
@@ -78,32 +74,25 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
 
   const buildServerDir = join(nitro.options.buildDir, "dist/server");
 
+  const presetsDir = resolve(runtimeDir, "../presets");
+
   const chunkNamePrefixes = [
     [nitro.options.buildDir, "build"],
     [buildServerDir, "app"],
     [runtimeDir, "nitro"],
-    [pkgDir, "nitro"],
+    [presetsDir, "nitro"],
     ["\0raw:", "raw"],
     ["\0nitro-wasm:", "wasm"],
     ["\0", "virtual"],
   ] as const;
 
   function getChunkGroup(id: string): string | void {
-    if (
-      id.startsWith(runtimeDir) ||
-      id.startsWith("#internal/nitro") ||
-      id.startsWith(pkgDir)
-    ) {
+    if (id.startsWith(runtimeDir) || id.startsWith(presetsDir)) {
       return "nitro";
     }
   }
 
   function getChunkName(id: string) {
-    // Runtime
-    if (id.startsWith(runtimeDir)) {
-      return `chunks/runtime.mjs`;
-    }
-
     // Known path prefixes
     for (const [dir, name] of chunkNamePrefixes) {
       if (id.startsWith(dir)) {

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -131,6 +131,16 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
         const lastModule = normalize(chunk.moduleIds.at(-1) || "");
         return getChunkName(lastModule);
       },
+      manualChunks: {
+        nitro: [
+          runtimeDir,
+          "nitropack/runtime",
+          "nitro/runtime",
+          "#internal/nitro",
+          "#internal/app",
+          "#imports",
+        ],
+      },
       inlineDynamicImports: nitro.options.inlineDynamicImports,
       format: "esm",
       exports: "auto",

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -137,7 +137,6 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
           "nitropack/runtime",
           "nitro/runtime",
           "#internal/nitro",
-          "#internal/app",
           "#imports",
         ],
       },

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -186,6 +186,10 @@ export const getRollupConfig = (nitro: Nitro): RollupConfig => {
     },
   });
 
+  if(rollupConfig.output.inlineDynamicImports) {
+    delete rollupConfig.output.manualChunks
+  }
+
   if (nitro.options.timing) {
     rollupConfig.plugins.push(timing());
   }


### PR DESCRIPTION
(context: Reported by @Atinux testing nitropack nightly against nuxt content module which has top level imports from `#imports` + nuxt renderer from `#internal/nitro`)

Nitro runtime can be imported with different ways `#nitropack/runtime`, `#internal/nitro`, `#nitriopack/runtime/*`. This makes rollup warning about manual chunks.