### PR TITLE
fix(handler-meta): check for `.name` with `undefined`  value in `ObjectExpression`

### DIFF
--- a/src/rollup/plugins/handlers-meta.ts
+++ b/src/rollup/plugins/handlers-meta.ts
@@ -81,7 +81,7 @@ function astToObject(node: Expression | Literal): any {
       const obj: Record<string, any> = {};
       for (const prop of node.properties) {
         if (prop.type === "Property") {
-          const key = (prop.key as any).name;
+          const key = (prop.key as any).name ?? (prop.key as any).value;
           obj[key] = astToObject(prop.value as any);
         }
       }

--- a/test/fixture/api/meta/test.ts
+++ b/test/fixture/api/meta/test.ts
@@ -3,6 +3,11 @@ defineRouteMeta({
     tags: ["test"],
     description: "Test route description",
     parameters: [{ in: "query", name: "test", required: true }],
+    responses: {
+      200: {
+        description: "OK"
+      }
+    }
   },
 });
 

--- a/test/fixture/api/meta/test.ts
+++ b/test/fixture/api/meta/test.ts
@@ -5,9 +5,9 @@ defineRouteMeta({
     parameters: [{ in: "query", name: "test", required: true }],
     responses: {
       200: {
-        description: "OK"
-      }
-    }
+        description: "OK",
+      },
+    },
   },
 });
 


### PR DESCRIPTION

### 🔗 Linked issue
https://github.com/unjs/nitro/issues/2564

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Checks ObjectExpression keys and attemptes to use the value property as the key if name indefined, allowing for number or number-like keys.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
