### PR TITLE
feat(modules): infer modules types in config

### DIFF
--- a/src/core/build/types.ts
+++ b/src/core/build/types.ts
@@ -127,6 +127,7 @@ export async function writeTypes(nitro: Nitro) {
     `
 // App Config
 import type { Defu } from 'defu'
+import type { NitroModule } from 'nitropack/types'
 
 ${nitro.options.appConfigFiles
   .map((file, index) =>
@@ -160,6 +161,12 @@ declare module "nitropack/types" {
           }
         )
       : "",
+    "",
+    "interface NitroConfig {",
+    (nitro.options._resolvedModules ?? [])?.map((module) => {
+      return `  ["${module.configKey}"]: typeof import("${module._url}").default extends NitroModule<infer O> ? Partial<O> : Record<string, any>`;
+    }),
+    "}",
     `}`,
     // Makes this a module for augmentation purposes
     "export {}",

--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -6,6 +6,8 @@ export async function installModules(nitro: Nitro) {
   const modules = await Promise.all(
     _modules.map((mod) => _resolveNitroModule(mod, nitro.options))
   );
+  nitro.options._resolvedModules = modules;
+
   const _installedURLs = new Set<string>();
   for (const mod of modules) {
     if (mod._url) {
@@ -14,7 +16,7 @@ export async function installModules(nitro: Nitro) {
       }
       _installedURLs.add(mod._url);
     }
-    await mod.setup(nitro);
+    await mod.setup(nitro, nitro.options[mod.configKey || ""]);
   }
 }
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -30,7 +30,7 @@ import type {
   NitroEventHandler,
 } from "./handler";
 import type { NitroHooks } from "./hooks";
-import type { NitroModuleInput } from "./module";
+import type { NitroModule, NitroModuleInput } from "./module";
 import type { NitroFrameworkInfo } from "./nitro";
 import type { NitroOpenAPIConfig } from "./openapi";
 import type { NitroPreset } from "./preset";
@@ -48,6 +48,7 @@ export interface NitroOptions extends PresetOptions {
   _cli?: {
     command?: string;
   };
+  _resolvedModules?: (NitroModule & { _url?: string })[];
 
   // Compatibility
   compatibilityDate: CompatibilityDates;
@@ -252,6 +253,8 @@ export interface NitroOptions extends PresetOptions {
     mergeConfig?: boolean;
     overrideConfig?: boolean;
   };
+
+  [key: string]: any;
 }
 
 /**

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -1,5 +1,5 @@
 import type { NitroConfig, NitroOptions } from "./config";
-import type { NitroModule } from "./module";
+import type { NitroModule, NitroModuleOptions } from "./module";
 
 export interface NitroStaticBuildFlags {
   _asyncContext?: boolean;
@@ -27,7 +27,9 @@ declare global {
 
 declare global {
   const defineNitroConfig: (config: NitroConfig) => NitroConfig;
-  const defineNitroModule: (definition: NitroModule) => NitroModule;
+  const defineNitroModule: <O extends NitroModuleOptions>(
+    definition: NitroModule<O>
+  ) => NitroModule<O>;
 }
 
 export type {};

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -2,7 +2,12 @@ import type { Nitro } from "./nitro";
 
 export type NitroModuleInput = string | NitroModule | NitroModule["setup"];
 
-export interface NitroModule {
+export type NitroModuleOptions = Record<string, any>;
+
+export interface NitroModule<
+  O extends NitroModuleOptions = NitroModuleOptions,
+> {
   name?: string;
-  setup: (this: void, nitro: Nitro) => void | Promise<void>;
+  configKey?: string;
+  setup: (this: void, nitro: Nitro, options: O) => void | Promise<void>;
 }


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
fix #2685

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Hello 👋,

This feature uses typegen to add modules types within the `NitroConfig` interface to allow autocompletion in the `nitro.config.ts` file.

With the following module:

```ts
interface ModuleOptions {
  bar: string;
  foo: {
    baz: string;
  };
}

export default defineNitroModule<ModuleOptions>({
  name: "playground",
  configKey: "playground",
  setup: (nitro, moduleOptions) => {},
});
```

TypeScript will help you with autocompletion when you are configuring the module in the `nitro.config.ts` file:

```ts
import { defineNitroConfig } from "nitropack/config";

export default defineNitroConfig({
  playground: {
    bar: "bar",
    foo: "baz",
  },

  compatibilityDate: "2024-06-12",
});
```

_Of course, the `foo` property should be an object, and TypeScript will raise an error._

<img width="605" alt="Screenshot 2024-08-23 at 01 15 43" src="https://github.com/user-attachments/assets/a8625475-ac2e-43f2-b665-1bdb5e81f211">


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
