### PR TITLE
docs: update reference to old radix3 link

### DIFF
--- a/docs/1.guide/2.routing.md
+++ b/docs/1.guide/2.routing.md
@@ -281,7 +281,7 @@ This behaviour can be overridden by some request properties (eg.: `Accept` or `U
 
 Nitro allows you to add logic at the top-level for each route of your configuration. It can be used for redirecting, proxying, caching and adding headers to routes.
 
-It is a map from route pattern (following [unjs/radix3](https://github.com/unjs/radix3#route-matcher)) to route options.
+It is a map from route pattern (following [unjs/radix3](https://github.com/unjs/rou3/tree/radix3#route-matcher)) to route options.
 
 When `cache` option is set, handlers matching pattern will be automatically wrapped with `defineCachedEventHandler`. See the [cache guide](/guide/cache) to learn more about this function.
 

--- a/docs/3.config/0.index.md
+++ b/docs/3.config/0.index.md
@@ -328,7 +328,7 @@ export default defineNitroErrorHandler((error, event) => {
 
 **🧪 Experimental!**
 
-Route options. It is a map from route pattern (following [unjs/radix3](https://github.com/unjs/radix3#route-matcher)) to route options.
+Route options. It is a map from route pattern (following [unjs/radix3](https://github.com/unjs/rou3/tree/radix3#route-matcher)) to route options.
 
 When `cache` option is set, handlers matching pattern will be automatically wrapped with `defineCachedEventHandler`.
 


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

unjs/radix3 has been moved to a separate branch of unjs/rou3. This change updates the reference to the old unjs/radix3 repo in the Nitro docs to the new branch of unjs/rou3.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
