### PR TITLE
fix: handle incompatible compatibility date for presets

### DIFF
--- a/src/core/config/loader.ts
+++ b/src/core/config/loader.ts
@@ -110,12 +110,14 @@ async function _loadUserConfig(
           generateRuntimeConfigTypes:
             !framework?.name || framework.name === "nitro",
         },
-        preset: (
-          await resolvePreset("" /* auto detect */, {
-            static: configOverrides.static,
-            compatibilityDate: compatibilityDate || fallbackCompatibilityDate,
-          })
-        )?._meta?.name,
+        preset:
+          presetOverride ||
+          (
+            await resolvePreset("" /* auto detect */, {
+              static: configOverrides.static,
+              compatibilityDate: compatibilityDate || fallbackCompatibilityDate,
+            })
+          )?._meta?.name,
       };
     },
     defaults: NitroDefaults,

--- a/src/presets/_resolve.ts
+++ b/src/presets/_resolve.ts
@@ -2,6 +2,7 @@ import {
   type CompatibilityDateSpec,
   type PlatformName,
   resolveCompatibilityDatesFromEnv,
+  formatCompatibilityDate,
 } from "compatx";
 import type { NitroPreset, NitroPresetMeta } from "nitropack/types";
 import { kebabCase } from "scule";
@@ -17,35 +18,38 @@ const _stdProviderMap: Partial<Record<ProviderName, PlatformName>> = {
 
 export async function resolvePreset(
   name: string,
-  opts: { static?: boolean; compatibilityDate?: CompatibilityDateSpec }
+  opts: { static?: boolean; compatibilityDate?: false | CompatibilityDateSpec }
 ): Promise<(NitroPreset & { _meta?: NitroPresetMeta }) | undefined> {
   const _name = kebabCase(name) || provider;
 
-  const _compatDates = resolveCompatibilityDatesFromEnv(opts.compatibilityDate);
+  const _compatDates = opts.compatibilityDate
+    ? resolveCompatibilityDatesFromEnv(opts.compatibilityDate)
+    : false;
 
   const matches = allPresets
     .filter((preset) => {
-      const names = [
-        preset._meta.name,
-        preset._meta.stdName,
-        ...(preset._meta.aliases || []),
-      ].filter(Boolean);
+      // prettier-ignore
+      const names = [preset._meta.name, preset._meta.stdName, ...(preset._meta.aliases || [])].filter(Boolean);
       if (!names.includes(_name)) {
         return false;
       }
 
-      const _date =
-        _compatDates[_stdProviderMap[preset._meta.stdName!] as PlatformName] ||
-        _compatDates[preset._meta.stdName as PlatformName] ||
-        _compatDates[preset._meta.name as PlatformName] ||
-        _compatDates.default;
+      if (_compatDates) {
+        const _date =
+          _compatDates[
+            _stdProviderMap[preset._meta.stdName!] as PlatformName
+          ] ||
+          _compatDates[preset._meta.stdName as PlatformName] ||
+          _compatDates[preset._meta.name as PlatformName] ||
+          _compatDates.default;
 
-      if (
-        _date &&
-        preset._meta.compatibilityDate &&
-        new Date(preset._meta.compatibilityDate) > new Date(_date)
-      ) {
-        return false;
+        if (
+          _date &&
+          preset._meta.compatibilityDate &&
+          new Date(preset._meta.compatibilityDate) > new Date(_date)
+        ) {
+          return false;
+        }
       }
 
       return true;
@@ -69,6 +73,30 @@ export async function resolvePreset(
     return opts?.static
       ? resolvePreset("static", opts)
       : resolvePreset("node-server", opts);
+  }
+
+  if (name && !preset) {
+    const options = allPresets
+      .filter(
+        (p) =>
+          p._meta.name === name ||
+          p._meta.stdName === name ||
+          p._meta.aliases?.includes(name)
+      )
+      .sort((a, b) =>
+        (a._meta.compatibilityDate || 0) > (b._meta.compatibilityDate || 0)
+          ? 1
+          : -1
+      );
+    if (options.length > 0) {
+      let msg = `Preset "${name}" cannot be resolved with current compatibilityDate: ${formatCompatibilityDate(_compatDates || "")}.\n\n`;
+      for (const option of options) {
+        msg += `\n- ${option._meta.name} (requires compatibilityDate >= ${option._meta.compatibilityDate})`;
+      }
+      const err = new Error(msg);
+      Error.captureStackTrace?.(err, resolvePreset);
+      throw err;
+    }
   }
 
   return preset;

--- a/src/presets/_resolve.ts
+++ b/src/presets/_resolve.ts
@@ -76,18 +76,10 @@ export async function resolvePreset(
   }
 
   if (name && !preset) {
+    // prettier-ignore
     const options = allPresets
-      .filter(
-        (p) =>
-          p._meta.name === name ||
-          p._meta.stdName === name ||
-          p._meta.aliases?.includes(name)
-      )
-      .sort((a, b) =>
-        (a._meta.compatibilityDate || 0) > (b._meta.compatibilityDate || 0)
-          ? 1
-          : -1
-      );
+      .filter((p) =>p._meta.name === name ||p._meta.stdName === name ||p._meta.aliases?.includes(name) )
+      .sort((a, b) => (a._meta.compatibilityDate || 0) > (b._meta.compatibilityDate || 0) ? 1 : -1);
     if (options.length > 0) {
       let msg = `Preset "${name}" cannot be resolved with current compatibilityDate: ${formatCompatibilityDate(_compatDates || "")}.\n\n`;
       for (const option of options) {

--- a/src/presets/cloudflare/preset.ts
+++ b/src/presets/cloudflare/preset.ts
@@ -143,7 +143,6 @@ const cloudflareModuleLegacy = defineNitroPreset(
   {
     name: "cloudflare-module-legacy" as const,
     aliases: ["cloudflare-module"] as const,
-    compatibilityDate: "2024-05-07",
     url: import.meta.url,
   }
 );
@@ -198,6 +197,7 @@ const cloudflareDurable = defineNitroPreset(
   },
   {
     name: "cloudflare-durable" as const,
+    compatibilityDate: "2024-09-19",
     url: import.meta.url,
   }
 );


### PR DESCRIPTION
When using presets with incompatible compatibility dates, this PR adds a new functionality for the resolver to explicitly detect it and throw an error.

Other relavant fixes:
- respect presetOverride (env or args) over auto detection for defaults
- remove extra compat date for `cloudflare-module-legacy` and instead set it for `cloudflare-durable` preset