### PR TITLE
fix(cloudflare-module): use correct types for `email` and `queue` events/hooks

### DIFF
--- a/src/presets/cloudflare/runtime/cloudflare-module.ts
+++ b/src/presets/cloudflare/runtime/cloudflare-module.ts
@@ -1,19 +1,18 @@
 import "#nitro-internal-pollyfills";
-import { useNitroApp } from "nitro/runtime";
-import { useRuntimeConfig } from "nitro/runtime";
-import { runCronTasks } from "nitro/runtime/internal";
-import { requestHasBody } from "nitro/runtime/internal";
-import { getPublicAssetMeta } from "#nitro-internal-virtual/public-assets";
-
 import {
   getAssetFromKV,
   mapRequestToAsset,
 } from "@cloudflare/kv-asset-handler";
-import type { ExecutionContext } from "@cloudflare/workers-types";
+import type {
+  ExecutionContext,
+  ForwardableEmailMessage,
+  MessageBatch,
+} from "@cloudflare/workers-types";
 import wsAdapter from "crossws/adapters/cloudflare";
+import { useNitroApp, useRuntimeConfig } from "nitro/runtime";
+import { requestHasBody, runCronTasks } from "nitro/runtime/internal";
 import { withoutBase } from "ufo";
-
-import type { CloudflareEmailContext, CloudflareMessageBatch } from "../types";
+import { getPublicAssetMeta } from "#nitro-internal-virtual/public-assets";
 
 // @ts-ignore Bundled by Wrangler
 // See https://github.com/cloudflare/kv-asset-handler#asset_manifest-required-for-es-modules
@@ -103,7 +102,7 @@ export default {
   },
 
   email(
-    event: CloudflareEmailContext,
+    event: ForwardableEmailMessage,
     env: CFModuleEnv,
     context: ExecutionContext
   ) {
@@ -113,11 +112,7 @@ export default {
     );
   },
 
-  queue(
-    event: CloudflareEmailContext,
-    env: CFModuleEnv,
-    context: ExecutionContext
-  ) {
+  queue(event: MessageBatch, env: CFModuleEnv, context: ExecutionContext) {
     (globalThis as any).__env__ = env;
     context.waitUntil(
       nitroApp.hooks.callHook("cloudflare:queue", { event, env, context })

--- a/src/presets/cloudflare/types.ts
+++ b/src/presets/cloudflare/types.ts
@@ -1,4 +1,8 @@
-import type { ExecutionContext } from "@cloudflare/workers-types";
+import type {
+  ExecutionContext,
+  ForwardableEmailMessage,
+  MessageBatch,
+} from "@cloudflare/workers-types";
 import type { Config as WranglerConfig } from "./types.wrangler";
 
 /**
@@ -52,47 +56,15 @@ export interface CloudflareOptions {
   };
 }
 
-/** @experimental */
-export interface CloudflareEmailContext {
-  readonly from?: string;
-  readonly to?: string;
-  readonly headers?: Headers;
-  readonly raw?: ReadableStream;
-  readonly rawSize?: number;
-
-  setReject?(reason: string): void;
-  forward?(rcptTo: string, headers?: Headers): Promise<void>;
-  reply?(message: CloudflareEmailContext): Promise<void>;
-}
-
-export interface CloudflareQueueRetryOptions {
-  delaySeconds?: number;
-}
-
-export interface CloudflareMessageBody<Body = unknown> {
-  readonly id: string;
-  readonly timestamp: Date;
-  readonly body: Body;
-  adk(): void;
-  retry(options?: CloudflareQueueRetryOptions): void;
-}
-
-export interface CloudflareMessageBatch<Body = unknown> {
-  readonly queue: string;
-  readonly messages: CloudflareMessageBody<Body>[];
-  ackAll(): void;
-  retryAll(options?: CloudflareQueueRetryOptions): void;
-}
-
 declare module "nitro/types" {
   export interface NitroRuntimeHooks {
     "cloudflare:email": (_: {
-      event: CloudflareEmailContext;
+      event: ForwardableEmailMessage;
       env: any;
       context: ExecutionContext;
     }) => void;
     "cloudflare:queue": (_: {
-      event: CloudflareEmailContext;
+      event: MessageBatch;
       env: any;
       context: ExecutionContext;
     }) => void;


### PR DESCRIPTION
### 🔗 Linked issue

Original issue: https://github.com/unjs/nitro/issues/2480

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

https://github.com/unjs/nitro/pull/2487 introduced custom types for these events and hooks that contain typos. (for example: `adk()` instead of `ack()`)

There are native types provided by `@cloudflare/workers-types` that we can use for these. 
I updated the exported handler and the hooks accordingly.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
