### PR TITLE
fix: ensure legacy runtime config types are populated

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,4 @@
-import type { NitroConfig, NitroRouteConfig } from "nitropack/types";
-import type { NitroOpenAPIConfig } from "../types/openapi";
+import type { NitroConfig, NitroOpenAPIConfig, NitroRouteConfig } from "nitropack/types";
 
 // Core
 export { createNitro } from "./nitro";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,8 @@
-import type { NitroConfig, NitroOpenAPIConfig, NitroRouteConfig } from "nitropack/types";
+import type {
+  NitroConfig,
+  NitroOpenAPIConfig,
+  NitroRouteConfig,
+} from "nitropack/types";
 
 // Core
 export { createNitro } from "./nitro";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,5 @@
-import type { NitroConfig } from "nitropack/types";
+import type { NitroConfig, NitroRouteConfig } from "nitropack/types";
+import type { NitroOpenAPIConfig } from "../types/openapi"
 
 // Core
 export { createNitro } from "./nitro";
@@ -50,10 +51,24 @@ export {
 } from "./scan";
 
 /** @deprecated Use `NitroRuntimeConfig` from `nitropack/types` */
-export interface NitroRuntimeConfig {}
+export interface NitroRuntimeConfig {
+  app: NitroRuntimeConfigApp;
+  nitro: {
+    envPrefix?: string;
+    envExpansion?: boolean;
+    routeRules?: {
+      [path: string]: NitroRouteConfig;
+    };
+    openAPI?: NitroOpenAPIConfig;
+  };
+  [key: string]: any;
+}
 
 /** @deprecated Use `NitroRuntimeConfigApp` from `nitropack/types` */
-export interface NitroRuntimeConfigApp {}
+export interface NitroRuntimeConfigApp {
+  baseURL: string;
+  [key: string]: any;
+}
 
 /** @deprecated Directly import { ... } from "nitropack/types"; */
 export type {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,5 @@
 import type { NitroConfig, NitroRouteConfig } from "nitropack/types";
-import type { NitroOpenAPIConfig } from "../types/openapi"
+import type { NitroOpenAPIConfig } from "../types/openapi";
 
 // Core
 export { createNitro } from "./nitro";

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -337,20 +337,6 @@ export type DatabaseConnectionConfigs = Record<
 
 // Runtime config
 
-export interface NitroRuntimeConfigApp extends NitroTypesRuntimeConfigApp {
-  baseURL: string;
-  [key: string]: any;
-}
+export interface NitroRuntimeConfigApp extends NitroTypesRuntimeConfigApp {}
 
-export interface NitroRuntimeConfig extends NitroTypeskRuntimeConfig {
-  app: NitroRuntimeConfigApp;
-  nitro: {
-    envPrefix?: string;
-    envExpansion?: boolean;
-    routeRules?: {
-      [path: string]: NitroRouteConfig;
-    };
-    openAPI?: NitroOpenAPIConfig;
-  };
-  [key: string]: any;
-}
+export interface NitroRuntimeConfig extends NitroTypeskRuntimeConfig {}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -33,6 +33,7 @@ import type { NitroHooks } from "./hooks";
 import type { NitroModuleInput } from "./module";
 import type { NitroFrameworkInfo } from "./nitro";
 import type { NitroOpenAPIConfig } from "./openapi";
+export type { NitroOpenAPIConfig } from "./openapi";
 import type { NitroPreset } from "./preset";
 import type { EsbuildOptions, NodeExternalsOptions } from "./rollup";
 import type { RollupConfig } from "./rollup";


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Context: https://github.com/nuxt/nuxt/pull/28924, https://github.com/nuxt/ecosystem-ci/actions/runs/10799722624.

Currently changes to `NitroRuntimeConfig` and  `NitroRuntimeConfigApp` are breaking for users/modules consuming `nitropack`.

This ensures types imported from `nitropack` aren't breaking.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
