### PR TITLE
fix: ensure legacy hook types are populated

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,7 +1,10 @@
+import type { AppOptions, H3Event } from "h3";
 import type {
+  CaptureError,
   NitroConfig,
   NitroOpenAPIConfig,
   NitroRouteConfig,
+  RenderResponse,
 } from "nitropack/types";
 
 // Core
@@ -65,6 +68,21 @@ export interface NitroRuntimeConfig {
     openAPI?: NitroOpenAPIConfig;
   };
   [key: string]: any;
+}
+
+/** @deprecated Use `NitroRuntimeHooks` from `nitropack/types` */
+export interface NitroRuntimeHooks {
+  close: () => void;
+  error: CaptureError;
+
+  request: NonNullable<AppOptions["onRequest"]>;
+  beforeResponse: NonNullable<AppOptions["onBeforeResponse"]>;
+  afterResponse: NonNullable<AppOptions["onAfterResponse"]>;
+
+  "render:response": (
+    response: Partial<RenderResponse>,
+    context: { event: H3Event }
+  ) => void;
 }
 
 /** @deprecated Use `NitroRuntimeConfigApp` from `nitropack/types` */

--- a/src/types/runtime/nitro.ts
+++ b/src/types/runtime/nitro.ts
@@ -1,5 +1,6 @@
-import type { AppOptions, App as H3App, H3Event, Router } from "h3";
+import type { App as H3App, H3Event, Router } from "h3";
 import type { Hookable } from "hookable";
+import type { NitroRuntimeHooks as NitroTypesRuntimeHooks } from "nitropack";
 import type {
   createCall,
   createFetch as createLocalFetch,
@@ -43,16 +44,4 @@ export type CaptureError = (
   context: CapturedErrorContext
 ) => void;
 
-export interface NitroRuntimeHooks {
-  close: () => void;
-  error: CaptureError;
-
-  request: NonNullable<AppOptions["onRequest"]>;
-  beforeResponse: NonNullable<AppOptions["onBeforeResponse"]>;
-  afterResponse: NonNullable<AppOptions["onAfterResponse"]>;
-
-  "render:response": (
-    response: Partial<RenderResponse>,
-    context: { event: H3Event }
-  ) => void;
-}
+export interface NitroRuntimeHooks extends NitroTypesRuntimeHooks {}


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

follow on from https://github.com/unjs/nitro/pull/2724

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
