### PR TITLE
docs: convert to underscore preset names

### DIFF
--- a/docs/1.guide/10.tasks.md
+++ b/docs/1.guide/10.tasks.md
@@ -93,7 +93,7 @@ export default defineNuxtConfig({
 ### Platform support
 
 - `dev`, `node-server`, `bun` and `deno-server` presets are supported with [croner](https://croner.56k.guru/) engine.
-- `cloudflare_module` preset have native integraton with [Cron Triggers](https://developers.cloudflare.com/workers/configuration/cron-triggers/). Make sure to configure wrangler to use exactly same patterns you define in `scheduledTasks` to be matched.
+- `cloudflare_module` preset have native integration with [Cron Triggers](https://developers.cloudflare.com/workers/configuration/cron-triggers/). Make sure to configure wrangler to use exactly same patterns you define in `scheduledTasks` to be matched.
 - More presets (with native primitives support) are planned to be supported!
 
 ## Programmatically run tasks

--- a/docs/2.deploy/10.runtimes/1.node.md
+++ b/docs/2.deploy/10.runtimes/1.node.md
@@ -6,7 +6,7 @@ icon: akar-icons:node-fill
 
 > Run Nitro apps with Node.js runtime.
 
-**Preset:** `node-server`
+**Preset:** `node_server`
 
 Node.js is the default nitro output preset for production builds and Nitro has native Node.js runtime support.
 
@@ -40,16 +40,15 @@ You can customize server behavior using following environment variables:
 
 ## Cluster mode
 
-**Preset:** `node-cluster`
+**Preset:** `node_cluster`
 
 For more performance and leveraging multi core handling, you can use cluster preset.
 
 ### Environment Variables
 
-In addition to `node-server` environment variables, you can customize behavior:
+In addition to environment variables from the `node_server` preset, you can customize behavior:
 
 - `NITRO_CLUSTER_WORKERS`: Number of cluster workers (default is Number of available cpu cores)
-
 
 ## Handler (advanced)
 

--- a/docs/2.deploy/10.runtimes/deno.md
+++ b/docs/2.deploy/10.runtimes/deno.md
@@ -6,13 +6,13 @@ icon: simple-icons:deno
 
 > Run Nitro apps with [Deno](https://deno.com/) runtime.
 
-**Preset:** `deno-server`
+**Preset:** `deno_server`
 
 You can build your Nitro server using Node.js to run within [Deno Runtime](https://deno.com/runtime) in a custom server.
 
 ```bash
 # Build with the deno NITRO preset
-NITRO_PRESET=deno-server npm run build
+NITRO_PRESET=deno_server npm run build
 
 # Start production server
 deno run --unstable --allow-net --allow-read --allow-env .output/server/index.ts

--- a/docs/2.deploy/20.providers/cloudflare.md
+++ b/docs/2.deploy/20.providers/cloudflare.md
@@ -26,16 +26,16 @@ If you use the [Cloudflare Pages GitHub/GitLab integration](https://developers.c
 
 If instead you want preview your application locally and/or manually deploy it, when building the application you will need to let Nitro know that the target environment is the Cloudflare Pages one, you can do that in two ways:
 
-1. By defining either the `NITRO_PRESET` or the `SERVER_PRESET` environment variable set to `cloudflare-pages` when running the build process, like so:
+1. By defining either the `NITRO_PRESET` or the `SERVER_PRESET` environment variable set to `cloudflare_pages` when running the build process, like so:
 
   ```bash
-  NITRO_PRESET=cloudflare-pages npm run build
+  NITRO_PRESET=cloudflare_pages npm run build
   ```
 
 1. Or by updating your Nitro [preset configuration](/config#preset):
 
   ```json5
-  "preset": "cloudflare-pages",
+  "preset": "cloudflare_pages",
   ```
 
 and then running the standard build command:

--- a/docs/2.deploy/20.providers/digitalocean.md
+++ b/docs/2.deploy/20.providers/digitalocean.md
@@ -2,7 +2,7 @@
 
 > Deploy Nitro apps to DigitalOcean.
 
-**Preset:** `digital-ocean`
+**Preset:** `digital_ocean`
 
 :read-more{title="Digital Ocean App Platform" to="https://docs.digitalocean.com/products/app-platform/"}
 
@@ -13,7 +13,7 @@
 1. Next, you'll need to configure environment variables. In your app settings, ensure the following app-level environment variables are set:
 
    ```bash
-   NITRO_PRESET=digital-ocean
+   NITRO_PRESET=digital_ocean
    ```
 
    [More information](https://docs.digitalocean.com/products/app-platform/how-to/use-environment-variables/).

--- a/docs/3.config/0.index.md
+++ b/docs/3.config/0.index.md
@@ -12,7 +12,7 @@ icon: ri:settings-3-line
 
 Use `preset` option `NITRO_PRESET` environment variable for custom **production** preset.
 
-Preset for development mode is always `nitro-dev` and default `node-server` for production building a standalone Node.js server.
+Preset for development mode is always `nitro_dev` and default `node_server` for production building a standalone Node.js server.
 
 The preset will automatically be detected when the `preset` option is not set and running in known environments.
 


### PR DESCRIPTION
Followup of https://github.com/unjs/nitro/pull/2576#issuecomment-2212480843

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Changes docs to use `_` preset names

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
