### PR TITLE
chore(types): annotate `h3Exports` types

### DIFF
--- a/src/core/config/resolvers/imports.ts
+++ b/src/core/config/resolvers/imports.ts
@@ -15,7 +15,7 @@ export async function resolveImportsOptions(options: NitroOptions) {
   options.imports.presets.push(...getNitroImportsPreset());
 
   // Add h3 auto imports preset
-  const h3Exports = await resolveModuleExportNames("h3", {
+  const h3Exports: string[] = await resolveModuleExportNames("h3", {
     url: import.meta.url,
   });
   options.imports.presets ??= [];


### PR DESCRIPTION
<!---

*** IMPORTANT: PLEASE READ BEFORE CONTINUING TO MAKE A PULL REQUEST ***

- The title should follow conventional commits (https://conventionalcommits.org).

- If it is a bug fix, please ensure there is a linked issue with minimal (nitro) reproduction and/or enough context to explain exactly what it is fixing and why this fix is the best option in Nitro.

- If it is a security fix, please always report it first as per https://github.com/unjs/nitro/blob/main/SECURITY.md

- If it is a new feature, please ensure it has already been discussed. Keep the scope of changes minimal to what is essential, and try to break down your changes into smaller PRs when possible.

- If you are submitting a new preset, please, in addition to the docs, ALWAYS add a new preset in src/presets.

- After submitting, please remain patient until your PR is reviewed.

Thanks for your contribution ❤️
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
`resolveModuleExportNames` function returns `Promise<string[]>`. Here we have called it but `h3Exports` is returning `any`. I have explicitly annotated `string[]` for `h3Exports`. Also below we are filtering `h3Exports`. I think `filter` can be used only with arrays. That is why I think we may explicitly annotate `h3Exports` here.  
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
