### PR TITLE
fix: do not generate runtime config types with external framework

### DIFF
--- a/src/core/config/loader.ts
+++ b/src/core/config/loader.ts
@@ -102,7 +102,11 @@ async function _loadUserConfig(
           configs.rc?.compatibilityDate ||
           configs.packageJson?.compatibilityDate;
       }
+      const framework = configs.overrides?.framework || configs.main?.framework;
       return {
+        typescript: {
+          generateRuntimeConfigTypes: !framework?.name || framework.name === 'nitro'
+        },
         preset: (
           await resolvePreset("" /* auto detect */, {
             static: configOverrides.static,

--- a/src/core/config/loader.ts
+++ b/src/core/config/loader.ts
@@ -105,7 +105,8 @@ async function _loadUserConfig(
       const framework = configs.overrides?.framework || configs.main?.framework;
       return {
         typescript: {
-          generateRuntimeConfigTypes: !framework?.name || framework.name === 'nitro'
+          generateRuntimeConfigTypes:
+            !framework?.name || framework.name === "nitro",
         },
         preset: (
           await resolvePreset("" /* auto detect */, {


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/28924

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This changes the default for `typescript.generateRuntimeConfigTypes` to false in the presence of an external framework, which should prevent this new feature from accidentally breaking downstream types.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
