### PR TITLE
fix(netlify): ensure preview command is correct

### DIFF
--- a/src/presets/netlify/legacy/preset.ts
+++ b/src/presets/netlify/legacy/preset.ts
@@ -130,10 +130,11 @@ const netlifyStatic = defineNitroPreset(
   {
     extends: "static",
     output: {
+      dir: "{{ rootDir }}/dist",
       publicDir: "{{ rootDir }}/dist",
     },
     commands: {
-      preview: "npx serve ./static",
+      preview: "npx serve ./",
     },
     hooks: {
       "rollup:before": (nitro: Nitro) => {

--- a/src/presets/netlify/preset.ts
+++ b/src/presets/netlify/preset.ts
@@ -111,10 +111,11 @@ const netlifyStatic = defineNitroPreset(
   {
     extends: "static",
     output: {
+      dir: "{{ rootDir }}/dist",
       publicDir: "{{ rootDir }}/dist",
     },
     commands: {
-      preview: "npx serve ./static",
+      preview: "npx serve ./",
     },
     hooks: {
       async compiled(nitro: Nitro) {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/24015

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

You can also reproduce locally - the issue is that relative paths are resolved relative to `output.dir` which is not overridden in these netlify presets. And in fact no `static` directory is produced.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
