### PR TITLE
feat(deno-server): use output `node_modules` for `start` task

### DIFF
--- a/src/presets/deno/preset.ts
+++ b/src/presets/deno/preset.ts
@@ -145,7 +145,7 @@ const denoServer = defineNitroPreset(
         const denoJSON = {
           tasks: {
             start:
-              "deno run --unstable --allow-net --allow-read --allow-write --allow-env ./server/index.mjs",
+              "deno run --allow-net --allow-read --allow-write --allow-env --unstable-byonm ./server/index.mjs",
           },
         };
         await writeFile(


### PR DESCRIPTION
Nitro generates `.output/server/node_moduels` for used dependencies, however deno does not use this directory (and instead tries to download all dependencies again on first run!).

This PR removed old `--unstable` and adds new `--unstable-byonm` flag by default to the start task. (this also speeds up our internal CI tests for deno-server by ~2x)