### PR TITLE
fix(prerender): skip protocol relative links

### DIFF
--- a/src/core/prerender/utils.ts
+++ b/src/core/prerender/utils.ts
@@ -85,7 +85,7 @@ export function extractLinks(
 
   for (const link of _links.filter(Boolean)) {
     const _link = parseURL(link);
-    if (_link.protocol) {
+    if (_link.protocol || _link.host) {
       continue;
     }
     if (!_link.pathname.startsWith("/")) {


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/28525

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Came across this reported in nuxt. If a protocol relative URL is present in the HTML, for example:

```html
<script>window.__NUXT__={};window.__NUXT__.config={public:{},app:{baseURL:"/",buildId:"714a6c13-10f0-427c-9610-0084561693b4",buildAssetsDir:"/_nuxt/",cdnURL:"//xxx.cqyx.vip/static/"}}</script>
```

Then `/static` will be crawled. We check for protocol but not for protocol relative URLs. I think checking for `host` should be sufficient as `/static` would not have a defined host but let me know if you have a better idea.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
