### PR TITLE
feat(raw): add `.sql` to raw file extensions

### DIFF
--- a/src/rollup/plugins/raw.ts
+++ b/src/rollup/plugins/raw.ts
@@ -14,6 +14,7 @@ export function raw(opts: RawOptions = {}): Plugin {
     ".css",
     ".htm",
     ".html",
+    ".sql",
     ...(opts.extensions || []),
   ]);
 
@@ -81,7 +82,7 @@ function isBinary(id: string) {
   if (idMime.startsWith("text/")) {
     return false;
   }
-  if (/application\/(json|xml|yaml)/.test(idMime)) {
+  if (/application\/(json|sql|xml|yaml)/.test(idMime)) {
     return false;
   }
   return true;


### PR DESCRIPTION
### 🔗 Linked issue

#2666 [useStorage] getItem and getItemRaw -> Inconsistent behaviour between dev and preview/production

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The change adds the `.sql` extension and the `application/sql` mime type (that is what the `mime` library assigns to .sql files) to the list of file types that are stored as string and not as Uint8Array.

That makes the process to use the server:assets storage for .sql files straightforward and intuitive.

Resolves partly #2666
The change does not solve the issue that useStorage acts differently in dev and production environment, but it solves the problem that .sql files are not stored as string.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
