### PR TITLE
feat(netlify): use new `durable` cache-control directive for `isr` rule

### DIFF
--- a/src/presets/netlify/runtime/netlify.ts
+++ b/src/presets/netlify/runtime/netlify.ts
@@ -64,7 +64,7 @@ function getCacheHeaders(url: string): Record<string, string> {
         : "must-revalidate";
     return {
       "Cache-Control": "public, max-age=0, must-revalidate",
-      "Netlify-CDN-Cache-Control": `public, max-age=${maxAge}, ${revalidateDirective}`,
+      "Netlify-CDN-Cache-Control": `public, max-age=${maxAge}, ${revalidateDirective}, durable`,
     };
   }
   return {};

--- a/test/presets/netlify.test.ts
+++ b/test/presets/netlify.test.ts
@@ -87,11 +87,11 @@ describe("nitro:preset:netlify", async () => {
         `);
       });
       describe("matching ISR route rule with no max-age", () => {
-        it("sets Netlify-CDN-Cache-Control header with revalidation after 1 year", async () => {
+        it("sets Netlify-CDN-Cache-Control header with revalidation after 1 year and durable directive", async () => {
           const { headers } = await callHandler({ url: "/rules/isr" });
           expect(
             (headers as Record<string, string>)["netlify-cdn-cache-control"]
-          ).toBe("public, max-age=31536000, must-revalidate");
+          ).toBe("public, max-age=31536000, must-revalidate, durable");
         });
         it("sets Cache-Control header with immediate revalidation", async () => {
           const { headers } = await callHandler({ url: "/rules/isr" });
@@ -101,11 +101,13 @@ describe("nitro:preset:netlify", async () => {
         });
       });
       describe("matching ISR route rule with a max-age", () => {
-        it("sets Netlify-CDN-Cache-Control header with SWC=1yr and given max-age", async () => {
+        it("sets Netlify-CDN-Cache-Control header with SWC=1yr, given max-age, and durable directive", async () => {
           const { headers } = await callHandler({ url: "/rules/isr-ttl" });
           expect(
             (headers as Record<string, string>)["netlify-cdn-cache-control"]
-          ).toBe("public, max-age=60, stale-while-revalidate=31536000");
+          ).toBe(
+            "public, max-age=60, stale-while-revalidate=31536000, durable"
+          );
         });
         it("sets Cache-Control header with immediate revalidation", async () => {
           const { headers } = await callHandler({ url: "/rules/isr-ttl" });
@@ -130,7 +132,7 @@ describe("nitro:preset:netlify", async () => {
         });
         expect(
           (headers as Record<string, string>)["netlify-cdn-cache-control"]
-        ).toBe("public, max-age=60, stale-while-revalidate=31536000");
+        ).toBe("public, max-age=60, stale-while-revalidate=31536000, durable");
       });
     }
   );


### PR DESCRIPTION
### 🔗 Linked issue

N/A - discussed on Discord

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a follow-up to https://github.com/unjs/nitro/pull/2406.

See https://docs.netlify.com/platform/caching/#durable-directive. (This link should go live a bit later today!)

With this change, responses from `isr` routes will be propagated to the global edge network rather than be local to the CDN node that rendered and served it. This will improve performance and reduce serverless function invocations, in various scenarios.

This won't immediately have any effect since we're gradually rolling out the feature on the platform, but by the time nitro v3 (and frameworks that use it, like nuxt v4) are released it should be fully rolled out. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
