### PR TITLE
fix(types): infer types correctly when method is omitted

### DIFF
--- a/src/types/fetch/fetch.ts
+++ b/src/types/fetch/fetch.ts
@@ -78,7 +78,13 @@ export interface $Fetch<
   >(
     request: R,
     opts?: O
-  ): Promise<TypedInternalResponse<R, T, ExtractedRouteMethod<R, O>>>;
+  ): Promise<
+    TypedInternalResponse<
+      R,
+      T,
+      NitroFetchOptions<R> extends O ? "get" : ExtractedRouteMethod<R, O>
+    >
+  >;
   raw<
     T = DefaultT,
     R extends NitroFetchRequest = DefaultR,
@@ -87,7 +93,13 @@ export interface $Fetch<
     request: R,
     opts?: O
   ): Promise<
-    FetchResponse<TypedInternalResponse<R, T, ExtractedRouteMethod<R, O>>>
+    FetchResponse<
+      TypedInternalResponse<
+        R,
+        T,
+        NitroFetchOptions<R> extends O ? "get" : ExtractedRouteMethod<R, O>
+      >
+    >
   >;
   create<T = DefaultT, R extends NitroFetchRequest = DefaultR>(
     defaults: FetchOptions

--- a/test/fixture/types.ts
+++ b/test/fixture/types.ts
@@ -183,6 +183,13 @@ describe("API routes", () => {
   });
 
   it("generates the correct type depending on the method used", () => {
+    expectTypeOf($fetch("/api/methods")).toEqualTypeOf<Promise<"Index get">>();
+    expectTypeOf($fetch("/api/methods", {})).toEqualTypeOf<
+      Promise<"Index get">
+    >();
+    expectTypeOf($fetch("/api/methods", { query: {} })).toEqualTypeOf<
+      Promise<"Index get">
+    >();
     expectTypeOf($fetch("/api/methods", { method: "get" })).toEqualTypeOf<
       Promise<"Index get">
     >();


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Related: https://github.com/unjs/nitro/pull/2550

This fixes the types for `$fetch` when a method is omitted.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
