### PR TITLE
refactor(dev): attach worker reload error as `cause`

### DIFF
--- a/src/core/dev-server/server.ts
+++ b/src/core/dev-server/server.ts
@@ -46,8 +46,7 @@ function initWorker(filename: string): Promise<NitroWorker> | undefined {
       );
     });
     worker.once("error", (err) => {
-      const newErr = new Error("[worker init] " + err.message);
-      newErr.stack = err.stack;
+      const newErr = new Error(`[worker init] ${filename} failed`, { cause: err });
       reject(newErr);
     });
     const addressListener = (event: any) => {

--- a/src/core/dev-server/server.ts
+++ b/src/core/dev-server/server.ts
@@ -46,7 +46,9 @@ function initWorker(filename: string): Promise<NitroWorker> | undefined {
       );
     });
     worker.once("error", (err) => {
-      const newErr = new Error(`[worker init] ${filename} failed`, { cause: err });
+      const newErr = new Error(`[worker init] ${filename} failed`, {
+        cause: err,
+      });
       reject(newErr);
     });
     const addressListener = (event: any) => {

--- a/src/core/dev-server/server.ts
+++ b/src/core/dev-server/server.ts
@@ -45,11 +45,14 @@ function initWorker(filename: string): Promise<NitroWorker> | undefined {
         )
       );
     });
-    worker.once("error", (err) => {
-      const newErr = new Error(`[worker init] ${filename} failed`, {
-        cause: err,
+    worker.once("error", (error) => {
+      const newError = new Error(`[worker init] ${filename} failed`, {
+        cause: error,
       });
-      reject(newErr);
+      if (Error.captureStackTrace) {
+        Error.captureStackTrace(newError, initWorker);
+      }
+      reject(newError);
     });
     const addressListener = (event: any) => {
       if (!event || !event?.address) {


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Improve the error message to include more details on where the error happens.

Before
```
[worker reload] Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:228:11)
    at defaultLoad (node:internal/modules/esm/load:110:3)
    at ModuleLoader.load (node:internal/modules/esm/loader:567:13)
    at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:442:56)
    at new ModuleJob (node:internal/modules/esm/module_job:76:27)
    at #createModuleJob (node:internal/modules/esm/loader:455:17)
    at ModuleLoader.getJobFromResolveResult (node:internal/modules/esm/loader:266:34)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:247:17)
```
After
```
[worker reload] Error: [worker init] D:/Programming/JabRefOnline/.nuxt/dev/index.mjs failed
    at Worker.<anonymous> (file:///D:/Programming/JabRefOnline/node_modules/.pnpm/nitropack@2.9.7_patch_hash=i7fsivvt52bwxcdhgprlrzxqpy_@azure+identity@4.4.1_@opentelemetry+api@1.9.0_magicast@0.3.4/node_modules/nitropack/dist/chunks/server.mjs:210:22)
    at Object.onceWrapper (node:events:635:26)
    at Worker.emit (node:events:520:28)
    at [kOnErrorMessage] (node:internal/worker:326:10)
    at [kOnMessage] (node:internal/worker:337:37)
    at MessagePort.<anonymous> (node:internal/worker:232:57)
    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:816:20)
    at MessagePort.<anonymous> (node:internal/per_context/messageport:23:28)
    at MessagePort.callbackTrampoline (node:internal/async_hooks:130:17)
    at [kOnExit] (node:internal/worker:303:5) {
  [cause]: Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'  
      at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:228:11)
      at defaultLoad (node:internal/modules/esm/load:110:3)
      at ModuleLoader.load (node:internal/modules/esm/loader:567:13)
      at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:442:56)
      at new ModuleJob (node:internal/modules/esm/module_job:76:27)
      at #createModuleJob (node:internal/modules/esm/loader:455:17)
      at ModuleLoader.getJobFromResolveResult (node:internal/modules/esm/loader:266:34)
      at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:247:17) {
    code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME'
```


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
