### PR TITLE
fix(prerender): allow ignoring errors in `prerender:generate` hook

### DIFF
--- a/src/core/prerender/prerender.ts
+++ b/src/core/prerender/prerender.ts
@@ -254,6 +254,7 @@ export async function prerender(nitro: Nitro) {
       nitro._prerenderMeta![_route.fileName].contentType = _route.contentType;
     }
 
+    // After hook to allow ignoring in `prerender:generate` hook
     if (_route.error) {
       failedRoutes.add(_route);
     }

--- a/src/core/prerender/prerender.ts
+++ b/src/core/prerender/prerender.ts
@@ -223,7 +223,6 @@ export async function prerender(nitro: Nitro) {
       _route.error = new Error(`[${res.status}] ${res.statusText}`) as any;
       _route.error!.statusCode = res.status;
       _route.error!.statusMessage = res.statusText;
-      failedRoutes.add(_route);
     }
 
     // Measure actual time taken for generating route
@@ -253,6 +252,10 @@ export async function prerender(nitro: Nitro) {
     if (_route.contentType !== inferredContentType) {
       nitro._prerenderMeta![_route.fileName] ||= {};
       nitro._prerenderMeta![_route.fileName].contentType = _route.contentType;
+    }
+
+    if (_route.error) {
+      failedRoutes.add(_route);
     }
 
     // Check if route is skipped or has errors


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We currently allow skipping route generation in `prerender:generate`, but it's not possible to granularly ignore errors on a per-route basis. Instead we either turn off `failOnError` for the entire build or not.

This change allows the user (or integration) to ignore _particular_ errors based on their own criteria, without disabling `failOnError` protection entirely.

You might also consider this an enhancement - feel free to amend 🙏 

> **background**: was debugging some strange errors prerendering `/_ipx` routes that only occured in Vercel on my personal site - I am happy ignoring these but would like any _other_ errors to be build-breaking ones.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
