### PR TITLE
docs(routing): add error handling section

### DIFF
--- a/docs/1.guide/0.index.md
+++ b/docs/1.guide/0.index.md
@@ -72,7 +72,7 @@ The `routes/` directory contains your application handlers. You can create subdi
 
 ### `api/`
 
-The `api/` directory is similar to `routes/` with the main difference that routes inside it will be prefixed with `/api/` for convenience.
+The `api/` directory is similar to `routes/` with the only difference that routes inside it will be prefixed with `/api/` for convenience.
 
 :read-more{to="/guide/routing"}
 

--- a/docs/1.guide/0.index.md
+++ b/docs/1.guide/0.index.md
@@ -72,7 +72,7 @@ The `routes/` directory contains your application handlers. You can create subdi
 
 ### `api/`
 
-The `api/` directory is similar to `routes/` with only difference that routes inside it will be prefixed with `/api/` for convenience.
+The `api/` directory is similar to `routes/` with the main difference that routes inside it will be prefixed with `/api/` for convenience.
 
 :read-more{to="/guide/routing"}
 

--- a/docs/1.guide/2.routing.md
+++ b/docs/1.guide/2.routing.md
@@ -50,11 +50,6 @@ Some providers like Vercel use a top-level `api/` directory as a feature, theref
 You will have to use `routes/api/`.
 ::
 
-#### Differences between the two directories
-The `api/` directory is mainly for convenience, routes inside it will be prefixed with `/api/`.
-
-A notable difference between the two directories is how errors are handled by default: in `routes/` they are sent back with with a `Content-Type` of `text/html`, while in `api/` with `application/json`. This behaviour is overridden by some request properties (eg.: `Accept` or `User-Agent` headers).
-
 ### Simple routes
 
 First, create a file in `routes/` or `api/` directory. The filename will be the route path.
@@ -273,6 +268,14 @@ export default defineEventHandler((event) => {
   }
 })
 ```
+
+## Error handling
+
+You can use the [utilities available in H3](https://h3.unjs.io/guide/event-handler#error-handling) to handle errors in both routes and middlewares.
+
+The way errors are sent back to the client depends on the route's path. For most routes `Content-Type` is set to `text/html` by default and a simple html error page is delievered. If the route starts with `/api/` (either because it is placed in `api/` or `routes/api/`) the default will change to `application/json` and a JSON object will be sent.
+
+This behaviour can be overridden by some request properties (eg.: `Accept` or `User-Agent` headers).
 
 ## Route Rules
 

--- a/docs/1.guide/2.routing.md
+++ b/docs/1.guide/2.routing.md
@@ -50,6 +50,11 @@ Some providers like Vercel use a top-level `api/` directory as a feature, theref
 You will have to use `routes/api/`.
 ::
 
+#### Differences between the two directories
+The `api/` directory is mainly for convenience, routes inside it will be prefixed with `/api/`.
+
+A notable difference between the two directories is how errors are handled by default: in `routes/` they are sent back with with a `Content-Type` of `text/html`, while in `api/` with `application/json`. This behaviour is overridden by some request properties (eg.: `Accept` or `User-Agent` headers).
+
 ### Simple routes
 
 First, create a file in `routes/` or `api/` directory. The filename will be the route path.


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

While migrating some servers to Nitro (in Nuxt), I came across an odd behaviour that took some time to unveil. For some of the routes errors were handled correctly, while for others the client could not determine the error type. With some trial and error I figured out, that there is a difference between how an error is sent back to the client depening on which route directory the route is placed.

The `routes/` dir uses a Content-Type of `text/html`, while the `api/` dir `application/json` by default. In this PR I tried to clarify this in the docs, wich previously stated that the *only* difference is the `/api/` prefix.

As a side note I would be very interested, in the reasoning behind this behaviour. I feel like it is quite footgun-y, while I don't see the benefits.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
