### PR TITLE
feat(renderer): add `render:before` hook

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -5,6 +5,7 @@ import type {
   NitroOpenAPIConfig,
   NitroRouteConfig,
   RenderResponse,
+  RenderContext,
 } from "nitropack/types";
 
 // Core
@@ -79,9 +80,11 @@ export interface NitroRuntimeHooks {
   beforeResponse: NonNullable<AppOptions["onBeforeResponse"]>;
   afterResponse: NonNullable<AppOptions["onAfterResponse"]>;
 
+  "render:before": (context: RenderContext) => void;
+
   "render:response": (
     response: Partial<RenderResponse>,
-    context: { event: H3Event }
+    context: RenderContext
   ) => void;
 }
 

--- a/src/runtime/internal/renderer.ts
+++ b/src/runtime/internal/renderer.ts
@@ -17,7 +17,7 @@ export function defineRenderHandler(render: RenderHandler) {
     const nitroApp = useNitroApp();
 
     // Create shared context for hooks
-    const ctx: RenderContext = { event, render };
+    const ctx: RenderContext = { event, render, response: undefined };
 
     // Call initial hook to prepare and optionally custom render
     await nitroApp.hooks.callHook("render:before", ctx);

--- a/src/runtime/internal/renderer.ts
+++ b/src/runtime/internal/renderer.ts
@@ -7,24 +7,35 @@ import {
   setResponseHeaders,
   setResponseStatus,
 } from "h3";
-import type { RenderHandler } from "nitropack/types";
+import type { RenderHandler, RenderContext } from "nitropack/types";
 import { useNitroApp } from "./app";
 import { useRuntimeConfig } from "./config";
 
-export function defineRenderHandler(handler: RenderHandler) {
+export function defineRenderHandler(render: RenderHandler) {
   const runtimeConfig = useRuntimeConfig();
   return eventHandler(async (event) => {
-    // TODO: Use serve-placeholder
-    if (event.path === `${runtimeConfig.app.baseURL}favicon.ico`) {
-      setResponseHeader(event, "Content-Type", "image/x-icon");
-      return send(
-        event,
-        "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-      );
+    const nitroApp = useNitroApp();
+
+    // Create shared context for hooks
+    const ctx: RenderContext = { event, render };
+
+    // Call initial hook to prepare and optionally custom render
+    await nitroApp.hooks.callHook("render:before", ctx);
+
+    if (!ctx.response /* not handled by hook */) {
+      // TODO: Use serve-placeholder
+      if (event.path === `${runtimeConfig.app.baseURL}favicon.ico`) {
+        setResponseHeader(event, "Content-Type", "image/x-icon");
+        return send(
+          event,
+          "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+        );
+      }
+
+      ctx.response = await ctx.render(event);
     }
 
-    const response = await handler(event);
-    if (!response) {
+    if (!ctx.response) {
       const _currentStatus = getResponseStatus(event);
       setResponseStatus(event, _currentStatus === 200 ? 500 : _currentStatus);
       return send(
@@ -33,23 +44,22 @@ export function defineRenderHandler(handler: RenderHandler) {
       );
     }
 
-    // Allow hooking and modifying response
-    const nitroApp = useNitroApp();
-    await nitroApp.hooks.callHook("render:response", response, { event });
-
-    // TODO: Warn if response is already handled
-
-    // TODO: Caching support
+    // Allow  modifying response
+    await nitroApp.hooks.callHook("render:response", ctx.response, ctx);
 
     // Send headers
-    if (response.headers) {
-      setResponseHeaders(event, response.headers);
+    if (ctx.response.headers) {
+      setResponseHeaders(event, ctx.response.headers);
     }
-    if (response.statusCode || response.statusMessage) {
-      setResponseStatus(event, response.statusCode, response.statusMessage);
+    if (ctx.response.statusCode || ctx.response.statusMessage) {
+      setResponseStatus(
+        event,
+        ctx.response.statusCode,
+        ctx.response.statusMessage
+      );
     }
 
     // Send response body
-    return response.body;
+    return ctx.response.body;
   });
 }

--- a/src/runtime/internal/renderer.ts
+++ b/src/runtime/internal/renderer.ts
@@ -33,9 +33,7 @@ export function defineRenderHandler(render: RenderHandler) {
       }
 
       ctx.response = await ctx.render(event);
-    }
 
-    if (!ctx.response) {
       const _currentStatus = getResponseStatus(event);
       setResponseStatus(event, _currentStatus === 200 ? 500 : _currentStatus);
       return send(

--- a/src/types/runtime/nitro.ts
+++ b/src/types/runtime/nitro.ts
@@ -34,6 +34,12 @@ export type RenderHandler = (
   event: H3Event
 ) => Partial<RenderResponse> | Promise<Partial<RenderResponse>>;
 
+export interface RenderContext {
+  event: H3Event;
+  render: RenderHandler;
+  response?: Partial<RenderResponse>;
+}
+
 export interface CapturedErrorContext {
   event?: H3Event;
   [key: string]: unknown;


### PR DESCRIPTION
(context: Discussion with @atinux regarding how to set cache callback options to the renderer handler. This PR, adds a primitive to allow it with advanced usage)

---

This PR adds a new `render:before` runtime hook support for renderer handlers (like Nuxt SSR). This hook allows to customize rendering behavior by intercepting the context:
- Render function can be overridden or wrapped by setting `context.render`
- A response can be directly generated/handled by setting `context.response`

Usage is not restricted to caching only and it allows more general customization of renderer behavior but for particularly caching purposes here is an example:


```js
import { defineNitroPlugin, defineCachedFunction } from "nitro/runtime";

export default defineNitroPlugin((nitro) => {
  const cachedRender = new WeakMap();
  nitro.hooks.hook("render:before", (ctx) => {
    let cRender = cachedRender.get(ctx.render);
    if (!cRender) {
      cRender = defineCachedFunction(ctx.render, {
        // Custom cache options
        maxAge: 60_000,
        shouldBypassCache: (event) => { /* custom logic */ }
      });
      cachedRender.set(ctx.render, cRender);
    }
    ctx.render = cRender;
  });
});
```