### PR TITLE
fix: `vercel_edge` enable code splitting by default

### DIFF
--- a/src/presets/vercel/preset.ts
+++ b/src/presets/vercel/preset.ts
@@ -56,7 +56,9 @@ const vercelEdge = defineNitroPreset(
     },
     rollupConfig: {
       output: {
-        format: "module",
+        entryFileNames: "index.js",
+        format: "esm",
+        inlineDynamicImports: false,
       },
     },
     unenv: {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously when building using the `vercel_edge` preset the entire function code would be exported as a single JS file at `.vercel/functions/__nitro.func/index.mjs`. This means all dyanmic `import`'s are flattened to be inline.

This change copies the rollup configuration from the Cloudflare preset to the Vercel edge preset so this is no longer the case and dynamic imports actually lazily import code.

This changes allows me to lazy load less important code instead of requiring it all to be loaded and parsed at server startup.

This change aligns the `vercel_edge` preset with Nitro's existing Cloudflare presets which seems logical because Vercel's Edge functions run on Cloudflare Workers.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
