### PR TITLE
fix(azure-functions): follow symlinks in zip bundle

### DIFF
--- a/src/presets/azure/utils.ts
+++ b/src/presets/azure/utils.ts
@@ -210,7 +210,7 @@ function _zipDirectory(dir: string, outfile: string): Promise<undefined> {
 
   return new Promise((resolve, reject) => {
     archive
-      .directory(dir, false)
+      .glob("**/*", { cwd: dir, nodir: true, dot: true, follow: true })
       .on("error", (err: Error) => reject(err))
       .pipe(stream);
 


### PR DESCRIPTION
The archiver instance was not configured to follow symlinks.
Fixes #2114