### PR TITLE
fix: hide unhandled error messages in prod

### DIFF
--- a/src/runtime/internal/error.ts
+++ b/src/runtime/internal/error.ts
@@ -21,7 +21,10 @@ interface ParsedError {
 
 export default defineNitroErrorHandler(
   function defaultNitroErrorHandler(error, event) {
-    const { stack, statusCode, statusMessage, message } = normalizeError(error);
+    const { stack, statusCode, statusMessage, message } = normalizeError(
+      error,
+      isDev
+    );
 
     const showDetails = isDev && statusCode !== 404;
 

--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -55,33 +55,41 @@ export function isJsonRequest(event: H3Event) {
   );
 }
 
-export function normalizeError(error: any) {
+export function normalizeError(error: any, isDev?: boolean) {
   // temp fix for https://github.com/unjs/nitro/issues/759
   // TODO: investigate vercel-edge not using unenv pollyfill
   const cwd = typeof process.cwd === "function" ? process.cwd() : "/";
-  const stack = ((error.stack as string) || "")
-    .split("\n")
-    .splice(1)
-    .filter((line) => line.includes("at "))
-    .map((line) => {
-      const text = line
-        .replace(cwd + "/", "./")
-        .replace("webpack:/", "")
-        .replace("file://", "")
-        .trim();
-      return {
-        text,
-        internal:
-          (line.includes("node_modules") && !line.includes(".cache")) ||
-          line.includes("internal") ||
-          line.includes("new Promise"),
-      };
-    });
+
+  // Hide details of unhandled/fatal errors in production
+  const hideDetails = !isDev && (error.unhandled || error.fatal);
+
+  const stack = hideDetails
+    ? []
+    : ((error.stack as string) || "")
+        .split("\n")
+        .splice(1)
+        .filter((line) => line.includes("at "))
+        .map((line) => {
+          const text = line
+            .replace(cwd + "/", "./")
+            .replace("webpack:/", "")
+            .replace("file://", "")
+            .trim();
+          return {
+            text,
+            internal:
+              (line.includes("node_modules") && !line.includes(".cache")) ||
+              line.includes("internal") ||
+              line.includes("new Promise"),
+          };
+        });
 
   const statusCode = error.statusCode || 500;
   const statusMessage =
     error.statusMessage ?? (statusCode === 404 ? "Not Found" : "");
-  const message = error.message || error.toString();
+  const message = hideDetails
+    ? "internal server error"
+    : error.message || error.toString();
 
   return {
     stack,


### PR DESCRIPTION
We should hide error messages (to client) in case of unhandled errors because they can include internal server state.

Thanks for @galactichypernova for discovering this! (issue was if a chunk is missing, we were showing full path but it can be extended to other causes)

Note: This might be a minor behavior change but since we only hide unhandled errors, (`new Error` not `createError`) i guess should be safe for v2 as patch.