### PR TITLE
WIP: Deno server preset use parallel server mechanism

### DIFF
--- a/src/presets/deno/preset.ts
+++ b/src/presets/deno/preset.ts
@@ -145,7 +145,7 @@ const denoServer = defineNitroPreset(
         const denoJSON = {
           tasks: {
             start:
-              "deno run --allow-net --allow-read --allow-write --allow-env --unstable-byonm ./server/index.mjs",
+              "deno serve --allow-net --allow-read --allow-write --allow-env --unstable-byonm --parallel ./server/index.mjs",
           },
         };
         await writeFile(

--- a/src/presets/deno/runtime/deno-server.ts
+++ b/src/presets/deno/runtime/deno-server.ts
@@ -50,8 +50,6 @@ if (!serveOptions.key || !serveOptions.cert) {
   delete serveOptions.cert;
 }
 
-Deno.serve(serveOptions, handler);
-
 // Websocket support
 const ws = import.meta._websocket
   ? wsAdapter(nitroApp.h3App.websocket)
@@ -89,4 +87,9 @@ if (import.meta._tasks) {
   startScheduleRunner();
 }
 
-export default {};
+export default {
+  fetch(request: Request) {
+    // todo: integrate serveOptions
+    return handler(request);
+  }
+};


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #2803

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #2803 

Changes in this PR at this moment will allow using the parallel server in Deno 2. I have some questions to fully integrate this feature which I would greatly appreciate if you could answer.

- How can I test run this new preset? Can the playground be used with a specific preset?
- Deno supports command line arguments to specify port, host, certs and ... for this kind of server. But previously these  were given as env vars. What do you propose to do for it?

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
