### PR TITLE
fix: only hide message of unhandled errors in prod

### DIFF
--- a/src/runtime/internal/utils.ts
+++ b/src/runtime/internal/utils.ts
@@ -60,36 +60,35 @@ export function normalizeError(error: any, isDev?: boolean) {
   // TODO: investigate vercel-edge not using unenv pollyfill
   const cwd = typeof process.cwd === "function" ? process.cwd() : "/";
 
-  // Hide details of unhandled/fatal errors in production
-  const hideDetails = !isDev && (error.unhandled || error.fatal);
-
-  const stack = hideDetails
-    ? []
-    : ((error.stack as string) || "")
-        .split("\n")
-        .splice(1)
-        .filter((line) => line.includes("at "))
-        .map((line) => {
-          const text = line
-            .replace(cwd + "/", "./")
-            .replace("webpack:/", "")
-            .replace("file://", "")
-            .trim();
-          return {
-            text,
-            internal:
-              (line.includes("node_modules") && !line.includes(".cache")) ||
-              line.includes("internal") ||
-              line.includes("new Promise"),
-          };
-        });
+  const stack =
+    !isDev && (error.unhandled || error.fatal)
+      ? []
+      : ((error.stack as string) || "")
+          .split("\n")
+          .splice(1)
+          .filter((line) => line.includes("at "))
+          .map((line) => {
+            const text = line
+              .replace(cwd + "/", "./")
+              .replace("webpack:/", "")
+              .replace("file://", "")
+              .trim();
+            return {
+              text,
+              internal:
+                (line.includes("node_modules") && !line.includes(".cache")) ||
+                line.includes("internal") ||
+                line.includes("new Promise"),
+            };
+          });
 
   const statusCode = error.statusCode || 500;
   const statusMessage =
     error.statusMessage ?? (statusCode === 404 ? "Not Found" : "");
-  const message = hideDetails
-    ? "internal server error"
-    : error.message || error.toString();
+  const message =
+    !isDev && error.unhandled
+      ? "internal server error"
+      : error.message || error.toString();
 
   return {
     stack,


### PR DESCRIPTION
Fix regression of https://github.com/unjs/nitro/pull/2591 that hides messages of `fatal: true` errors. 

Context: As pointed out in https://github.com/nuxt/nuxt/pull/28156#discussion_r1679720615, the current assumption was that `fatal` can be also used by user-thrown errors. 

In the future, we might introduce a new `internal` flag to h3 errors to clearly separate internal and user errors from each other and keep (internal) fatal also private.